### PR TITLE
feat: initial support for X25519Kyber768Draft00 PQC

### DIFF
--- a/rpxy-acme/Cargo.toml
+++ b/rpxy-acme/Cargo.toml
@@ -10,6 +10,9 @@ readme.workspace = true
 edition.workspace = true
 publish.workspace = true
 
+[features]
+post-quantum = ["rustls-post-quantum"]
+
 [dependencies]
 url = { version = "2.5.2" }
 rustc-hash = "2.0.0"
@@ -21,7 +24,7 @@ aws-lc-rs = { version = "1.10.0", default-features = false, features = [
   "aws-lc-sys",
 ] }
 blocking = "1.6.1"
-rustls = { version = "0.23.15", default-features = false, features = [
+rustls = { version = "0.23.16", default-features = false, features = [
   "std",
   "aws_lc_rs",
 ] }
@@ -29,6 +32,7 @@ rustls-platform-verifier = { version = "0.3.4" }
 rustls-acme = { path = "../submodules/rustls-acme/", default-features = false, features = [
   "aws-lc-rs",
 ] }
+rustls-post-quantum = { version = "0.1.0", optional = true }
 tokio = { version = "1.41.0", default-features = false }
 tokio-util = { version = "0.7.12", default-features = false }
 tokio-stream = { version = "0.1.16", default-features = false }

--- a/rpxy-acme/src/manager.rs
+++ b/rpxy-acme/src/manager.rs
@@ -37,8 +37,11 @@ impl AcmeManager {
     domains: &[String],
     runtime_handle: Handle,
   ) -> Result<Self, RpxyAcmeError> {
+    #[cfg(not(feature = "post-quantum"))]
     // Install aws_lc_rs as default crypto provider for rustls
     let _ = rustls::crypto::CryptoProvider::install_default(rustls::crypto::aws_lc_rs::default_provider());
+    #[cfg(feature = "post-quantum")]
+    let _ = rustls::crypto::CryptoProvider::install_default(rustls_post_quantum::provider());
 
     let acme_registry_dir = acme_registry_dir
       .map(|v| v.to_ascii_lowercase())

--- a/rpxy-bin/Cargo.toml
+++ b/rpxy-bin/Cargo.toml
@@ -13,7 +13,9 @@ publish.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = ["http3-quinn", "cache", "rustls-backend", "acme"]
+default = ["http3-quinn", "cache", "rustls-backend", "acme", "post-quantum"]
+# default = ["http3-s2n", "cache", "rustls-backend", "acme", "post-quantum"]
+# default = ["http3-quinn", "cache", "rustls-backend", "acme"]
 # default = ["http3-s2n", "cache", "rustls-backend", "acme"]
 http3-quinn = ["rpxy-lib/http3-quinn"]
 http3-s2n = ["rpxy-lib/http3-s2n"]
@@ -22,6 +24,7 @@ rustls-backend = ["rpxy-lib/rustls-backend"]
 webpki-roots = ["rpxy-lib/webpki-roots"]
 cache = ["rpxy-lib/cache"]
 acme = ["rpxy-lib/acme", "rpxy-acme"]
+post-quantum = ["rpxy-lib/post-quantum"]
 
 [dependencies]
 rpxy-lib = { path = "../rpxy-lib/", default-features = false, features = [
@@ -31,7 +34,7 @@ rpxy-lib = { path = "../rpxy-lib/", default-features = false, features = [
 mimalloc = { version = "*", default-features = false }
 anyhow = "1.0.91"
 rustc-hash = "2.0.0"
-serde = { version = "1.0.213", default-features = false, features = ["derive"] }
+serde = { version = "1.0.214", default-features = false, features = ["derive"] }
 tokio = { version = "1.41.0", default-features = false, features = [
   "net",
   "rt-multi-thread",

--- a/rpxy-certs/Cargo.toml
+++ b/rpxy-certs/Cargo.toml
@@ -12,6 +12,7 @@ publish.workspace = true
 
 [features]
 default = ["http3"]
+post-quantum = ["rustls-post-quantum"]
 http3 = []
 
 [dependencies]
@@ -21,7 +22,7 @@ derive_builder = { version = "0.20.2" }
 thiserror = { version = "1.0.65" }
 hot_reload = { version = "0.1.6" }
 async-trait = { version = "0.1.83" }
-rustls = { version = "0.23.15", default-features = false, features = [
+rustls = { version = "0.23.16", default-features = false, features = [
   "std",
   "aws_lc_rs",
 ] }
@@ -30,6 +31,7 @@ rustls-webpki = { version = "0.102.8", default-features = false, features = [
   "std",
   "aws_lc_rs",
 ] }
+rustls-post-quantum = { version = "0.1.0", optional = true }
 x509-parser = { version = "0.16.0" }
 
 [dev-dependencies]

--- a/rpxy-certs/src/lib.rs
+++ b/rpxy-certs/src/lib.rs
@@ -12,7 +12,7 @@ mod log {
 use crate::{error::*, log::*, reloader_service::DynCryptoSource};
 use hot_reload::{ReloaderReceiver, ReloaderService};
 use rustc_hash::FxHashMap as HashMap;
-use rustls::crypto::{aws_lc_rs, CryptoProvider};
+use rustls::crypto::CryptoProvider;
 use std::sync::Arc;
 
 /* ------------------------------------------------ */
@@ -44,8 +44,11 @@ where
   T: CryptoSource<Error = RpxyCertError> + Send + Sync + Clone + 'static,
 {
   info!("Building certificate reloader service");
+  #[cfg(not(feature = "post-quantum"))]
   // Install aws_lc_rs as default crypto provider for rustls
-  let _ = CryptoProvider::install_default(aws_lc_rs::default_provider());
+  let _ = CryptoProvider::install_default(rustls::crypto::aws_lc_rs::default_provider());
+  #[cfg(feature = "post-quantum")]
+  let _ = CryptoProvider::install_default(rustls_post_quantum::provider());
 
   let source = crypto_source_map
     .iter()

--- a/rpxy-certs/src/server_crypto.rs
+++ b/rpxy-certs/src/server_crypto.rs
@@ -179,7 +179,10 @@ mod tests {
 
   #[tokio::test]
   async fn test_server_crypto_base_try_into() {
+    #[cfg(not(feature = "post-quantum"))]
     let _ = CryptoProvider::install_default(rustls::crypto::aws_lc_rs::default_provider());
+    #[cfg(feature = "post-quantum")]
+    let _ = CryptoProvider::install_default(rustls_post_quantum::provider());
 
     let mut server_crypto_base = ServerCryptoBase::default();
 

--- a/rpxy-lib/Cargo.toml
+++ b/rpxy-lib/Cargo.toml
@@ -28,6 +28,11 @@ native-tls-backend = ["hyper-tls"]
 rustls-backend = ["hyper-rustls"]
 webpki-roots = ["rustls-backend", "hyper-rustls/webpki-tokio"]
 acme = ["dep:rpxy-acme"]
+post-quantum = [
+  "rustls-post-quantum",
+  "rpxy-acme/post-quantum",
+  "rpxy-certs/post-quantum",
+]
 
 [dependencies]
 rand = "0.8.5"
@@ -55,7 +60,7 @@ thiserror = "1.0.65"
 http = "1.1.0"
 http-body-util = "0.1.2"
 hyper = { version = "1.5.0", default-features = false }
-hyper-util = { version = "0.1.9", features = ["full"] }
+hyper-util = { version = "0.1.10", features = ["full"] }
 futures-util = { version = "0.3.31", default-features = false }
 futures-channel = { version = "0.3.31", default-features = false }
 
@@ -74,7 +79,8 @@ hyper-rustls = { version = "0.27.3", default-features = false, features = [
 # tls and cert management for server
 rpxy-certs = { path = "../rpxy-certs/", default-features = false }
 hot_reload = "0.1.6"
-rustls = { version = "0.23.15", default-features = false }
+rustls = { version = "0.23.16", default-features = false }
+rustls-post-quantum = { version = "0.1.0", optional = true }
 tokio-rustls = { version = "0.26.0", features = ["early-data"] }
 
 # acme

--- a/rpxy-lib/src/lib.rs
+++ b/rpxy-lib/src/lib.rs
@@ -22,7 +22,7 @@ use crate::{
 use futures::future::join_all;
 use hot_reload::ReloaderReceiver;
 use rpxy_certs::ServerCryptoBase;
-use rustls::crypto::{aws_lc_rs, CryptoProvider};
+use rustls::crypto::CryptoProvider;
 use std::sync::Arc;
 use tokio_util::sync::CancellationToken;
 
@@ -101,8 +101,11 @@ pub async fn entrypoint(
     info!("Cache is disabled")
   }
 
+  #[cfg(not(feature = "post-quantum"))]
   // Install aws_lc_rs as default crypto provider for rustls
-  let _ = CryptoProvider::install_default(aws_lc_rs::default_provider());
+  let _ = CryptoProvider::install_default(rustls::crypto::aws_lc_rs::default_provider());
+  #[cfg(feature = "post-quantum")]
+  let _ = CryptoProvider::install_default(rustls_post_quantum::provider());
 
   // 1. build backends, and make it contained in Arc
   let app_manager = Arc::new(backend::BackendAppManager::try_from(app_config_list)?);


### PR DESCRIPTION
This supports X25519Kyber768Draft00 for key exchange in TLS1.3, using rustls-post-quantum.

#201 is solved.