### PR TITLE
Fix: log level 

### DIFF
--- a/rpxy-acme/Cargo.toml
+++ b/rpxy-acme/Cargo.toml
@@ -28,7 +28,7 @@ rustls = { version = "0.23.16", default-features = false, features = [
   "std",
   "aws_lc_rs",
 ] }
-rustls-platform-verifier = { version = "0.3.4" }
+rustls-platform-verifier = { version = "0.4.0" }
 rustls-acme = { path = "../submodules/rustls-acme/", default-features = false, features = [
   "aws-lc-rs",
 ] }

--- a/rpxy-bin/Cargo.toml
+++ b/rpxy-bin/Cargo.toml
@@ -49,7 +49,7 @@ futures-util = { version = "0.3.31", default-features = false }
 # config
 clap = { version = "4.5.20", features = ["std", "cargo", "wrap_help"] }
 toml = { version = "0.8.19", default-features = false, features = ["parse"] }
-hot_reload = "0.1.6"
+hot_reload = "0.1.8"
 serde_ignored = "0.1.10"
 
 # logging

--- a/rpxy-bin/src/config/service.rs
+++ b/rpxy-bin/src/config/service.rs
@@ -8,17 +8,16 @@ pub struct ConfigTomlReloader {
 }
 
 #[async_trait]
-impl Reload<ConfigToml> for ConfigTomlReloader {
+impl Reload<ConfigToml, String> for ConfigTomlReloader {
   type Source = String;
-  async fn new(source: &Self::Source) -> Result<Self, ReloaderError<ConfigToml>> {
+  async fn new(source: &Self::Source) -> Result<Self, ReloaderError<ConfigToml, String>> {
     Ok(Self {
       config_path: source.clone(),
     })
   }
 
-  async fn reload(&self) -> Result<Option<ConfigToml>, ReloaderError<ConfigToml>> {
-    let conf = ConfigToml::new(&self.config_path)
-      .map_err(|_e| ReloaderError::<ConfigToml>::Reload("Failed to reload config toml"))?;
+  async fn reload(&self) -> Result<Option<ConfigToml>, ReloaderError<ConfigToml, String>> {
+    let conf = ConfigToml::new(&self.config_path).map_err(|e| ReloaderError::<ConfigToml, String>::Reload(e.to_string()))?;
     Ok(Some(conf))
   }
 }

--- a/rpxy-bin/src/log.rs
+++ b/rpxy-bin/src/log.rs
@@ -21,7 +21,7 @@ pub fn init_logger() {
           .target()
           .starts_with(env!("CARGO_PKG_NAME").replace('-', "_").as_str())
           && metadata.level() <= &level)
-          || metadata.level() <= &tracing::Level::ERROR.min(level)
+          || metadata.level() <= &tracing::Level::WARN.min(level)
       }));
     tracing_subscriber::registry().with(stdio_layer).init();
   } else {

--- a/rpxy-bin/src/main.rs
+++ b/rpxy-bin/src/main.rs
@@ -40,10 +40,13 @@ fn main() {
         std::process::exit(1);
       }
     } else {
-      let (config_service, config_rx) =
-        ReloaderService::<ConfigTomlReloader, ConfigToml>::new(&parsed_opts.config_file_path, CONFIG_WATCH_DELAY_SECS, false)
-          .await
-          .unwrap();
+      let (config_service, config_rx) = ReloaderService::<ConfigTomlReloader, ConfigToml, String>::new(
+        &parsed_opts.config_file_path,
+        CONFIG_WATCH_DELAY_SECS,
+        false,
+      )
+      .await
+      .unwrap();
 
       tokio::select! {
         config_res = config_service.start() => {
@@ -246,7 +249,7 @@ async fn rpxy_service_without_watcher(
 }
 
 async fn rpxy_service_with_watcher(
-  mut config_rx: ReloaderReceiver<ConfigToml>,
+  mut config_rx: ReloaderReceiver<ConfigToml, String>,
   runtime_handle: tokio::runtime::Handle,
 ) -> Result<(), anyhow::Error> {
   info!("Start rpxy service with dynamic config reloader");

--- a/rpxy-certs/Cargo.toml
+++ b/rpxy-certs/Cargo.toml
@@ -20,7 +20,7 @@ rustc-hash = { version = "2.0.0" }
 tracing = { version = "0.1.40" }
 derive_builder = { version = "0.20.2" }
 thiserror = { version = "1.0.68" }
-hot_reload = { version = "0.1.6" }
+hot_reload = { version = "0.1.8" }
 async-trait = { version = "0.1.83" }
 rustls = { version = "0.23.16", default-features = false, features = [
   "std",

--- a/rpxy-lib/Cargo.toml
+++ b/rpxy-lib/Cargo.toml
@@ -79,7 +79,7 @@ hyper-rustls = { version = "0.27.3", default-features = false, features = [
 
 # tls and cert management for server
 rpxy-certs = { path = "../rpxy-certs/", default-features = false }
-hot_reload = "0.1.6"
+hot_reload = "0.1.8"
 rustls = { version = "0.23.16", default-features = false }
 rustls-post-quantum = { version = "0.1.0", optional = true }
 tokio-rustls = { version = "0.26.0", features = ["early-data"] }


### PR DESCRIPTION
Update the default logging level of external crates to warn. Another solution to the problem posed in #214 