### PR TITLE
feat: Add 502 error when upstream unavailable

### DIFF
--- a/rpxy-lib/src/message_handler/http_result.rs
+++ b/rpxy-lib/src/message_handler/http_result.rs
@@ -53,6 +53,7 @@ impl From<HttpError> for StatusCode {
       HttpError::FailedToAddSetCookeInResponse(_) => StatusCode::INTERNAL_SERVER_ERROR,
       HttpError::FailedToGenerateDownstreamResponse(_) => StatusCode::INTERNAL_SERVER_ERROR,
       HttpError::FailedToUpgrade(_) => StatusCode::INTERNAL_SERVER_ERROR,
+      HttpError::FailedToGetResponseFromBackend(_) => StatusCode::BAD_GATEWAY,
       // HttpError::NoUpgradeExtensionInRequest => StatusCode::BAD_REQUEST,
       // HttpError::NoUpgradeExtensionInResponse => StatusCode::BAD_GATEWAY,
       _ => StatusCode::INTERNAL_SERVER_ERROR,


### PR DESCRIPTION
When upstream server does not respond, 502 is imho a much better response than 500.