### PR TITLE
feat: Add "if-same-cert" sni consistency mode

### DIFF
--- a/config-example.toml
+++ b/config-example.toml
@@ -106,10 +106,13 @@ tls = { https_redirection = true, acme = true }
 #      Experimantal settings      #
 ###################################
 [experimental]
-# Higly recommend not to be true. If true, you ignore RFC. if not specified, it is always false.
-# This might be required to be true when a certificate is used by multiple backend hosts, especially in case where a TLS connection is re-used.
+# Higly recommend not to be true. If either is true, you ignore RFC. If not specified, they are always false.
+# Either might be required to be true when a certificate is used by multiple backend hosts, especially in case where a TLS connection is re-used.
+# The `samecert_sni_consistency` option is a middleground. It only allows to share a connection if the apps of each request share the same tls certficate that was chosen during TLS handshake.
+# The `ignore_sni_consistency` options takes precedence if both are true.
 # We should note that this strongly depends on the client implementation.
 ignore_sni_consistency = false
+samecert_sni_consistency = false
 
 # Force connection handling timeout regardless of the connection status, i.e., idle or not.
 # 0 represents an infinite timeout. [default: 0]

--- a/rpxy-lib/src/backend/backend_main.rs
+++ b/rpxy-lib/src/backend/backend_main.rs
@@ -27,6 +27,8 @@ pub struct BackendApp {
   /// tls settings: mutual TLS is enabled
   #[builder(default)]
   pub mutual_tls: Option<bool>,
+  #[builder(default)]
+  pub cert: Option<String>,
 }
 impl<'a> BackendAppBuilder {
   pub fn server_name(&mut self, server_name: impl Into<Cow<'a, str>>) -> &mut Self {
@@ -61,6 +63,7 @@ impl TryFrom<&AppConfig> for BackendApp {
       let tls = app_config.tls.as_ref().unwrap();
       backend_builder
         .https_redirection(Some(tls.https_redirection))
+        .cert(tls.cert.clone())
         .mutual_tls(Some(tls.mutual_tls))
         .build()?
     };

--- a/rpxy-lib/src/globals.rs
+++ b/rpxy-lib/src/globals.rs
@@ -1,7 +1,7 @@
 use crate::{constants::*, count::RequestCount};
 use hot_reload::ReloaderReceiver;
 use rpxy_certs::ServerCryptoBase;
-use std::{net::SocketAddr, time::Duration};
+use std::{fmt::Display, net::SocketAddr, time::Duration};
 use tokio_util::sync::CancellationToken;
 
 /// Global object containing proxy configurations and shared object like counters.
@@ -50,7 +50,7 @@ pub struct ProxyConfig {
 
   // experimentals
   /// SNI consistency check
-  pub sni_consistency: bool, // Handler
+  pub sni_consistency: SniConsistency, // Handler
   /// Connection handling timeout
   /// timeout to handle a connection, total time of receive request, serve, and send response. this might limits the max length of response.
   pub connection_handling_timeout: Option<Duration>,
@@ -100,7 +100,7 @@ impl Default for ProxyConfig {
       max_concurrent_streams: MAX_CONCURRENT_STREAMS,
       keepalive: true,
 
-      sni_consistency: true,
+      sni_consistency: SniConsistency::Full,
       connection_handling_timeout: None,
 
       #[cfg(feature = "cache")]
@@ -169,6 +169,24 @@ pub struct UpstreamUri {
 pub struct TlsConfig {
   pub mutual_tls: bool,
   pub https_redirection: bool,
+  pub cert: Option<String>,
   #[cfg(feature = "acme")]
   pub acme: bool,
+}
+
+#[derive(PartialEq, Eq, Clone)]
+pub enum SniConsistency {
+  Full,
+  SameCertificate,
+  Ignore,
+}
+
+impl Display for SniConsistency {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    f.write_str(match self {
+      SniConsistency::Full => "Full",
+      SniConsistency::SameCertificate => "Same-certificate",
+      SniConsistency::Ignore => "Ignore",
+    })
+  }
 }

--- a/rpxy-lib/src/lib.rs
+++ b/rpxy-lib/src/lib.rs
@@ -27,7 +27,7 @@ use std::sync::Arc;
 use tokio_util::sync::CancellationToken;
 
 /* ------------------------------------------------ */
-pub use crate::globals::{AppConfig, AppConfigList, ProxyConfig, ReverseProxyConfig, TlsConfig, UpstreamUri};
+pub use crate::globals::{AppConfig, AppConfigList, ProxyConfig, ReverseProxyConfig, SniConsistency, TlsConfig, UpstreamUri};
 pub mod reexports {
   pub use hyper::Uri;
 }
@@ -91,8 +91,11 @@ pub async fn entrypoint(
   if proxy_config.http3 {
     info!("Experimental HTTP/3.0 is enabled. Note it is still very unstable.");
   }
-  if !proxy_config.sni_consistency {
-    info!("Ignore consistency between TLS SNI and Host header (or Request line). Note it violates RFC.");
+  if proxy_config.sni_consistency != SniConsistency::Full {
+    info!(
+      "{} consistency between TLS SNI and Host header (or Request line). Note it violates RFC.",
+      proxy_config.sni_consistency
+    );
   }
   #[cfg(feature = "cache")]
   if proxy_config.cache_enabled {


### PR DESCRIPTION
So yeah, I have a wildcard certificate that I use for multiple separate apps. And my browser is indeed reusing a connection to site1.example.com for service site2.example.com. I don't yet know whether it is doing it because it notices the same certificate is valid for both, or because they are served by the same IP:port combination. But I am hopeful the latter is not the case because that honestly feels a bit insane.

So yeah, by default rpxy sends 421 responses to such un-rfc behaviour. But unfortunately my browser does not either automatically re-issue the request on a different connection (MDN docs also says it is indeed optional operation). So at least one app that I have stops polling the server when this happens.

So I tested setting `ignore_sni_consistency = true` in the config. And that solved the problem. But the comments in front of the configuration option left me restless and I thought "so will it serve any configured app then, regardless of certificate?".. So I tested it and found out that yes, I could even access sites that don't have a tls certificate configured by using e.g. `curl 'https://site1.example.com/' -H 'Host: site2.example.com'` where site2 does not have a tls cert configured.

So I wanted a middle ground that allows this un-rfc behaviour ONLY when both the app served by the servername from sni AND the app requested by the `Host` header have the **SAME** certificate configured. More specifically, I defined "SAME" as "has the same `tls_cert_path`".

It works. I have yet to configure apps using two different certificates, will probably try that later using the built-in acme support. But even if my beloved browser decided to re-use a connection for to a site with a different certificate, I would be very angry at said browser and perhaps even file a ticket for it. So it would probably not change my stance that I want to stick to this "same-cert" middle-ground.

Anyway, this PR is my first take on adding this functionality. I initially wanted to make `ignore_sni_consistency` a three-state variable still supporting `true` and `false` so that existing configurations would not be broken, but alas `true` and `false` always seem to get treated as booleans so that didn't work. Instead I added a new `samecert_sni_consistency` boolean next to it to avoid breaking existing configurations. Please give your opinion on this. How it works now is:

| `ignore_sni_consistency` | `samecert_sni_consistency` | result |
|--------|--------|--------|
| false | false | "Full" SNI consistency = sni hostname must match `Host` hostname |
| false | true | "Same certificate" SNI consistency = app configured for sni hostname must use same certificate as app configured for `Host` hostname |
| true | ignored | "Ignore" SNI constistency = any app can be accessed, even ones without tls configured |

I'll be happy to receive any feedback about this. Documentation changes not yet done. I introduced a `LazyCell<>` in `handle_request_inner()` to avoid the hashmap lookup until it is needed in one of the two places. I don't know if it makes sense performance-wise. Also if you want to support older rust versions then LazyCell is not usable. And yeah, I had to add the certificate path to the Backend object so I could compare it. But in retrospect I could also perhaps replace that with some certificate id so the comparison would be faster in the request path. Perhaps I'll do that.