### PR TITLE
0.9.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # CHANGELOG
 
-## 0.9.6 or 0.10.0 (Unreleased)
+## 0.9.7 or 0.10.0 (Unreleased)
+
+## 0.9.6
+
+### Improvement
+
+- Feat: Change the default hashing algorithm for internal hashmaps and hashsets from FxHash to aHash. This change is to improve the security against HashDos attacks for colliding domain names and paths, and to improve the speed of hash operations for string keys (c.f., [the performance comparison](https://github.com/tkaitchuck/aHash/blob/master/compare/readme.md)).
+- Deps and refactor
 
 ## 0.9.5
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.9.5"
+version = "0.9.6"
 authors = ["Jun Kurihara"]
 homepage = "https://github.com/junkurihara/rust-rpxy"
 repository = "https://github.com/junkurihara/rust-rpxy"

--- a/rpxy-acme/Cargo.toml
+++ b/rpxy-acme/Cargo.toml
@@ -16,11 +16,11 @@ post-quantum = ["rustls-post-quantum"]
 [dependencies]
 url = { version = "2.5.4" }
 rustc-hash = "2.1.0"
-thiserror = "2.0.6"
+thiserror = "2.0.9"
 tracing = "0.1.41"
 async-trait = "0.1.83"
 base64 = "0.22.1"
-aws-lc-rs = { version = "1.11.1", default-features = false, features = [
+aws-lc-rs = { version = "1.12.0", default-features = false, features = [
   "aws-lc-sys",
 ] }
 blocking = "1.6.1"
@@ -28,7 +28,7 @@ rustls = { version = "0.23.20", default-features = false, features = [
   "std",
   "aws_lc_rs",
 ] }
-rustls-platform-verifier = { version = "0.4.0" }
+rustls-platform-verifier = { version = "0.5.0" }
 rustls-acme = { path = "../submodules/rustls-acme/", default-features = false, features = [
   "aws-lc-rs",
 ] }

--- a/rpxy-acme/Cargo.toml
+++ b/rpxy-acme/Cargo.toml
@@ -18,7 +18,7 @@ url = { version = "2.5.4" }
 rustc-hash = "2.1.0"
 thiserror = "2.0.9"
 tracing = "0.1.41"
-async-trait = "0.1.83"
+async-trait = "0.1.84"
 base64 = "0.22.1"
 aws-lc-rs = { version = "1.12.0", default-features = false, features = [
   "aws-lc-sys",

--- a/rpxy-acme/Cargo.toml
+++ b/rpxy-acme/Cargo.toml
@@ -15,7 +15,7 @@ post-quantum = ["rustls-post-quantum"]
 
 [dependencies]
 url = { version = "2.5.4" }
-rustc-hash = "2.1.0"
+ahash = "0.8.11"
 thiserror = "2.0.9"
 tracing = "0.1.41"
 async-trait = "0.1.84"

--- a/rpxy-acme/src/manager.rs
+++ b/rpxy-acme/src/manager.rs
@@ -4,7 +4,7 @@ use crate::{
   error::RpxyAcmeError,
   log::*,
 };
-use rustc_hash::FxHashMap as HashMap;
+use ahash::HashMap;
 use rustls::ServerConfig;
 use rustls_acme::AcmeConfig;
 use std::{path::PathBuf, sync::Arc};

--- a/rpxy-bin/Cargo.toml
+++ b/rpxy-bin/Cargo.toml
@@ -32,7 +32,7 @@ rpxy-lib = { path = "../rpxy-lib/", default-features = false, features = [
 mimalloc = { version = "*", default-features = false }
 anyhow = "1.0.95"
 rustc-hash = "2.1.0"
-serde = { version = "1.0.216", default-features = false, features = ["derive"] }
+serde = { version = "1.0.217", default-features = false, features = ["derive"] }
 tokio = { version = "1.42.0", default-features = false, features = [
   "net",
   "rt-multi-thread",
@@ -41,7 +41,7 @@ tokio = { version = "1.42.0", default-features = false, features = [
   "macros",
 ] }
 tokio-util = { version = "0.7.13", default-features = false }
-async-trait = "0.1.83"
+async-trait = "0.1.84"
 futures-util = { version = "0.3.31", default-features = false }
 
 # config

--- a/rpxy-bin/Cargo.toml
+++ b/rpxy-bin/Cargo.toml
@@ -31,7 +31,7 @@ rpxy-lib = { path = "../rpxy-lib/", default-features = false, features = [
 
 mimalloc = { version = "*", default-features = false }
 anyhow = "1.0.95"
-rustc-hash = "2.1.0"
+ahash = "0.8.11"
 serde = { version = "1.0.217", default-features = false, features = ["derive"] }
 tokio = { version = "1.42.0", default-features = false, features = [
   "net",

--- a/rpxy-bin/Cargo.toml
+++ b/rpxy-bin/Cargo.toml
@@ -30,7 +30,7 @@ rpxy-lib = { path = "../rpxy-lib/", default-features = false, features = [
 ] }
 
 mimalloc = { version = "*", default-features = false }
-anyhow = "1.0.94"
+anyhow = "1.0.95"
 rustc-hash = "2.1.0"
 serde = { version = "1.0.216", default-features = false, features = ["derive"] }
 tokio = { version = "1.42.0", default-features = false, features = [

--- a/rpxy-bin/src/config/parse.rs
+++ b/rpxy-bin/src/config/parse.rs
@@ -1,10 +1,10 @@
 use super::toml::ConfigToml;
 use crate::error::{anyhow, ensure};
+use ahash::HashMap;
 use clap::{Arg, ArgAction};
 use hot_reload::{ReloaderReceiver, ReloaderService};
 use rpxy_certs::{build_cert_reloader, CryptoFileSourceBuilder, CryptoReloader, ServerCryptoBase};
 use rpxy_lib::{AppConfig, AppConfigList, ProxyConfig};
-use rustc_hash::FxHashMap as HashMap;
 
 #[cfg(feature = "acme")]
 use rpxy_acme::{AcmeManager, ACME_DIR_URL, ACME_REGISTRY_PATH};

--- a/rpxy-bin/src/config/toml.rs
+++ b/rpxy-bin/src/config/toml.rs
@@ -3,8 +3,8 @@ use crate::{
   error::{anyhow, ensure},
   log::warn,
 };
+use ahash::HashMap;
 use rpxy_lib::{reexports::Uri, AppConfig, ProxyConfig, ReverseProxyConfig, TlsConfig, UpstreamUri};
-use rustc_hash::FxHashMap as HashMap;
 use serde::Deserialize;
 use std::{fs, net::SocketAddr};
 use tokio::time::Duration;
@@ -232,7 +232,7 @@ impl ConfigToml {
 
     // Check unused fields during deserialization
     let t = toml::de::Deserializer::new(&config_str);
-    let mut unused = rustc_hash::FxHashSet::default();
+    let mut unused = ahash::HashSet::default();
 
     let res = serde_ignored::deserialize(t, |path| {
       unused.insert(path.to_string());

--- a/rpxy-certs/Cargo.toml
+++ b/rpxy-certs/Cargo.toml
@@ -16,7 +16,7 @@ post-quantum = ["rustls-post-quantum"]
 http3 = []
 
 [dependencies]
-rustc-hash = { version = "2.1.0" }
+ahash = { version = "0.8.11" }
 tracing = { version = "0.1.41" }
 derive_builder = { version = "0.20.2" }
 thiserror = { version = "2.0.9" }

--- a/rpxy-certs/Cargo.toml
+++ b/rpxy-certs/Cargo.toml
@@ -21,7 +21,7 @@ tracing = { version = "0.1.41" }
 derive_builder = { version = "0.20.2" }
 thiserror = { version = "2.0.9" }
 hot_reload = { version = "0.1.8" }
-async-trait = { version = "0.1.83" }
+async-trait = { version = "0.1.84" }
 rustls = { version = "0.23.20", default-features = false, features = [
   "std",
   "aws_lc_rs",

--- a/rpxy-certs/Cargo.toml
+++ b/rpxy-certs/Cargo.toml
@@ -19,7 +19,7 @@ http3 = []
 rustc-hash = { version = "2.1.0" }
 tracing = { version = "0.1.41" }
 derive_builder = { version = "0.20.2" }
-thiserror = { version = "2.0.6" }
+thiserror = { version = "2.0.9" }
 hot_reload = { version = "0.1.8" }
 async-trait = { version = "0.1.83" }
 rustls = { version = "0.23.20", default-features = false, features = [

--- a/rpxy-certs/src/certs.rs
+++ b/rpxy-certs/src/certs.rs
@@ -1,5 +1,5 @@
 use crate::error::*;
-use rustc_hash::FxHashMap as HashMap;
+use ahash::HashMap;
 use rustls::{crypto::aws_lc_rs::sign::any_supported_type, pki_types, sign::CertifiedKey};
 use std::sync::Arc;
 use x509_parser::prelude::*;

--- a/rpxy-certs/src/lib.rs
+++ b/rpxy-certs/src/lib.rs
@@ -10,8 +10,8 @@ mod log {
 }
 
 use crate::{error::*, log::*, reloader_service::DynCryptoSource};
+use ahash::HashMap;
 use hot_reload::{ReloaderReceiver, ReloaderService};
-use rustc_hash::FxHashMap as HashMap;
 use rustls::crypto::CryptoProvider;
 use std::sync::Arc;
 

--- a/rpxy-certs/src/reloader_service.rs
+++ b/rpxy-certs/src/reloader_service.rs
@@ -4,9 +4,9 @@ use crate::{
   log::*,
   server_crypto::{ServerCryptoBase, ServerNameBytes},
 };
+use ahash::HashMap;
 use async_trait::async_trait;
 use hot_reload::{Reload, ReloaderError};
-use rustc_hash::FxHashMap as HashMap;
 use std::sync::Arc;
 
 /* ------------------------------------------------ */

--- a/rpxy-certs/src/server_crypto.rs
+++ b/rpxy-certs/src/server_crypto.rs
@@ -1,5 +1,5 @@
 use crate::{certs::SingleServerCertsKeys, error::*, log::*};
-use rustc_hash::FxHashMap as HashMap;
+use ahash::HashMap;
 use rustls::{
   crypto::CryptoProvider,
   server::{ResolvesServerCertUsingSni, WebPkiClientVerifier},

--- a/rpxy-lib/Cargo.toml
+++ b/rpxy-lib/Cargo.toml
@@ -51,7 +51,7 @@ tokio = { version = "1.42.0", default-features = false, features = [
 ] }
 tokio-util = { version = "0.7.13", default-features = false }
 pin-project-lite = "0.2.15"
-async-trait = "0.1.83"
+async-trait = "0.1.84"
 
 # Error handling
 anyhow = "1.0.95"

--- a/rpxy-lib/Cargo.toml
+++ b/rpxy-lib/Cargo.toml
@@ -37,7 +37,7 @@ post-quantum = [
 
 [dependencies]
 rand = "0.8.5"
-rustc-hash = "2.1.0"
+ahash = "0.8.11"
 bytes = "1.9.0"
 derive_builder = "0.20.2"
 futures = { version = "0.3.31", features = ["alloc", "async-await"] }

--- a/rpxy-lib/Cargo.toml
+++ b/rpxy-lib/Cargo.toml
@@ -54,13 +54,13 @@ pin-project-lite = "0.2.15"
 async-trait = "0.1.83"
 
 # Error handling
-anyhow = "1.0.94"
-thiserror = "2.0.6"
+anyhow = "1.0.95"
+thiserror = "2.0.9"
 
 # http for both server and client
 http = "1.2.0"
 http-body-util = "0.1.2"
-hyper = { version = "1.5.1", default-features = false }
+hyper = { version = "1.5.2", default-features = false }
 hyper-util = { version = "0.1.10", features = ["full"] }
 futures-util = { version = "0.3.31", default-features = false }
 futures-channel = { version = "0.3.31", default-features = false }
@@ -70,7 +70,7 @@ hyper-tls = { version = "0.6.0", features = [
   "alpn",
   "vendored",
 ], optional = true }
-hyper-rustls = { version = "0.27.3", default-features = false, features = [
+hyper-rustls = { version = "0.27.5", default-features = false, features = [
   "aws-lc-rs",
   "http1",
   "http2",

--- a/rpxy-lib/src/backend/backend_main.rs
+++ b/rpxy-lib/src/backend/backend_main.rs
@@ -4,8 +4,8 @@ use crate::{
   name_exp::{ByteName, ServerName},
   AppConfig, AppConfigList,
 };
+use ahash::HashMap;
 use derive_builder::Builder;
-use rustc_hash::FxHashMap as HashMap;
 use std::borrow::Cow;
 
 use super::upstream::PathManager;

--- a/rpxy-lib/src/backend/load_balance/load_balance_sticky.rs
+++ b/rpxy-lib/src/backend/load_balance/load_balance_sticky.rs
@@ -4,8 +4,8 @@ use super::{
   Upstream,
 };
 use crate::{constants::STICKY_COOKIE_NAME, log::*};
+use ahash::HashMap;
 use derive_builder::Builder;
-use rustc_hash::FxHashMap as HashMap;
 use std::{
   borrow::Cow,
   sync::{

--- a/rpxy-lib/src/backend/upstream.rs
+++ b/rpxy-lib/src/backend/upstream.rs
@@ -11,10 +11,10 @@ use crate::{
   log::*,
   name_exp::{ByteName, PathName},
 };
+use ahash::{HashMap, HashSet};
 #[cfg(feature = "sticky-cookie")]
 use base64::{engine::general_purpose, Engine as _};
 use derive_builder::Builder;
-use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 #[cfg(feature = "sticky-cookie")]
 use sha2::{Digest, Sha256};
 use std::borrow::Cow;

--- a/rpxy-lib/src/globals.rs
+++ b/rpxy-lib/src/globals.rs
@@ -20,7 +20,7 @@ pub struct Globals {
 
   #[cfg(feature = "acme")]
   /// ServerConfig used for only ACME challenge for ACME domains
-  pub server_configs_acme_challenge: std::sync::Arc<rustc_hash::FxHashMap<String, std::sync::Arc<rustls::ServerConfig>>>,
+  pub server_configs_acme_challenge: std::sync::Arc<ahash::HashMap<String, std::sync::Arc<rustls::ServerConfig>>>,
 }
 
 /// Configuration parameters for proxy transport and request handlers

--- a/rpxy-lib/src/lib.rs
+++ b/rpxy-lib/src/lib.rs
@@ -48,7 +48,7 @@ pub struct RpxyOptions {
 
   #[cfg(feature = "acme")]
   /// ServerConfig used for only ACME challenge for ACME domains
-  pub server_configs_acme_challenge: Arc<rustc_hash::FxHashMap<String, Arc<rustls::ServerConfig>>>,
+  pub server_configs_acme_challenge: Arc<ahash::HashMap<String, Arc<rustls::ServerConfig>>>,
 }
 
 /// Entrypoint that creates and spawns tasks of reverse proxy services

--- a/rpxy-lib/src/proxy/mod.rs
+++ b/rpxy-lib/src/proxy/mod.rs
@@ -14,12 +14,11 @@ use crate::{
   name_exp::ServerName,
 };
 use hyper_util::server::{self, conn::auto::Builder as ConnectionBuilder};
-use rustc_hash::FxHashMap as HashMap;
 use rustls::ServerConfig;
 use std::sync::Arc;
 
 /// SNI to ServerConfig map type
-pub type SniServerCryptoMap = HashMap<ServerName, Arc<ServerConfig>>;
+pub type SniServerCryptoMap = std::collections::HashMap<ServerName, Arc<ServerConfig>, ahash::RandomState>;
 
 pub(crate) use proxy_main::Proxy;
 

--- a/rpxy-lib/src/proxy/proxy_main.rs
+++ b/rpxy-lib/src/proxy/proxy_main.rs
@@ -294,7 +294,7 @@ where
           let map = server_config.individual_config_map.clone().iter().map(|(k,v)| {
             let server_name = ServerName::from(k.as_slice());
             (server_name, v.clone())
-          }).collect::<rustc_hash::FxHashMap<_,_>>();
+          }).collect::<std::collections::HashMap<_,_,ahash::RandomState>>();
           server_crypto_map = Some(Arc::new(map));
         }
       }


### PR DESCRIPTION
## Improvement

- Feat: Change the default hashing algorithm for internal hashmaps and hashsets from FxHash to aHash. This change is to improve the security against HashDos attacks for colliding domain names and paths, and to improve the speed of hash operations for string keys (c.f., [the performance comparison](https://github.com/tkaitchuck/aHash/blob/master/compare/readme.md)). Solves #227.
- Deps and refactor