### PR TITLE
 Support per-app HTTP basic authentication 

### DIFF
--- a/rpxy-bin/src/config/toml.rs
+++ b/rpxy-bin/src/config/toml.rs
@@ -73,6 +73,7 @@ pub struct Apps(pub HashMap<String, Application>);
 pub struct Application {
   pub server_name: Option<String>,
   pub reverse_proxy: Option<Vec<ReverseProxyOption>>,
+  pub htpasswd: Option<HashMap<String, String>>,
   pub tls: Option<TlsOption>,
 }
 
@@ -290,6 +291,7 @@ impl Application {
     Ok(AppConfig {
       app_name: app_name.to_owned(),
       server_name: server_name_string.to_owned(),
+      htpasswd: self.htpasswd.clone(),
       reverse_proxy: reverse_proxy_config,
       tls: tls_config,
     })

--- a/rpxy-lib/src/backend/backend_main.rs
+++ b/rpxy-lib/src/backend/backend_main.rs
@@ -21,6 +21,9 @@ pub struct BackendApp {
   pub server_name: ServerName,
   /// struct of reverse proxy serving incoming request
   pub path_manager: PathManager,
+  /// WWW-Authenticate user before forwarding request
+  #[builder(default)]
+  pub htpasswd: Option<HashMap<String, String>>,
   /// tls settings: https redirection with 30x
   #[builder(default)]
   pub https_redirection: Option<bool>,
@@ -53,6 +56,7 @@ impl TryFrom<&AppConfig> for BackendApp {
     backend_builder
       .app_name(app_config.app_name.clone())
       .server_name(app_config.server_name.clone())
+      .htpasswd(app_config.htpasswd.clone())
       .path_manager(path_manager);
     // TLS settings and build backend instance
     let backend = if app_config.tls.is_none() {

--- a/rpxy-lib/src/globals.rs
+++ b/rpxy-lib/src/globals.rs
@@ -146,6 +146,7 @@ pub struct AppConfig {
   pub server_name: String,
   pub reverse_proxy: Vec<ReverseProxyConfig>,
   pub tls: Option<TlsConfig>,
+  pub htpasswd: Option<rustc_hash::FxHashMap<String, String>>,
 }
 
 /// Configuration parameters for single reverse proxy corresponding to the path

--- a/rpxy-lib/src/message_handler/http_result.rs
+++ b/rpxy-lib/src/message_handler/http_result.rs
@@ -1,6 +1,8 @@
 use http::StatusCode;
 use thiserror::Error;
 
+use crate::name_exp::ServerName;
+
 /// HTTP result type, T is typically a hyper::Response
 /// HttpError is used to generate a synthetic error response
 pub(crate) type HttpResult<T> = std::result::Result<T, HttpError>;
@@ -32,6 +34,8 @@ pub enum HttpError {
 
   #[error("Failed to upgrade connection: {0}")]
   FailedToUpgrade(String),
+  #[error("Requires basic authentication: {}", .0.try_into().unwrap_or_else(|_| format!("{:?}", .0)))]
+  RequiresBasicAuthentication(ServerName),
   // #[error("Request does not have an upgrade extension")]
   // NoUpgradeExtensionInRequest,
   // #[error("Response does not have an upgrade extension")]

--- a/rpxy-lib/src/message_handler/synthetic_response.rs
+++ b/rpxy-lib/src/message_handler/synthetic_response.rs
@@ -4,12 +4,23 @@ use crate::{
   hyper_ext::body::{empty, ResponseBody},
   name_exp::ServerName,
 };
-use http::{Request, Response, StatusCode, Uri};
+use http::{response::Builder, Request, Response, StatusCode, Uri};
 
 /// build http response with status code of 4xx and 5xx
 pub(crate) fn synthetic_error_response(status_code: StatusCode) -> RpxyResult<Response<ResponseBody>> {
   let res = Response::builder()
     .status(status_code)
+    .body(ResponseBody::Boxed(empty()))
+    .unwrap();
+  Ok(res)
+}
+
+/// build http response with status code of 4xx and 5xx, with custom adjustments
+pub(crate) fn synthetic_error_response_custom(
+  status_code: StatusCode,
+  custom: impl FnOnce(Builder) -> Builder,
+) -> RpxyResult<Response<ResponseBody>> {
+  let res = custom(Response::builder().status(status_code))
     .body(ResponseBody::Boxed(empty()))
     .unwrap();
   Ok(res)


### PR DESCRIPTION
Hi,

I have some websites that don't offer any authentication by themselves, but I still don't want them to be open to everyone, so I thought to add support for that in rpxy using HTTP basic authentication. This is a crude first version, but it works. Will update documentation etc if you think this is something you would like in rpxy. I am also looking forward to suggestions regarding naming, style etc.

Example config as it is right now:

```toml
[apps.localhost]
server_name = 'localhost'

[apps.localhost.htpasswd]
sampleuser = 'samplepassword'
anotheruser = 'anotherpass'
```
or 
```toml
[apps.localhost]
server_name = 'localhost'
htpasswd = { sampleuser = 'samplepassword', anotheruser = 'anotherpass' }
```

Alternatively the passwords could be stored in a separate `[passwords]` section from where they could be referenced by name (which would also allow sharing one set of passwords between multiple sites).. Could also store the passwords in a separate file.