### PR TITLE
Update config-example.toml to explain Alt-SVC header

### DIFF
--- a/config-example.toml
+++ b/config-example.toml
@@ -11,8 +11,8 @@ listen_port = 8080
 listen_port_tls = 8443
 
 # Optional. If you listen on a custom port like 8443 but redirect with firewall to 443
-# When you specify this, the server sends a redirection response 301 with specified port to the client for plaintext http request.
-# Otherwise, the server sends 301 with the same port as `listen_port_tls`.
+# When you specify this, the server uses this port in an "Alt-SVC" header for e.g. indicating support for HTTP/3 and also sends a redirection response 301 with specified port to the client for plaintext http request
+# Otherwise, the server sends Alt-SVC and 301 with the same port as `listen_port_tls`.
 # https_redirection_port = 443
 
 # Optional for h2 and http1.1


### PR DESCRIPTION
#192 forgot to update the example configuration file

I decided to put the Alt-SVC in front of the old one because otherwise people not interested the plaintext feature might overlook the relevance.