### PR TITLE
Refactor: preparing the rpxy librarization first step

### DIFF
--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -19,7 +19,7 @@ use crate::{
 };
 use derive_builder::Builder;
 use rustc_hash::FxHashMap as HashMap;
-use std::{borrow::Cow, path::PathBuf};
+use std::borrow::Cow;
 
 /// Struct serving information to route incoming connections, like server name to be handled and tls certs/keys settings.
 #[derive(Builder)]
@@ -36,16 +36,11 @@ where
   /// struct of reverse proxy serving incoming request
   pub reverse_proxy: ReverseProxy,
 
-  /// tls settings
-  #[builder(setter(custom), default)]
-  pub tls_cert_path: Option<PathBuf>,
-  #[builder(setter(custom), default)]
-  pub tls_cert_key_path: Option<PathBuf>,
+  /// tls settings: https redirection with 30x
   #[builder(default)]
   pub https_redirection: Option<bool>,
-  #[builder(setter(custom), default)]
-  pub client_ca_cert_path: Option<PathBuf>,
 
+  /// TLS settings: source meta for server cert, key, client ca cert
   #[builder(default)]
   pub crypto_source: Option<T>,
 }
@@ -57,22 +52,6 @@ where
     self.server_name = Some(server_name.into().to_ascii_lowercase());
     self
   }
-  pub fn tls_cert_path(&mut self, v: &Option<String>) -> &mut Self {
-    self.tls_cert_path = Some(opt_string_to_opt_pathbuf(v));
-    self
-  }
-  pub fn tls_cert_key_path(&mut self, v: &Option<String>) -> &mut Self {
-    self.tls_cert_key_path = Some(opt_string_to_opt_pathbuf(v));
-    self
-  }
-  pub fn client_ca_cert_path(&mut self, v: &Option<String>) -> &mut Self {
-    self.client_ca_cert_path = Some(opt_string_to_opt_pathbuf(v));
-    self
-  }
-}
-
-fn opt_string_to_opt_pathbuf(input: &Option<String>) -> Option<PathBuf> {
-  input.to_owned().as_ref().map(PathBuf::from)
 }
 
 /// HashMap and some meta information for multiple Backend structs.

