### PR TITLE
Feat: forwarded header

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .vscode
 .private
+.tmp
 docker/log
 docker/cache
 docker/config

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Improvement
 
 - Feat: Support `Forwarded` header in addition to `X-Forwarded-For` header. This is to support the standard forwarding header for reverse proxy applications (RFC 7239). Use the `forwarded_header` upstream option to enable this feature.
+  By default, it is not appended to the outgoing header. However, if the incoming request has the forwarded header, it would be preserved and updated simultaneously with `x-forwarded-for` header. if both forwarded and x-forwarded-for headers exists (and they are inconsistent), x-forwarded-for is prioritized. This means that x-forwarded-for is first updated and it is then copied (overridden) to `for` param of forwarded header.
 
 ## 0.10.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.10.1 or 0.11.0 (Unreleased)
 
+### Improvement
+
+- Feat: Support `Forwarded` header in addition to `X-Forwarded-For` header. This is to support the standard forwarding header for reverse proxy applications (RFC 7239). Use the `forwarded_header` upstream option to enable this feature.
+
 ## 0.10.0
 
 ### Important Changes

--- a/config-example.toml
+++ b/config-example.toml
@@ -84,6 +84,7 @@ upstream_options = [
   "upgrade_insecure_requests",
   "force_http11_upstream",
   "set_upstream_host",         # overwrite HOST value with upstream hostname (like www.yahoo.com)
+  "forwarded_header" # add Forwarded header
 ]
 ######################################################################
 

--- a/config-example.toml
+++ b/config-example.toml
@@ -83,8 +83,8 @@ load_balance = "random" # or "round_robin" or "sticky" (sticky session) or "none
 upstream_options = [
   "upgrade_insecure_requests",
   "force_http11_upstream",
-  "set_upstream_host",         # overwrite HOST value with upstream hostname (like www.yahoo.com)
-  "forwarded_header" # add Forwarded header
+  "set_upstream_host",        # overwrite HOST value with upstream hostname (like www.yahoo.com)
+  "forwarded_header"          # add Forwarded header (by default, this is not added. However, if the incoming request has Forwarded header, it would be preserved and updated)
 ]
 ######################################################################
 

--- a/rpxy-lib/src/backend/upstream_opts.rs
+++ b/rpxy-lib/src/backend/upstream_opts.rs
@@ -13,6 +13,8 @@ pub enum UpstreamOption {
   ForceHttp11Upstream,
   /// Force HTTP/2 upstream
   ForceHttp2Upstream,
+  /// Add RFC 7239 Forwarded header
+  ForwardedHeader,
   // TODO: Adds more options for heder override
 }
 impl TryFrom<&str> for UpstreamOption {
@@ -24,6 +26,7 @@ impl TryFrom<&str> for UpstreamOption {
       "upgrade_insecure_requests" => Ok(Self::UpgradeInsecureRequests),
       "force_http11_upstream" => Ok(Self::ForceHttp11Upstream),
       "force_http2_upstream" => Ok(Self::ForceHttp2Upstream),
+      "forwarded_header" => Ok(Self::ForwardedHeader),
       _ => Err(RpxyError::UnsupportedUpstreamOption),
     }
   }

--- a/rpxy-lib/src/message_handler/handler_manipulate_messages.rs
+++ b/rpxy-lib/src/message_handler/handler_manipulate_messages.rs
@@ -87,7 +87,7 @@ where
     remove_connection_header(headers);
     // delete hop headers including header.connection
     remove_hop_header(headers);
-    // X-Forwarded-For
+    // X-Forwarded-For (and Forwarded if exists)
     add_forwarding_header(headers, client_addr, listen_addr, tls_enabled, &original_uri)?;
 
     // Add te: trailer if te_trailer
@@ -126,7 +126,7 @@ where
 
     // apply upstream-specific headers given in upstream_option
     let headers = req.headers_mut();
-    // apply upstream options to header
+    // apply upstream options to header, after X-Forwarded-For is added
     apply_upstream_options_to_header(headers, &upstream_chosen.uri, upstream_candidates)?;
 
     // update uri in request

--- a/rpxy-lib/src/message_handler/handler_manipulate_messages.rs
+++ b/rpxy-lib/src/message_handler/handler_manipulate_messages.rs
@@ -81,7 +81,7 @@ where
         .unwrap_or(false)
     };
 
-    let original_uri = req.uri().to_string();
+    let original_uri = req.uri().clone();
     let headers = req.headers_mut();
     // delete headers specified in header.connection
     remove_connection_header(headers);
@@ -98,18 +98,6 @@ where
     // by default, add "host" header of original server_name if not exist
     if req.headers().get(header::HOST).is_none() {
       let org_host = req.uri().host().ok_or_else(|| anyhow!("Invalid request"))?.to_owned();
-      // Omit port 80 if !tls_enabled, omit port 443 if tls_enabled
-      let org_host = req
-        .uri()
-        .port_u16()
-        .map(|port| {
-          if (tls_enabled && port == 443) || (!tls_enabled && port == 80) {
-            org_host.clone()
-          } else {
-            format!("{}:{}", org_host, port)
-          }
-        })
-        .unwrap_or(org_host);
       req.headers_mut().insert(header::HOST, HeaderValue::from_str(&org_host)?);
     };
 
