### PR TITLE
feat: update features of hyper-rutstls with aws-lc-rs and platform-verifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Improvement
 
 - Refactor: lots of minor improvements
+- Change the certificate verifier from `rustls-native-certs` to `rustls-platform-verifier` to use the system's default root cert store for better client (forwarder) performance in `hyper-rustls`.
 
 
 ## 0.7.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.8.0-alpha.0"
+version = "0.8.0-alpha.1"
 authors = ["Jun Kurihara"]
 homepage = "https://github.com/junkurihara/rust-rpxy"
 repository = "https://github.com/junkurihara/rust-rpxy"

--- a/rpxy-bin/Cargo.toml
+++ b/rpxy-bin/Cargo.toml
@@ -13,8 +13,8 @@ publish.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-# default = ["http3-quinn", "cache", "rustls-backend"]
-default = ["http3-s2n", "cache", "rustls-backend"]
+default = ["http3-quinn", "cache", "rustls-backend"]
+# default = ["http3-s2n", "cache", "rustls-backend"]
 http3-quinn = ["rpxy-lib/http3-quinn"]
 http3-s2n = ["rpxy-lib/http3-s2n"]
 native-tls-backend = ["rpxy-lib/native-tls-backend"]
@@ -42,7 +42,7 @@ async-trait = "0.1.80"
 
 
 # config
-clap = { version = "4.5.4", features = ["std", "cargo", "wrap_help"] }
+clap = { version = "4.5.6", features = ["std", "cargo", "wrap_help"] }
 toml = { version = "0.8.14", default-features = false, features = ["parse"] }
 hot_reload = "0.1.5"
 

--- a/rpxy-lib/Cargo.toml
+++ b/rpxy-lib/Cargo.toml
@@ -13,8 +13,8 @@ publish.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = ["http3-s2n", "sticky-cookie", "cache", "rustls-backend"]
-# default = ["http3-quinn", "sticky-cookie", "cache", "rustls-backend"]
+# default = ["http3-s2n", "sticky-cookie", "cache", "rustls-backend"]
+default = ["http3-quinn", "sticky-cookie", "cache", "rustls-backend"]
 http3-quinn = ["socket2", "quinn", "h3", "h3-quinn", "rpxy-certs/http3"]
 http3-s2n = [
   "h3",
@@ -64,11 +64,13 @@ hyper-tls = { version = "0.6.0", features = [
   "alpn",
   "vendored",
 ], optional = true }
-hyper-rustls = { version = "0.27.2", default-features = false, features = [
-  "ring",
-  "native-tokio",
+# TODO: Work around to enable rustls-platform-verifier feature: https://github.com/rustls/hyper-rustls/pull/276
+# hyper-rustls = { version = "0.27.2", default-features = false, features = [
+hyper-rustls = { git = "https://github.com/junkurihara/hyper-rustls", branch = "fix/builder-feature-platform-verifier", features = [
+  "aws-lc-rs",
   "http1",
   "http2",
+  "rustls-platform-verifier",
 ], optional = true }
 
 # tls and cert management for server


### PR DESCRIPTION
Changed the default crypto provider from ring to aws-lc-rs for the connection between rpxy and backends. Also we use rustls-platform-verifier instead of rustls-native-certs for better performance.
