### PR TITLE
Support gRPC

### DIFF
--- a/rpxy-lib/src/forwarder/client.rs
+++ b/rpxy-lib/src/forwarder/client.rs
@@ -226,7 +226,9 @@ where
     let connector = builder.https_or_http().enable_all_versions().wrap_connector(http.clone());
     let connector_h2 = builder_h2.https_or_http().enable_http2().wrap_connector(http);
     let inner = Client::builder(LocalExecutor::new(_globals.runtime_handle.clone())).build::<_, B1>(connector);
-    let inner_h2 = Client::builder(LocalExecutor::new(_globals.runtime_handle.clone())).build::<_, B1>(connector_h2);
+    let inner_h2 = Client::builder(LocalExecutor::new(_globals.runtime_handle.clone()))
+      .http2_only(true)
+      .build::<_, B1>(connector_h2);
 
     Ok(Self {
       inner,

--- a/rpxy-lib/src/message_handler/utils_request.rs
+++ b/rpxy-lib/src/message_handler/utils_request.rs
@@ -59,6 +59,18 @@ pub(super) fn update_request_line<B>(
   upstream_chosen: &Upstream,
   upstream_candidates: &UpstreamCandidates,
 ) -> anyhow::Result<()> {
+  // If request is grpc, HTTP/2 is required
+  if req
+    .headers()
+    .get(header::CONTENT_TYPE)
+    .map(|v| v.as_bytes().starts_with(b"application/grpc"))
+    == Some(true)
+  {
+    debug!("Must be http/2 for gRPC request.");
+    *req.version_mut() = Version::HTTP_2;
+    return Ok(());
+  }
+
   // If not specified (force_httpXX_upstream) and https, version is preserved except for http/3
   if upstream_chosen.uri.scheme() == Some(&Scheme::HTTP) {
     // Change version to http/1.1 when destination scheme is http


### PR DESCRIPTION
This PR makes `rpxy` to serve gRPC requests on the same port as HTTP and HTTPS, i.e., `listen_port` and `listen_port_tls`. This means that by using the different subdomain for HTTP(S) and gRPC, we can multiplex them on same ports without opening another port dedicated to gRPC.

- Make the forwarder to force HTTP/2 for gRPC requests towards backend (gRPC) app
- Fixed bug for the upstream option "force_http2_upstream"