@@ -139,7 +127,7 @@ where
     // apply upstream-specific headers given in upstream_option
     let headers = req.headers_mut();
     // apply upstream options to header, after X-Forwarded-For is added
-    apply_upstream_options_to_header(headers, &upstream_chosen.uri, upstream_candidates)?;
+    apply_upstream_options_to_header(headers, &upstream_chosen.uri, upstream_candidates, &original_uri)?;
 
     // update uri in request
     ensure!(

--- a/rpxy-lib/src/message_handler/utils_headers.rs
+++ b/rpxy-lib/src/message_handler/utils_headers.rs
@@ -96,6 +96,7 @@ fn override_host_header(headers: &mut HeaderMap, upstream_base_uri: &Uri) -> Res
 }
 
 /// Apply options to request header, which are specified in the configuration
+/// This function is called after almost all other headers has been set and updated.
 pub(super) fn apply_upstream_options_to_header(
   headers: &mut HeaderMap,
   upstream_base_uri: &Uri,
@@ -116,6 +117,22 @@ pub(super) fn apply_upstream_options_to_header(
         headers
           .entry(header::UPGRADE_INSECURE_REQUESTS)
           .or_insert(HeaderValue::from_bytes(b"1").unwrap());
+      }
+      UpstreamOption::ForwardedHeader => {
+        // This is called after X-Forwarded-For is added
+        // Generate RFC 7239 Forwarded header
+        let host = headers.get(header::HOST).and_then(|h| h.to_str().ok()).unwrap_or("unknown");
+        let tls = upstream_base_uri.scheme_str() == Some("https");
+
+        match generate_forwarded_header(headers, tls, host) {
+          Ok(forwarded_value) => {
+            add_header_entry_overwrite_if_exist(headers, "forwarded", forwarded_value)?;
+          }
+          Err(e) => {
+            // Log warning but don't fail the request if Forwarded generation fails
+            warn!("Failed to generate Forwarded header: {}", e);
+          }
+        }
       }
       _ => (),
     }
@@ -194,7 +211,9 @@ pub(super) fn make_cookie_single_line(headers: &mut HeaderMap) -> Result<()> {
   Ok(())
 }
 
