### PR TITLE
feat: Block CONNECT requests for improved security

### DIFF
--- a/rpxy-lib/src/message_handler/http_result.rs
+++ b/rpxy-lib/src/message_handler/http_result.rs
@@ -10,6 +10,8 @@ pub(crate) type HttpResult<T> = std::result::Result<T, HttpError>;
 pub enum HttpError {
   // #[error("No host is give in request header")]
   // NoHostInRequestHeader,
+  #[error("Unsupported method")]
+  UnsupportedMethod,
   #[error("Invalid host in request header")]
   InvalidHostInRequestHeader,
   #[error("SNI and Host header mismatch")]
@@ -44,6 +46,7 @@ impl From<HttpError> for StatusCode {
   fn from(e: HttpError) -> StatusCode {
     match e {
       // HttpError::NoHostInRequestHeader => StatusCode::BAD_REQUEST,
+      HttpError::UnsupportedMethod => StatusCode::METHOD_NOT_ALLOWED,
       HttpError::InvalidHostInRequestHeader => StatusCode::BAD_REQUEST,
       HttpError::SniHostInconsistency => StatusCode::MISDIRECTED_REQUEST,
       HttpError::NoMatchingBackendApp => StatusCode::SERVICE_UNAVAILABLE,


### PR DESCRIPTION
Hi, I found that the CONNECT http method is not blocked by rpxy. And imho it does not make sense to support them in a reverse proxy. So this PR just blocks all CONNECT requests outright.

But before I implemented that I tested it out, and rpxy did forward some of the test requests to the backend but did not handle 200 responses correctly, leaving the client and/or the server in funny situations (at least with HTTP/1.1).

Quoting the comment I added in the code:
`    // Block CONNECT requests because a) makes no sense to run a forward proxy behind a reverse proxy = fringe use case b) might have serious security implications for badly configured upstreams c) it doesn't work with current implementation (bodies are not forwarded)`