--- a/src/cert_file_reader.rs
+++ b/src/cert_file_reader.rs
@@ -1,4 +1,4 @@
-use crate::{log::*, proxy::CertsAndKeys};
+use crate::{certs::CertsAndKeys, log::*};
 use rustls::{Certificate, PrivateKey};
 use std::{
   fs::File,

--- a/src/cert_file_reader.rs
+++ b/src/cert_file_reader.rs
@@ -11,7 +11,7 @@ use std::{
   path::PathBuf,
 };
 
-#[derive(Builder, Debug)]
+#[derive(Builder, Debug, Clone)]
 /// Crypto-related file reader implementing certs::CryptoRead trait
 pub struct CryptoFileSource {
   #[builder(setter(custom))]

--- a/src/certs.rs
+++ b/src/certs.rs
@@ -13,5 +13,10 @@ pub struct CertsAndKeys {
 // Trait to read certs and keys anywhere from KVS, file, sqlite, etc.
 pub trait CryptoSource {
   type Error;
+
+  /// read crypto materials from source
   async fn read(&self) -> Result<CertsAndKeys, Self::Error>;
+
+  /// Returns true when mutual tls is enabled
+  fn is_mutual_tls(&self) -> bool;
 }

--- a/src/certs.rs
+++ b/src/certs.rs
@@ -1,0 +1,17 @@
+use async_trait::async_trait;
+use rustls::{Certificate, PrivateKey};
+
+/// Certificates and private keys in rustls loaded from files
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct CertsAndKeys {
+  pub certs: Vec<Certificate>,
+  pub cert_keys: Vec<PrivateKey>,
+  pub client_ca_certs: Option<Vec<Certificate>>,
+}
+
+#[async_trait]
+// Trait to read certs and keys anywhere from KVS, file, sqlite, etc.
+pub trait ReadCerts {
+  type Error;
+  async fn read_crypto_source(&self) -> Result<CertsAndKeys, Self::Error>;
+}

--- a/src/certs.rs
+++ b/src/certs.rs
@@ -11,7 +11,7 @@ pub struct CertsAndKeys {
 
 #[async_trait]
 // Trait to read certs and keys anywhere from KVS, file, sqlite, etc.
-pub trait ReadCerts {
+pub trait CryptoSource {
   type Error;
-  async fn read_crypto_source(&self) -> Result<CertsAndKeys, Self::Error>;
+  async fn read(&self) -> Result<CertsAndKeys, Self::Error>;
 }

--- a/src/config/parse.rs
+++ b/src/config/parse.rs
@@ -1,9 +1,12 @@
 use super::toml::ConfigToml;
-use crate::{backend::Backends, error::*, globals::*, log::*, utils::BytesName};
+use crate::{backend::Backends, certs::CryptoSource, error::*, globals::*, log::*, utils::BytesName};
 use clap::Arg;
 use tokio::runtime::Handle;
 
-pub fn build_globals(runtime_handle: Handle) -> std::result::Result<Globals, anyhow::Error> {
+pub fn build_globals<T>(runtime_handle: Handle) -> std::result::Result<Globals<T>, anyhow::Error>
+where
+  T: CryptoSource + Clone,
+{
   let _ = include_str!("../../Cargo.toml");
   let options = clap::command!().arg(
     Arg::new("config_file")
@@ -72,7 +75,7 @@ pub fn build_globals(runtime_handle: Handle) -> std::result::Result<Globals, any
   }
 
   // build backends
-  let mut backends = Backends::default();
+  let mut backends = Backends::new();
   for (app_name, app) in apps.0.iter() {
     let server_name_string = app.server_name.as_ref().ok_or(anyhow!("No server name"))?;
     let backend = app.try_into()?;

--- a/src/config/parse.rs
+++ b/src/config/parse.rs
@@ -1,12 +1,16 @@
 use super::toml::ConfigToml;
-use crate::{backend::Backends, certs::CryptoSource, error::*, globals::*, log::*, utils::BytesName};
+use crate::{
+  backend::Backends,
+  cert_file_reader::CryptoFileSource,
+  error::{anyhow, ensure},
+  globals::*,
+  log::*,
+  utils::BytesName,
+};
 use clap::Arg;
 use tokio::runtime::Handle;
 
-pub fn build_globals<T>(runtime_handle: Handle) -> std::result::Result<Globals<T>, anyhow::Error>
-where
-  T: CryptoSource + Clone,
-{
+pub fn build_globals(runtime_handle: Handle) -> std::result::Result<Globals<CryptoFileSource>, anyhow::Error> {
   let _ = include_str!("../../Cargo.toml");
   let options = clap::command!().arg(
     Arg::new("config_file")

--- a/src/config/toml.rs
+++ b/src/config/toml.rs
@@ -1,5 +1,6 @@
 use crate::{
   backend::{Backend, BackendBuilder, ReverseProxy, Upstream, UpstreamGroup, UpstreamGroupBuilder, UpstreamOption},
+  certs::CryptoSource,
   constants::*,
   error::*,
   globals::ProxyConfig,
@@ -170,10 +171,13 @@ impl ConfigToml {
   }
 }
 
-impl TryInto<Backend> for &Application {
+impl<T> TryInto<Backend<T>> for &Application
+where
+  T: CryptoSource + Clone,
+{
   type Error = anyhow::Error;
 
-  fn try_into(self) -> std::result::Result<Backend, Self::Error> {
+  fn try_into(self) -> std::result::Result<Backend<T>, Self::Error> {
     let server_name_string = self.server_name.as_ref().ok_or(anyhow!("Missing server_name"))?;
 
     // backend builder

--- a/src/error.rs
+++ b/src/error.rs
@@ -29,9 +29,8 @@ pub enum RpxyError {
   #[error("I/O Error")]
   Io(#[from] io::Error),
 
-  #[error("Toml Deserialization Error")]
-  TomlDe(#[from] toml::de::Error),
-
+  // #[error("Toml Deserialization Error")]
+  // TomlDe(#[from] toml::de::Error),
   #[cfg(feature = "http3")]
   #[error("Quic Connection Error")]
   QuicConn(#[from] quinn::ConnectionError),

--- a/src/globals.rs
+++ b/src/globals.rs
@@ -1,3 +1,4 @@
+use crate::certs::CryptoSource;
 use crate::{backend::Backends, constants::*};
 use std::net::SocketAddr;
 use std::sync::{
@@ -8,12 +9,15 @@ use tokio::time::Duration;
 
 /// Global object containing proxy configurations and shared object like counters.
 /// But note that in Globals, we do not have Mutex and RwLock. It is indeed, the context shared among async tasks.
-pub struct Globals {
+pub struct Globals<T>
+where
+  T: CryptoSource,
+{
   /// Configuration parameters for proxy transport and request handlers
   pub proxy_config: ProxyConfig, // TODO: proxy configはarcに包んでこいつだけ使いまわせばいいように変えていく。backendsも？
 
   /// Backend application objects to which http request handler forward incoming requests
-  pub backends: Backends,
+  pub backends: Backends<T>,
 
   /// Shared context - Counter for serving requests
   pub request_count: RequestCount,

--- a/src/handler/handler_main.rs
+++ b/src/handler/handler_main.rs
@@ -2,6 +2,7 @@
 use super::{utils_headers::*, utils_request::*, utils_synth_response::*, HandlerContext};
 use crate::{
   backend::{Backend, UpstreamGroup},
+  certs::CryptoSource,
   error::*,
   globals::Globals,
   log::*,
@@ -18,17 +19,19 @@ use std::{env, net::SocketAddr, sync::Arc};
 use tokio::{io::copy_bidirectional, time::timeout};
 
 #[derive(Clone, Builder)]
-pub struct HttpMessageHandler<T>
+pub struct HttpMessageHandler<T, U>
 where
   T: Connect + Clone + Sync + Send + 'static,
+  U: CryptoSource + Clone,
 {
   forwarder: Arc<Client<T>>,
-  globals: Arc<Globals>,
+  globals: Arc<Globals<U>>,
 }
 
-impl<T> HttpMessageHandler<T>
+impl<T, U> HttpMessageHandler<T, U>
 where
   T: Connect + Clone + Sync + Send + 'static,
+  U: CryptoSource + Clone,
 {
   fn return_with_error_log(&self, status_code: StatusCode, log_data: &mut MessageLog) -> Result<Response<Body>> {
     log_data.status_code(&status_code).output();
@@ -194,11 +197,10 @@ where
   ////////////////////////////////////////////////////
   // Functions to generate messages
 
-  fn generate_response_forwarded<B: core::fmt::Debug>(
-    &self,
-    response: &mut Response<B>,
-    chosen_backend: &Backend,
-  ) -> Result<()> {
+  fn generate_response_forwarded<B>(&self, response: &mut Response<B>, chosen_backend: &Backend<U>) -> Result<()>
+  where
+    B: core::fmt::Debug,
+  {
     let headers = response.headers_mut();
     remove_connection_header(headers);
     remove_hop_header(headers);

--- a/src/handler/handler_main.rs
+++ b/src/handler/handler_main.rs
@@ -209,7 +209,12 @@ where
     #[cfg(feature = "http3")]
     {
       // TODO: Workaround for avoid h3 for client authentication
-      if self.globals.proxy_config.http3 && chosen_backend.client_ca_cert_path.is_none() {
+      if self.globals.proxy_config.http3
+        && chosen_backend
+          .crypto_source
+          .as_ref()
+          .is_some_and(|v| !v.is_mutual_tls())
+      {
         if let Some(port) = self.globals.proxy_config.https_port {
           add_header_entry_overwrite_if_exist(
             headers,

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,8 @@ use tikv_jemallocator::Jemalloc;
 static GLOBAL: Jemalloc = Jemalloc;
 
 mod backend;
-mod cert_reader;
+mod cert_file_reader;
+mod certs;
 mod config;
 mod constants;
 mod error;

--- a/src/proxy/crypto_service.rs
+++ b/src/proxy/crypto_service.rs
@@ -1,5 +1,6 @@
 use crate::{
-  cert_reader::read_certs_and_keys, // TODO: Trait defining read_certs_and_keys and add struct implementing the trait to backend when build backend
+  cert_file_reader::read_certs_and_keys, // TODO: Trait defining read_certs_and_keys and add struct implementing the trait to backend when build backend
+  certs::CertsAndKeys,
   globals::Globals,
   log::*,
   utils::ServerNameBytesExp,
@@ -10,7 +11,7 @@ use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use rustls::{
   server::ResolvesServerCertUsingSni,
   sign::{any_supported_type, CertifiedKey},
-  Certificate, OwnedTrustAnchor, PrivateKey, RootCertStore, ServerConfig,
+  OwnedTrustAnchor, RootCertStore, ServerConfig,
 };
 use std::{io, sync::Arc};
 use x509_parser::prelude::*;
@@ -19,14 +20,6 @@ use x509_parser::prelude::*;
 /// Reloader service for certificates and keys for TLS
 pub struct CryptoReloader {
   globals: Arc<Globals>,
-}
-
-/// Certificates and private keys in rustls loaded from files
-#[derive(Debug, PartialEq, Eq, Clone)]
-pub struct CertsAndKeys {
-  pub certs: Vec<Certificate>,
-  pub cert_keys: Vec<PrivateKey>,
-  pub client_ca_certs: Option<Vec<Certificate>>,
 }
 
 pub type SniServerCryptoMap = HashMap<ServerNameBytesExp, Arc<ServerConfig>>;

--- a/src/proxy/mod.rs
+++ b/src/proxy/mod.rs
@@ -5,5 +5,4 @@ mod proxy_h3;
 mod proxy_main;
 mod proxy_tls;
 
-pub use crypto_service::CertsAndKeys;
 pub use proxy_main::{Proxy, ProxyBuilder, ProxyBuilderError};

--- a/src/proxy/proxy_h3.rs
+++ b/src/proxy/proxy_h3.rs
@@ -1,14 +1,15 @@
 use super::Proxy;
-use crate::{error::*, log::*, utils::ServerNameBytesExp};
+use crate::{certs::CryptoSource, error::*, log::*, utils::ServerNameBytesExp};
 use bytes::{Buf, Bytes};
 use h3::{quic::BidiStream, server::RequestStream};
 use hyper::{client::connect::Connect, Body, Request, Response};
 use std::net::SocketAddr;
 use tokio::time::{timeout, Duration};
 
-impl<T> Proxy<T>
+impl<T, U> Proxy<T, U>
 where
   T: Connect + Clone + Sync + Send + 'static,
+  U: CryptoSource + Clone + Sync + Send + 'static,
 {
   pub(super) async fn connection_serve_h3(
     self,


### PR DESCRIPTION
I am considering to make the current single executable binary project separated into a `rpxy-lib` and `rpxy-bin`. By doing this, the config source and certificate source can be more flexible. In particular, they could be not only the file but also KVS, sqlite, anywhere according to the implementation of executing binaries including `rpxy-lib`. Bu I will not change `rpxy-bin`'s current structure, i.e., reading config and certs from files, etc. I hope this librarization will solve #33 by constructing appropriate bin calling `rpxy-lib` in future.

Anyways, to these ends (and not only to this ends, i.e., just for refactoring:-)), I first refactored the code a lot and refined the definition of the certificate loader. I will continue this refactoring.