-/// Add forwarding headers like `x-forwarded-for`.
+/// Add or update forwarding headers like `x-forwarded-for`.
+/// If only `forwarded` header exists, it will update `x-forwarded-for` with the proxy chain.
+/// If both `x-forwarded-for` and `forwarded` headers exist, it will update `x-forwarded-for` first and then add `forwarded` header.
 pub(super) fn add_forwarding_header(
   headers: &mut HeaderMap,
   client_addr: &SocketAddr,
@@ -202,10 +221,40 @@ pub(super) fn add_forwarding_header(
   tls: bool,
   uri_str: &str,
 ) -> Result<()> {
-  // default process
-  // optional process defined by upstream_option is applied in fn apply_upstream_options
   let canonical_client_addr = client_addr.to_canonical().ip().to_string();
-  append_header_entry_with_comma(headers, "x-forwarded-for", &canonical_client_addr)?;
+  let has_forwarded = headers.contains_key("forwarded");
+  let has_xff = headers.contains_key("x-forwarded-for");
+
+  // Handle incoming Forwarded header (Case 2: only Forwarded exists)
+  if has_forwarded && !has_xff {
+    // Extract proxy chain from Forwarded header and update X-Forwarded-For for consistency
+    update_xff_from_forwarded(headers, client_addr)?;
+  } else {
+    // Case 1: only X-Forwarded-For exists, or Case 3: both exist (conservative: use X-Forwarded-For)
+    // TODO: In future PR, implement proper RFC 7239 precedence
+    // where Forwarded header should take priority over X-Forwarded-For
+    // This requires careful testing to ensure no breaking changes
+    append_header_entry_with_comma(headers, "x-forwarded-for", &canonical_client_addr)?;
+  }
+
+  // IMPORTANT: If Forwarded header exists, always update it for consistency
+  // This ensures headers remain consistent even when forwarded_header upstream option is not specified
+  if has_forwarded {
+    let host = headers
+      .get(header::HOST)
+      .and_then(|h| h.to_str().ok())
+      .unwrap_or("unknown");
+    
+    match generate_forwarded_header(headers, tls, host) {
+      Ok(forwarded_value) => {
+        add_header_entry_overwrite_if_exist(headers, "forwarded", forwarded_value)?;
+      }
+      Err(e) => {
+        // Log warning but don't fail the request if Forwarded generation fails
+        warn!("Failed to update existing Forwarded header for consistency: {}", e);
+      }
+    }
+  }
 
   // Single line cookie header
   // TODO: This should be only for HTTP/1.1. For 2+, this can be multi-lined.
@@ -230,6 +279,89 @@ pub(super) fn add_forwarding_header(
   add_header_entry_overwrite_if_exist(headers, "proxy", "")?;
 
   Ok(())
+}
+
+/// Extract proxy chain from existing Forwarded header
+fn extract_forwarded_chain(headers: &HeaderMap) -> Vec<String> {
+  headers
+    .get("forwarded")
+    .and_then(|h| h.to_str().ok())
+    .map(|forwarded_str| {
+      // Parse Forwarded header entries (comma-separated)
+      forwarded_str
+        .split(',')
+        .flat_map(|entry| entry.split(';'))
+        .map(str::trim)
+        .filter_map(|param| param.strip_prefix("for="))
+        .map(|for_value| {
+          // Remove quotes from IPv6 addresses for consistency with X-Forwarded-For
+          if let Some(ipv6) = for_value.strip_prefix("\"[").and_then(|s| s.strip_suffix("]\"")) {
+            ipv6.to_string()
+          } else {
+            for_value.to_string()
+          }
+        })
+        .collect()
+    })
+    .unwrap_or_default()
+}
+
+/// Update X-Forwarded-For with proxy chain from Forwarded header for consistency
+fn update_xff_from_forwarded(headers: &mut HeaderMap, client_addr: &SocketAddr) -> Result<()> {
+  let forwarded_chain = extract_forwarded_chain(headers);
+
+  if !forwarded_chain.is_empty() {
+    // Replace X-Forwarded-For with the chain from Forwarded header
+    headers.remove("x-forwarded-for");
+    for ip in forwarded_chain {
+      append_header_entry_with_comma(headers, "x-forwarded-for", &ip)?;
+    }
+  }
+
+  // Append current client IP (standard behavior)
+  let canonical_client_addr = client_addr.to_canonical().ip().to_string();
+  append_header_entry_with_comma(headers, "x-forwarded-for", &canonical_client_addr)?;
+
+  Ok(())
+}
+
+/// Generate RFC 7239 Forwarded header from X-Forwarded-For
+/// This function assumes that the X-Forwarded-For header is present and well-formed.
+fn generate_forwarded_header(headers: &HeaderMap, tls: bool, host: &str) -> Result<String> {
+  let for_values = headers
+    .get("x-forwarded-for")
+    .and_then(|h| h.to_str().ok())
+    .map(|xff_str| {
+      xff_str
+        .split(',')
+        .map(str::trim)
+        .filter(|ip| !ip.is_empty())
+        .map(|ip| {
+          // Format IP according to RFC 7239 (quote IPv6)
+          if ip.contains(':') {
+            format!("\"[{}]\"", ip)
+          } else {
+            ip.to_string()
+          }
+        })
+        .collect::<Vec<_>>()
+        .join(",for=")
+    })
+    .unwrap_or_default();
+
+  if for_values.is_empty() {
+    return Err(anyhow!("No X-Forwarded-For header found for Forwarded generation"));
+  }
+
+  // Build forwarded header value
+  let forwarded_value = format!(
+    "for={};proto={};host={}",
+    for_values,
+    if tls { "https" } else { "http" },
+    host
+  );
+
+  Ok(forwarded_value)
 }
 
 /// Remove connection header

--- a/rpxy-lib/src/message_handler/utils_headers.rs
+++ b/rpxy-lib/src/message_handler/utils_headers.rs
@@ -121,6 +121,7 @@ pub(super) fn apply_upstream_options_to_header(
       UpstreamOption::ForwardedHeader => {
         // This is called after X-Forwarded-For is added
         // Generate RFC 7239 Forwarded header
+        // TODO: host is generated from x-original-uri
         let host = headers.get(header::HOST).and_then(|h| h.to_str().ok()).unwrap_or("unknown");
         let tls = upstream_base_uri.scheme_str() == Some("https");
 
@@ -240,11 +241,8 @@ pub(super) fn add_forwarding_header(
   // IMPORTANT: If Forwarded header exists, always update it for consistency
   // This ensures headers remain consistent even when forwarded_header upstream option is not specified
   if has_forwarded {
-    let host = headers
-      .get(header::HOST)
-      .and_then(|h| h.to_str().ok())
-      .unwrap_or("unknown");
-    
+    let host = headers.get(header::HOST).and_then(|h| h.to_str().ok()).unwrap_or("unknown");
+
     match generate_forwarded_header(headers, tls, host) {
       Ok(forwarded_value) => {
         add_header_entry_overwrite_if_exist(headers, "forwarded", forwarded_value)?;


### PR DESCRIPTION
This resolves #124.

Support `Forwarded` header in addition to `X-Forwarded-For` header. This is to support the standard forwarding header for reverse proxy applications (RFC 7239). Use the `forwarded_header` upstream option to enable this feature.

By default, it is not appended to the outgoing header. However, if the incoming request has the forwarded header, it would be preserved and updated simultaneously with `x-forwarded-for` header. if both forwarded and x-forwarded-for headers exists (and they are inconsistent), x-forwarded-for is prioritized. This means that x-forwarded-for is first updated and it is then copied (overridden) to `for` param of forwarded header.
