### PR TITLE
fix: Also report toml loading failures with --watch

### DIFF
--- a/rpxy-bin/src/config/service.rs
+++ b/rpxy-bin/src/config/service.rs
@@ -1,6 +1,7 @@
 use super::toml::ConfigToml;
 use async_trait::async_trait;
 use hot_reload::{Reload, ReloaderError};
+use tracing::warn;
 
 #[derive(Clone)]
 pub struct ConfigTomlReloader {
@@ -17,8 +18,10 @@ impl Reload<ConfigToml> for ConfigTomlReloader {
   }
 
   async fn reload(&self) -> Result<Option<ConfigToml>, ReloaderError<ConfigToml>> {
-    let conf = ConfigToml::new(&self.config_path)
-      .map_err(|_e| ReloaderError::<ConfigToml>::Reload("Failed to reload config toml"))?;
+    let conf = ConfigToml::new(&self.config_path).map_err(|e| {
+      warn!("Invalid toml file: {e:?}");
+      ReloaderError::<ConfigToml>::Reload("Failed to reload config toml")
+    })?;
     Ok(Some(conf))
   }
 }


### PR DESCRIPTION
The hot_reload crate (used for loading config.toml) in `--watch` mode does not report the ReloaderError we give, only that reloading failed with generic message "Failed to reload watch target" in WARN level. But at the same time, WARN level logs of external crates are not logged by default => no log message when broken config and --watch is active.

So I changed it to report our own log message more in line with non-watch mode together with the error detail about why loading failed. I changed it from ERROR to WARN because it is non-fatal in the sense that if you fix the configuration it can still recover. But of course if it is the first time the config is being loaded it will block startup, so yeah feel free to comment on that.

Example log:
```
2024-11-03T23:04:03.703607Z  WARN Invalid toml file: TOML parse error at line 211, column 26
    |
211 | ignore_sni_consistency = if-same-cert
    |
invalid string
expected `"`, `'`

```

Steps to reproduce:
1. Break config.toml i.e. set `listen_port = true` which has wrong datatype.
2. run `cargo run -- --config config.toml --watch`
3. Watch startup jam without error in logs

Current implementation will keep re-reporting the problem at 15 second intervals until the error has been fixed.