### PR TITLE
0.10.1

### DIFF
--- a/.build/Jenkinsfile
+++ b/.build/Jenkinsfile
@@ -37,9 +37,6 @@ pipeline {
 
                     dir('rust-rpxy') {
                         sh """
-                        # Update submodule URLs to HTTPS (allows cloning without SSH keys)
-                        sed -i 's|git@github.com:|https://github.com/|g' .gitmodules
-
                         # Initialize and update submodules
                         git submodule update --init
                         """
@@ -59,7 +56,7 @@ pipeline {
 
                         // Build the binary
                         sh 'cargo build --release'
-                    
+
                         // Prepare and stash files
                         sh """
                             # Move binary to workspace root for easier access
@@ -81,7 +78,7 @@ pipeline {
                     stash includes: "${BINARY_NAME}.spec", name: "rpm-files"
                     stash includes: "rpxy.service, config.toml", name: "service-file"
                     stash includes: "LICENSE, README.md", name: "docs"
-                        
+
                     // Archive the binary as an artifact
                     archiveArtifacts artifacts: "${BINARY_NAME}", allowEmptyArchive: false, fingerprint: true
                 }

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,31 +1,8 @@
-# Basic dependabot.yml file with
-# minimum configuration for two package managers
-
 version: 2
 updates:
   # Enable version updates for cargo
   - package-ecosystem: "cargo"
     directory: "/"
-    schedule:
-      interval: "daily"
-
-  - package-ecosystem: "cargo"
-    directory: "/rpxy-bin"
-    schedule:
-      interval: "daily"
-
-  - package-ecosystem: "cargo"
-    directory: "/rpxy-lib"
-    schedule:
-      interval: "daily"
-
-  - package-ecosystem: "cargo"
-    directory: "/rpxy-certs"
-    schedule:
-      interval: "daily"
-
-  - package-ecosystem: "cargo"
-    directory: "/rpxy-acme"
     schedule:
       interval: "daily"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
   pull_request:
     types: [synchronize, opened]
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,10 @@ on:
 
 jobs:
   on-success:
+    permissions:
+      contents: read
+      packages: read
+
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' }} || ${{ github.event_name == 'repositry_dispatch' }}
     strategy:
@@ -98,12 +102,18 @@ jobs:
           path: "/tmp/${{ steps.set-env.outputs.target_name }}"
 
   on-failure:
+    permissions:
+      contents: read
+
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'failure' }}
     steps:
       - run: echo 'The release triggering workflows failed'
 
   release:
+    permissions:
+      contents: write
+
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'repository_dispatch' }}
     needs: on-success

--- a/.github/workflows/release_docker.yml
+++ b/.github/workflows/release_docker.yml
@@ -16,6 +16,10 @@ env:
 
 jobs:
   build_and_push:
+    permissions:
+      contents: read
+      packages: write
+
     runs-on: ubuntu-22.04
     if: ${{ github.event_name == 'push' }} || ${{ github.event_name == 'pull_request' && github.event.pull_request.merged == true }}
     strategy:
@@ -199,6 +203,10 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
 
   dispatch_release_event:
+    permissions:
+      contents: write
+      actions: write
+
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref == 'develop' && github.event.pull_request.base.ref == 'main' && github.event.pull_request.merged == true }}
     needs: build_and_push

--- a/.github/workflows/shift_left.yml
+++ b/.github/workflows/shift_left.yml
@@ -7,6 +7,8 @@ on:
 
 jobs:
   Scan-Build:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .vscode
 .private
+.tmp
 docker/log
 docker/cache
 docker/config

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,10 +1,10 @@
 [submodule "submodules/rusty-http-cache-semantics"]
-	path = submodules/rusty-http-cache-semantics
-	url = git@github.com:junkurihara/rusty-http-cache-semantics.git
+        path = submodules/rusty-http-cache-semantics
+        url = https://github.com/junkurihara/rusty-http-cache-semantics.git
 [submodule "submodules/rustls-acme"]
-	path = submodules/rustls-acme
-	url = git@github.com:junkurihara/rustls-acme.git
+        path = submodules/rustls-acme
+        url = https://github.com/junkurihara/rustls-acme.git
 [submodule "submodules/s2n-quic"]
-	path = submodules/s2n-quic
-	url = git@github.com:junkurihara/s2n-quic.git
-	branch = rustls-pq
+        path = submodules/s2n-quic
+        url = https://github.com/junkurihara/s2n-quic.git
+        branch = rustls-pq

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,15 @@
 # CHANGELOG
 
-## 0.10.1 or 0.11.0 (Unreleased)
+## 0.10.2 or 0.11.0 (Unreleased)
+
+## 0.10.1
 
 ### Improvement
 
 - Feat: Support `Forwarded` header in addition to `X-Forwarded-For` header. This is to support the standard forwarding header for reverse proxy applications (RFC 7239). Use the `forwarded_header` upstream option to enable this feature.
   By default, it is not appended to the outgoing header. However, if the incoming request has the forwarded header, it would be preserved and updated simultaneously with `x-forwarded-for` header. if both forwarded and x-forwarded-for headers exists (and they are inconsistent), x-forwarded-for is prioritized. This means that x-forwarded-for is first updated and it is then copied (overridden) to `for` param of forwarded header.
+- Refactor: lots of minor improvements
+- Deps
 
 ## 0.10.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 0.10.1 or 0.11.0 (Unreleased)
 
+### Improvement
+
+- Feat: Support `Forwarded` header in addition to `X-Forwarded-For` header. This is to support the standard forwarding header for reverse proxy applications (RFC 7239). Use the `forwarded_header` upstream option to enable this feature.
+  By default, it is not appended to the outgoing header. However, if the incoming request has the forwarded header, it would be preserved and updated simultaneously with `x-forwarded-for` header. if both forwarded and x-forwarded-for headers exists (and they are inconsistent), x-forwarded-for is prioritized. This means that x-forwarded-for is first updated and it is then copied (overridden) to `for` param of forwarded header.
+
 ## 0.10.0
 
 ### Important Changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -412,9 +412,9 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cc"
-version = "1.2.26"
+version = "1.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "956a5e21988b87f372569b66183b78babf23ebc2e744b733e4350a752c4dafac"
+checksum = "d487aa071b5f64da6f19a3e848e3578944b726ee5a4854b82172f02aa876bfdc"
 dependencies = [
  "jobserver",
  "libc",
@@ -1061,9 +1061,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f154ce46856750ed433c8649605bf7ed2de3bc35fd9d2a9f30cddd873c80cb08"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -1462,9 +1462,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.172"
+version = "0.2.173"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+checksum = "d8cfeafaffdbc32176b64fb251369d52ea9f0a8fbc6f8759edffef7b525d64bb"
 
 [[package]]
 name = "libloading"
@@ -1473,7 +1473,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.53.0",
+ "windows-targets 0.53.2",
 ]
 
 [[package]]
@@ -1484,9 +1484,9 @@ checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
 name = "libmimalloc-sys"
-version = "0.1.40"
+version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07d0e07885d6a754b9c7993f2625187ad694ee985d60f23355ff0e7077261502"
+checksum = "bf88cd67e9de251c1781dbe2f641a1a3ad66eaae831b8a2c38fbdc5ddae16d4d"
 dependencies = [
  "cc",
  "libc",
@@ -1542,9 +1542,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.4"
+version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
 name = "memoffset"
@@ -1557,9 +1557,9 @@ dependencies = [
 
 [[package]]
 name = "mimalloc"
-version = "0.1.44"
+version = "0.1.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99585191385958383e13f6b822e6b6d8d9cf928e7d286ceb092da92b43c87bc1"
+checksum = "b1791cbe101e95af5764f06f20f6760521f7158f69dbf9d6baf941ee1bf6bc40"
 dependencies = [
  "libmimalloc-sys",
 ]
@@ -1854,9 +1854,9 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.33"
+version = "0.2.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dee91521343f4c5c6a63edd65e54f31f5c92fe8978c40a4282f8372194c6a7d"
+checksum = "6837b9e10d61f45f987d50808f83d1ee3d206c66acf650c3e4ae2e1f6ddedf55"
 dependencies = [
  "proc-macro2",
  "syn",
@@ -2255,9 +2255,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.27"
+version = "0.23.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "730944ca083c1c233a75c09f199e973ca499344a2b7ba9e755c457e86fb4a321"
+checksum = "7160e3e10bf4535308537f3c4e1641468cd0e485175d6163087c0393c7d46643"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -2713,12 +2713,9 @@ checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
 name = "slab"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
-dependencies = [
- "autocfg",
-]
+checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
 
 [[package]]
 name = "smallvec"
@@ -2756,9 +2753,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.102"
+version = "2.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6397daf94fa90f058bd0fd88429dd9e5738999cca8d701813c80723add80462"
+checksum = "e4307e30089d6fd6aff212f2da3a1f9e32f3223b1f010fb09b7c95f90f3ca1e8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2841,12 +2838,11 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.1.8"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
- "once_cell",
 ]
 
 [[package]]
@@ -3396,9 +3392,9 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
-version = "0.1.1"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
 name = "windows-result"
@@ -3478,9 +3474,9 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.53.0"
+version = "0.53.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1e4c7e8ceaaf9cb7d7507c974735728ab453b67ef8f18febdd7c11fe59dca8b"
+checksum = "c66f69fcc9ce11da9966ddb31a40968cad001c5bedeb5c2b82ede4253ab48aef"
 dependencies = [
  "windows_aarch64_gnullvm 0.53.0",
  "windows_aarch64_msvc 0.53.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1032,9 +1032,9 @@ checksum = "74721d007512d0cb3338cd20f0654ac913920061a4c4d0d8708edb3f2a698c0c"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.2"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -1747,9 +1747,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.107"
+version = "0.9.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8288979acd84749c744a9014b4382d42b8f7b2592847b5afb2ed29e5d16ede07"
+checksum = "e145e1651e858e820e4860f7b9c5e169bc1d8ce1c86043be79fa7b7634821847"
 dependencies = [
  "cc",
  "libc",
@@ -1914,9 +1914,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.11"
+version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "541d0f57c6ec747a90738a52741d3221f7960e8ac2f0ff4b1a63680e033b4ab5"
+checksum = "ee4e529991f949c5e25755532370b8af5d114acae52326361d68d47af64aa842"
 dependencies = [
  "cfg_aliases",
  "libc",
@@ -2233,9 +2233,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.0.5"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d97817398dd4bb2e6da002002db259209759911da105da92bec29ccb12cf58bf"
+checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
 dependencies = [
  "bitflags",
  "errno",
@@ -2641,9 +2641,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.8"
+version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -2727,9 +2727,9 @@ dependencies = [
 
 [[package]]
 name = "synstructure"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2745,7 +2745,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.3.2",
  "once_cell",
- "rustix 1.0.5",
+ "rustix 1.0.7",
  "windows-sys 0.59.0",
 ]
 
@@ -2755,7 +2755,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45c6481c4829e4cc63825e62c49186a34538b7b2750b73b266581ffb612fb5ed"
 dependencies = [
- "rustix 1.0.5",
+ "rustix 1.0.7",
  "windows-sys 0.59.0",
 ]
 
@@ -3238,18 +3238,18 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "0.26.9"
+version = "0.26.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "180d2741b6115c3d906577e6533ad89472d48d96df00270fccb78233073d77f7"
+checksum = "c99403924bc5f23afefc319b8ac67ed0e50669f6e52a413314cccb1fdbc93ba0"
 dependencies = [
  "rustls-pki-types",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "0.26.9"
+version = "0.26.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29aad86cec885cafd03e8305fd727c418e970a521322c91688414d5b8efba16b"
+checksum = "37493cadf42a2a939ed404698ded7fb378bf301b5011f973361779a3a74f8c93"
 dependencies = [
  "rustls-pki-types",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1237,21 +1237,22 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "1.5.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
+checksum = "200072f5d0e3614556f94a9930d5dc3e0662a652823904c3a75dc3b0af7fee47"
 dependencies = [
  "displaydoc",
+ "potential_utf",
  "yoke",
  "zerofrom",
  "zerovec",
 ]
 
 [[package]]
-name = "icu_locid"
-version = "1.5.0"
+name = "icu_locale_core"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
+checksum = "0cde2700ccaed3872079a65fb1a78f6c0a36c91570f28755dda67bc8f7d9f00a"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -1261,30 +1262,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "icu_locid_transform"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e"
-dependencies = [
- "displaydoc",
- "icu_locid",
- "icu_locid_transform_data",
- "icu_provider",
- "tinystr",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locid_transform_data"
-version = "1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7515e6d781098bf9f7205ab3fc7e9709d34554ae0b21ddbcb5febfa4bc7df11d"
-
-[[package]]
 name = "icu_normalizer"
-version = "1.5.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
+checksum = "436880e8e18df4d7bbc06d58432329d6458cc84531f7ac5f024e93deadb37979"
 dependencies = [
  "displaydoc",
  "icu_collections",
@@ -1292,65 +1273,52 @@ dependencies = [
  "icu_properties",
  "icu_provider",
  "smallvec",
- "utf16_iter",
- "utf8_iter",
- "write16",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_normalizer_data"
-version = "1.5.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5e8338228bdc8ab83303f16b797e177953730f601a96c25d10cb3ab0daa0cb7"
+checksum = "00210d6893afc98edb752b664b8890f0ef174c8adbb8d0be9710fa66fbbf72d3"
 
 [[package]]
 name = "icu_properties"
-version = "1.5.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93d6020766cfc6302c15dbbc9c8778c37e62c14427cb7f6e601d849e092aeef5"
+checksum = "2549ca8c7241c82f59c80ba2a6f415d931c5b58d24fb8412caa1a1f02c49139a"
 dependencies = [
  "displaydoc",
  "icu_collections",
- "icu_locid_transform",
+ "icu_locale_core",
  "icu_properties_data",
  "icu_provider",
- "tinystr",
+ "potential_utf",
+ "zerotrie",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_properties_data"
-version = "1.5.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85fb8799753b75aee8d2a21d7c14d9f38921b54b3dbda10f5a3c7a7b82dba5e2"
+checksum = "8197e866e47b68f8f7d95249e172903bec06004b18b2937f1095d40a0c57de04"
 
 [[package]]
 name = "icu_provider"
-version = "1.5.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9"
+checksum = "03c80da27b5f4187909049ee2d72f276f0d9f99a42c306bd0131ecfe04d8e5af"
 dependencies = [
  "displaydoc",
- "icu_locid",
- "icu_provider_macros",
+ "icu_locale_core",
  "stable_deref_trait",
  "tinystr",
  "writeable",
  "yoke",
  "zerofrom",
+ "zerotrie",
  "zerovec",
-]
-
-[[package]]
-name = "icu_provider_macros"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -1372,9 +1340,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -1520,9 +1488,9 @@ checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "litemap"
-version = "0.7.5"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856"
+checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
 name = "log"
@@ -1828,6 +1796,15 @@ dependencies = [
  "rustix 0.38.44",
  "tracing",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "potential_utf"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7c30837279ca13e7c867e9e40053bc68740f988cb07f7ca6df43cc734b585"
+dependencies = [
+ "zerovec",
 ]
 
 [[package]]
@@ -2307,11 +2284,12 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "917ce264624a4b4db1c364dcc35bfca9ded014d0a958cd47ad3e960e988ea51c"
+checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
 dependencies = [
  "web-time",
+ "zeroize",
 ]
 
 [[package]]
@@ -2376,7 +2354,7 @@ checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "s2n-codec"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "byteorder",
  "bytes",
@@ -2385,7 +2363,7 @@ dependencies = [
 
 [[package]]
 name = "s2n-quic"
-version = "1.57.0"
+version = "1.58.0"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -2408,7 +2386,7 @@ dependencies = [
 
 [[package]]
 name = "s2n-quic-core"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "atomic-waker",
  "byteorder",
@@ -2427,7 +2405,7 @@ dependencies = [
 
 [[package]]
 name = "s2n-quic-crypto"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "aws-lc-rs",
  "cfg-if",
@@ -2450,7 +2428,7 @@ dependencies = [
 
 [[package]]
 name = "s2n-quic-platform"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "cfg-if",
  "futures",
@@ -2463,7 +2441,7 @@ dependencies = [
 
 [[package]]
 name = "s2n-quic-rustls"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "bytes",
  "rustls",
@@ -2476,7 +2454,7 @@ dependencies = [
 
 [[package]]
 name = "s2n-quic-tls"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "bytes",
  "errno",
@@ -2489,7 +2467,7 @@ dependencies = [
 
 [[package]]
 name = "s2n-quic-tls-default"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "s2n-quic-rustls",
  "s2n-quic-tls",
@@ -2497,7 +2475,7 @@ dependencies = [
 
 [[package]]
 name = "s2n-quic-transport"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -2513,9 +2491,9 @@ dependencies = [
 
 [[package]]
 name = "s2n-tls"
-version = "0.3.18"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1c2355bbfcccc93a61d56a8e8b8a22325a5c68b693ddeba904a5aa293cc66c8"
+checksum = "821c6c037686bbc60273f3c4af20012eecbe5e9b1c4ac3d7f766a1f2464681bf"
 dependencies = [
  "errno",
  "hex",
@@ -2526,9 +2504,9 @@ dependencies = [
 
 [[package]]
 name = "s2n-tls-sys"
-version = "0.3.18"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65818edc12b815a4b2140a6a031f6e5fe3a59b31c28d7f01835b9aa38654f81f"
+checksum = "6a755df740916e2fc0aaf99c6fc0e519028702a75bff018b6b55a735eada406a"
 dependencies = [
  "aws-lc-rs",
  "cc",
@@ -2842,9 +2820,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.7.6"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
+checksum = "5d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -3091,12 +3069,6 @@ dependencies = [
  "idna",
  "percent-encoding",
 ]
-
-[[package]]
-name = "utf16_iter"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
 
 [[package]]
 name = "utf8_iter"
@@ -3541,16 +3513,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "write16"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
-
-[[package]]
 name = "writeable"
-version = "0.5.5"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
+checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
 
 [[package]]
 name = "x509-parser"
@@ -3580,9 +3546,9 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.7.5"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40"
+checksum = "5f41bb01b8226ef4bfd589436a297c53d118f65921786300e427be8d487695cc"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -3592,9 +3558,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.7.5"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
+checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3664,10 +3630,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "zerovec"
-version = "0.10.4"
+name = "zerotrie"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079"
+checksum = "36f0bbd478583f79edad978b407914f61b2972f5af6fa089686016be8f9af595"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a05eb080e015ba39cc9e23bbe5e7fb04d5fb040350f99f34e338d5fdd294428"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -3676,9 +3653,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.10.3"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
+checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,9 +157,9 @@ dependencies = [
 
 [[package]]
 name = "async-channel"
-version = "2.3.1"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89b47800b0be77592da0afd425cc03468052844aff33b84e33cc696f64e77b6a"
+checksum = "16c74e56284d2188cabb6ad99603d1ace887a5d7e7b695d01b728155ed9ed427"
 dependencies = [
  "concurrent-queue",
  "event-listener-strategy",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1210,9 +1210,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.13"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1c293b6b3d21eca78250dc7dbebd6b9210ec5530e038cbfe0661b5c47ab06e8"
+checksum = "dc2fdfdbff08affe55bb779f33b053aa1fe5dd5b54c257343c17edfa55711bdb"
 dependencies = [
  "bytes",
  "futures-channel",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,7 +24,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
- "getrandom 0.3.2",
+ "getrandom 0.3.3",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -412,9 +412,9 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cc"
-version = "1.2.21"
+version = "1.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8691782945451c1c383942c4874dbe63814f61cb57ef773cda2972682b7bb3c0"
+checksum = "32db95edf998450acc7881c932f94cd9b05c87b4b2599e8bab064753da4acfd1"
 dependencies = [
  "jobserver",
  "libc",
@@ -767,7 +767,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27cea6e7f512d43b098939ff4d5a5d6fe3db07971e1d05176fe26c642d33f5b8"
 dependencies = [
- "getrandom 0.3.2",
+ "getrandom 0.3.3",
  "rand 0.9.1",
  "siphasher",
  "wide",
@@ -970,9 +970,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -1434,7 +1434,7 @@ version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38f262f097c174adebe41eb73d66ae9c06b2844fb0da69969647bbddd9b0538a"
 dependencies = [
- "getrandom 0.3.2",
+ "getrandom 0.3.3",
  "libc",
 ]
 
@@ -1468,12 +1468,12 @@ checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "libloading"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
+checksum = "6a793df0d7afeac54f95b471d3af7f0d4fb975699f972341a4b76988d49cdf0c"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets 0.53.0",
 ]
 
 [[package]]
@@ -1900,7 +1900,7 @@ checksum = "49df843a9161c85bb8aae55f101bc0bac8bcafd637a620d9122fd7e0b2f7422e"
 dependencies = [
  "bytes",
  "fastbloom",
- "getrandom 0.3.2",
+ "getrandom 0.3.3",
  "lru-slab",
  "rand 0.9.1",
  "ring",
@@ -2002,7 +2002,7 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
- "getrandom 0.3.2",
+ "getrandom 0.3.3",
 ]
 
 [[package]]
@@ -2751,12 +2751,12 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.19.1"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7437ac7763b9b123ccf33c338a5cc1bac6f69b45a136c19bdd8a65e3916435bf"
+checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
 dependencies = [
  "fastrand",
- "getrandom 0.3.2",
+ "getrandom 0.3.3",
  "once_cell",
  "rustix 1.0.7",
  "windows-sys 0.59.0",
@@ -3442,11 +3442,27 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1e4c7e8ceaaf9cb7d7507c974735728ab453b67ef8f18febdd7c11fe59dca8b"
+dependencies = [
+ "windows_aarch64_gnullvm 0.53.0",
+ "windows_aarch64_msvc 0.53.0",
+ "windows_i686_gnu 0.53.0",
+ "windows_i686_gnullvm 0.53.0",
+ "windows_i686_msvc 0.53.0",
+ "windows_x86_64_gnu 0.53.0",
+ "windows_x86_64_gnullvm 0.53.0",
+ "windows_x86_64_msvc 0.53.0",
 ]
 
 [[package]]
@@ -3462,6 +3478,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3472,6 +3494,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3486,10 +3514,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -3504,6 +3544,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3514,6 +3560,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -3528,6 +3580,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3538,6 +3596,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1210,12 +1210,13 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9f1e950e0d9d1d3c47184416723cf29c0d1f93bd8cccf37e4beb6b44f31710"
+checksum = "b1c293b6b3d21eca78250dc7dbebd6b9210ec5530e038cbfe0661b5c47ab06e8"
 dependencies = [
  "bytes",
  "futures-channel",
+ "futures-core",
  "futures-util",
  "http",
  "http-body",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -393,6 +393,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
 
 [[package]]
+name = "bytemuck"
+version = "1.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9134a6ef01ce4b366b50689c94f82c14bc72bc5d0386829828a2e2752ef7958c"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -468,18 +474,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.37"
+version = "4.5.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eccb054f56cbd38340b380d4a8e69ef1f02f1af43db2f0cc817a4774d80ae071"
+checksum = "ed93b9805f8ba930df42c2590f05453d5ec36cbb85d018868a5b24d31f6ac000"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.37"
+version = "4.5.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efd9466fac8543255d3b1fcad4762c5e116ffe808c8a3043d4263cd4fd4862a2"
+checksum = "379026ff283facf611b0ea629334361c4211d1b12ee01024eec1591133b04120"
 dependencies = [
  "anstream",
  "anstyle",
@@ -753,6 +759,18 @@ checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
 dependencies = [
  "event-listener",
  "pin-project-lite",
+]
+
+[[package]]
+name = "fastbloom"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27cea6e7f512d43b098939ff4d5a5d6fe3db07971e1d05176fe26c642d33f5b8"
+dependencies = [
+ "getrandom 0.3.2",
+ "rand 0.9.1",
+ "siphasher",
+ "wide",
 ]
 
 [[package]]
@@ -1508,6 +1526,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "matchers"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1849,9 +1873,9 @@ checksum = "1190fd18ae6ce9e137184f207593877e70f39b015040156b1e05081cdfe3733a"
 
 [[package]]
 name = "quinn"
-version = "0.11.7"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3bd15a6f2967aef83887dcb9fec0014580467e33720d073560cf015a5683012"
+checksum = "626214629cda6781b6dc1d316ba307189c85ba657213ce642d9c77670f8202c8"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -1870,12 +1894,14 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.11"
+version = "0.11.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcbafbbdbb0f638fe3f35f3c56739f77a8a1d070cb25603226c83339b391472b"
+checksum = "49df843a9161c85bb8aae55f101bc0bac8bcafd637a620d9122fd7e0b2f7422e"
 dependencies = [
  "bytes",
+ "fastbloom",
  "getrandom 0.3.2",
+ "lru-slab",
  "rand 0.9.1",
  "ring",
  "rustc-hash 2.1.1",
@@ -2330,9 +2356,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.2"
+version = "0.103.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7149975849f1abb3832b246010ef62ccc80d3a76169517ada7188252b9cfb437"
+checksum = "e4a72fe2bcf7a6ac6fd7d0b9e5cb68aeb7d4c0a0271730218b3e92d43b4eb435"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -2514,6 +2540,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "safe_arch"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b02de82ddbe1b636e6170c21be622223aea188ef2e139be0a5b219ec215323"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2589,9 +2624,9 @@ dependencies = [
 
 [[package]]
 name = "serde_ignored"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "566da67d80e92e009728b3731ff0e5360cb181432b8ca73ea30bb1d170700d76"
+checksum = "b516445dac1e3535b6d658a7b528d771153dfb272ed4180ca4617a20550365ff"
 dependencies = [
  "serde",
 ]
@@ -3254,6 +3289,16 @@ dependencies = [
  "home",
  "once_cell",
  "rustix 0.38.44",
+]
+
+[[package]]
+name = "wide"
+version = "0.7.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41b5576b9a81633f3e8df296ce0063042a73507636cbe956c61133dd7034ab22"
+dependencies = [
+ "bytemuck",
+ "safe_arch",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1088,9 +1088,9 @@ dependencies = [
 
 [[package]]
 name = "hot_reload"
-version = "0.1.9"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75c6b9b663cacaa5655b282218152476f7d38f6dc29b0d9b93a7f5fd73209b6a"
+checksum = "469bdabdc9436358811cd8fa2d35b3a0fc60534aca57979b931b9f5f9551ce16"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2093,7 +2093,7 @@ dependencies = [
 
 [[package]]
 name = "rpxy"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "ahash",
  "anyhow",
@@ -2117,7 +2117,7 @@ dependencies = [
 
 [[package]]
 name = "rpxy-acme"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "ahash",
  "async-trait",
@@ -2138,7 +2138,7 @@ dependencies = [
 
 [[package]]
 name = "rpxy-certs"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "ahash",
  "async-trait",
@@ -2156,7 +2156,7 @@ dependencies = [
 
 [[package]]
 name = "rpxy-lib"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "ahash",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -474,18 +474,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.39"
+version = "4.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd60e63e9be68e5fb56422e397cf9baddded06dae1d2e523401542383bc72a9f"
+checksum = "40b6887a1d8685cebccf115538db5c0efe625ccac9696ad45c409d96566e910f"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.39"
+version = "4.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89cc6392a1f72bbeb820d71f32108f61fdaf18bc526e1d23954168a67759ef51"
+checksum = "e0c66c08ce9f0c698cbce5c0279d0bb6ac936d8674174fe48f736533b964f59e"
 dependencies = [
  "anstream",
  "anstyle",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -474,18 +474,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.38"
+version = "4.5.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed93b9805f8ba930df42c2590f05453d5ec36cbb85d018868a5b24d31f6ac000"
+checksum = "fd60e63e9be68e5fb56422e397cf9baddded06dae1d2e523401542383bc72a9f"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.38"
+version = "4.5.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "379026ff283facf611b0ea629334361c4211d1b12ee01024eec1591133b04120"
+checksum = "89cc6392a1f72bbeb820d71f32108f61fdaf18bc526e1d23954168a67759ef51"
 dependencies = [
  "anstream",
  "anstyle",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1368,9 +1368,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
  "hashbrown",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1176,11 +1176,10 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.5"
+version = "0.27.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d191583f3da1305256f22463b9bb0471acad48a4e534a5218b9963e9c1f59b2"
+checksum = "03a01595e11bdcec50946522c32dde3fc6914743000a68b93000965f2f02406d"
 dependencies = [
- "futures-util",
  "http",
  "hyper",
  "hyper-util",
@@ -1190,7 +1189,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots 0.26.11",
+ "webpki-roots 1.0.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,12 +101,12 @@ dependencies = [
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.7"
+version = "3.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
+checksum = "6680de5231bd6ee4c6191b8a1325daa282b415391ec9d3a37bd34f2060dc73fa"
 dependencies = [
  "anstyle",
- "once_cell",
+ "once_cell_polyfill",
  "windows-sys 0.59.0",
 ]
 
@@ -182,9 +182,9 @@ dependencies = [
 
 [[package]]
 name = "async-io"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a2b323ccce0a1d90b449fd71f2a06ca7faa7c54c2751f06c9bd851fc061059"
+checksum = "1237c0ae75a0f3765f58910ff9cdd0a12eeb39ab2f4c7de23262f337f0aacbb3"
 dependencies = [
  "async-lock",
  "cfg-if",
@@ -193,7 +193,7 @@ dependencies = [
  "futures-lite",
  "parking",
  "polling",
- "rustix 0.38.44",
+ "rustix 1.0.7",
  "slab",
  "tracing",
  "windows-sys 0.59.0",
@@ -412,9 +412,9 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cc"
-version = "1.2.23"
+version = "1.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f4ac86a9e5bc1e2b3449ab9d7d3a6a405e3d1bb28d7b9be8614f55846ae3766"
+checksum = "16595d3be041c03b09d08d0858631facccee9221e579704070e6e9e4915d3bc7"
 dependencies = [
  "jobserver",
  "libc",
@@ -546,9 +546,9 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b55271e5c8c478ad3f38ad24ef34923091e0548492a266d19b3c0b4d82574c63"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -1061,9 +1061,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.4.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
+checksum = "f154ce46856750ed433c8649605bf7ed2de3bc35fd9d2a9f30cddd873c80cb08"
 
 [[package]]
 name = "hex"
@@ -1468,9 +1468,9 @@ checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "libloading"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a793df0d7afeac54f95b471d3af7f0d4fb975699f972341a4b76988d49cdf0c"
+checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
  "windows-targets 0.53.0",
@@ -1581,13 +1581,13 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
+checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
 dependencies = [
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1697,10 +1697,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
-name = "openssl"
-version = "0.10.72"
+name = "once_cell_polyfill"
+version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fedfea7d58a1f73118430a55da6a286e7b044961736ce96a16a17068ea25e5da"
+checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+
+[[package]]
+name = "openssl"
+version = "0.10.73"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8505734d46c8ab1e19a1dce3aef597ad87dcb4c37e7188231769bd6bd51cebf8"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -1739,9 +1745,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.108"
+version = "0.9.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e145e1651e858e820e4860f7b9c5e169bc1d8ce1c86043be79fa7b7634821847"
+checksum = "90096e2e47630d78b7d1c20952dc621f957103f8bc2c8359ec81290d75238571"
 dependencies = [
  "cc",
  "libc",
@@ -1809,15 +1815,15 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "polling"
-version = "3.7.4"
+version = "3.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a604568c3202727d1507653cb121dbd627a58684eb09a820fd746bee38b4442f"
+checksum = "b53a684391ad002dd6a596ceb6c74fd004fdce75f4be2e3f615068abbea5fd50"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
  "hermit-abi",
  "pin-project-lite",
- "rustix 0.38.44",
+ "rustix 1.0.7",
  "tracing",
  "windows-sys 0.59.0",
 ]
@@ -2324,7 +2330,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19787cda76408ec5404443dc8b31795c87cd8fec49762dc75fa727740d34acc1"
 dependencies = [
- "core-foundation 0.10.0",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "jni",
  "log",
@@ -2368,9 +2374,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
+checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
 
 [[package]]
 name = "ryu"
@@ -2380,7 +2386,7 @@ checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "s2n-codec"
-version = "0.58.0"
+version = "0.59.0"
 dependencies = [
  "byteorder",
  "bytes",
@@ -2389,7 +2395,7 @@ dependencies = [
 
 [[package]]
 name = "s2n-quic"
-version = "1.58.0"
+version = "1.59.0"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -2412,7 +2418,7 @@ dependencies = [
 
 [[package]]
 name = "s2n-quic-core"
-version = "0.58.0"
+version = "0.59.0"
 dependencies = [
  "atomic-waker",
  "byteorder",
@@ -2431,7 +2437,7 @@ dependencies = [
 
 [[package]]
 name = "s2n-quic-crypto"
-version = "0.58.0"
+version = "0.59.0"
 dependencies = [
  "aws-lc-rs",
  "cfg-if",
@@ -2454,7 +2460,7 @@ dependencies = [
 
 [[package]]
 name = "s2n-quic-platform"
-version = "0.58.0"
+version = "0.59.0"
 dependencies = [
  "cfg-if",
  "futures",
@@ -2467,7 +2473,7 @@ dependencies = [
 
 [[package]]
 name = "s2n-quic-rustls"
-version = "0.58.0"
+version = "0.59.0"
 dependencies = [
  "bytes",
  "rustls",
@@ -2480,7 +2486,7 @@ dependencies = [
 
 [[package]]
 name = "s2n-quic-tls"
-version = "0.58.0"
+version = "0.59.0"
 dependencies = [
  "bytes",
  "errno",
@@ -2493,7 +2499,7 @@ dependencies = [
 
 [[package]]
 name = "s2n-quic-tls-default"
-version = "0.58.0"
+version = "0.59.0"
 dependencies = [
  "s2n-quic-rustls",
  "s2n-quic-tls",
@@ -2501,7 +2507,7 @@ dependencies = [
 
 [[package]]
 name = "s2n-quic-transport"
-version = "0.58.0"
+version = "0.59.0"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -2517,9 +2523,9 @@ dependencies = [
 
 [[package]]
 name = "s2n-tls"
-version = "0.3.19"
+version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "821c6c037686bbc60273f3c4af20012eecbe5e9b1c4ac3d7f766a1f2464681bf"
+checksum = "6c5b886e605d71d8e78e37c7f6195887112f4c9d0a3269057f6447d3dae99908"
 dependencies = [
  "errno",
  "hex",
@@ -2530,9 +2536,9 @@ dependencies = [
 
 [[package]]
 name = "s2n-tls-sys"
-version = "0.3.19"
+version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a755df740916e2fc0aaf99c6fc0e519028702a75bff018b6b55a735eada406a"
+checksum = "753c5eb4a0632b275ee3c503b0a108b2430b429566c86501f311f67cf579b35f"
 dependencies = [
  "aws-lc-rs",
  "cc",
@@ -2586,7 +2592,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271720403f46ca04f7ba6f55d438f8bd878d6b8ca0a1046e8228c4145bcbb316"
 dependencies = [
  "bitflags",
- "core-foundation 0.10.0",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -412,9 +412,9 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cc"
-version = "1.2.22"
+version = "1.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32db95edf998450acc7881c932f94cd9b05c87b4b2599e8bab064753da4acfd1"
+checksum = "5f4ac86a9e5bc1e2b3449ab9d7d3a6a405e3d1bb28d7b9be8614f55846ae3766"
 dependencies = [
  "jobserver",
  "libc",
@@ -1302,9 +1302,9 @@ checksum = "00210d6893afc98edb752b664b8890f0ef174c8adbb8d0be9710fa66fbbf72d3"
 
 [[package]]
 name = "icu_properties"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2549ca8c7241c82f59c80ba2a6f415d931c5b58d24fb8412caa1a1f02c49139a"
+checksum = "016c619c1eeb94efb86809b015c58f479963de65bdb6253345c1a1276f22e32b"
 dependencies = [
  "displaydoc",
  "icu_collections",
@@ -1318,9 +1318,9 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8197e866e47b68f8f7d95249e172903bec06004b18b2937f1095d40a0c57de04"
+checksum = "298459143998310acd25ffe6810ed544932242d3f07083eee1084d83a71bd632"
 
 [[package]]
 name = "icu_provider"
@@ -3334,9 +3334,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
-version = "0.61.1"
+version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46ec44dc15085cea82cf9c78f85a9114c463a369786585ad2882d1ff0b0acf40"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
  "windows-implement",
  "windows-interface",
@@ -3375,18 +3375,18 @@ checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
 
 [[package]]
 name = "windows-result"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b895b5356fc36103d0f64dd1e94dfa7ac5633f1c9dd6e80fe9ec4adef69e09d"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
 dependencies = [
  "windows-link",
 ]
 
 [[package]]
 name = "windows-strings"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a7ab927b2637c19b3dbe0965e75d8f2d30bdd697a1516191cad2ec4df8fb28a"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
  "windows-link",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1386,6 +1386,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-uring"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b86e202f00093dcba4275d4636b93ef9dd75d025ae560d2521b45ea28ab49013"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2902,15 +2913,17 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.45.1"
+version = "1.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75ef51a33ef1da925cea3e4eb122833cb377c61439ca401b770f54902b806779"
+checksum = "1140bb80481756a8cbe10541f37433b459c5aa1e727b4c020fbfebdc25bf3ec4"
 dependencies = [
  "backtrace",
  "bytes",
+ "io-uring",
  "libc",
  "mio",
  "pin-project-lite",
+ "slab",
  "socket2",
  "tokio-macros",
  "windows-sys 0.52.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -412,9 +412,9 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cc"
-version = "1.2.27"
+version = "1.2.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d487aa071b5f64da6f19a3e848e3578944b726ee5a4854b82172f02aa876bfdc"
+checksum = "4ad45f4f74e4e20eaa392913b7b33a7091c87e59628f4dd27888205ad888843c"
 dependencies = [
  "jobserver",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -275,7 +275,7 @@ dependencies = [
  "log",
  "rustls-pki-types",
  "thiserror 1.0.69",
- "webpki-roots",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -406,9 +406,9 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cc"
-version = "1.2.20"
+version = "1.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04da6a0d40b948dfc4fa8f5bbf402b0fc1a64a28dbf7d12ffd683550f2c1b63a"
+checksum = "8691782945451c1c383942c4874dbe63814f61cb57ef773cda2972682b7bb3c0"
 dependencies = [
  "jobserver",
  "libc",
@@ -978,9 +978,9 @@ checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "h2"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75249d144030531f8dee69fe9cea04d3edf809a017ae445e2abdff6629e86633"
+checksum = "a9421a676d1b147b16b82c9225157dc629087ef8ec4d5e2960f9437a90dac0a5"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1172,7 +1172,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -1492,9 +1492,9 @@ dependencies = [
 
 [[package]]
 name = "libm"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9627da5196e5d8ed0b0495e61e518847578da83483c37288316d9b2e03a7f72"
+checksum = "a25169bd5913a4b437588a7e3d127cd6e90127b60e0ffbd834a38f1599e016b8"
 
 [[package]]
 name = "libmimalloc-sys"
@@ -2246,9 +2246,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.26"
+version = "0.23.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df51b5869f3a441595eac5e8ff14d486ff285f7b8c0df8770e49c3b56351f0f0"
+checksum = "730944ca083c1c233a75c09f199e973ca499344a2b7ba9e755c457e86fb4a321"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -2280,7 +2280,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.12",
- "webpki-roots",
+ "webpki-roots 0.26.11",
  "x509-parser",
 ]
 
@@ -2316,9 +2316,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-platform-verifier"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4937d110d34408e9e5ad30ba0b0ca3b6a8a390f8db3636db60144ac4fa792750"
+checksum = "19787cda76408ec5404443dc8b31795c87cd8fec49762dc75fa727740d34acc1"
 dependencies = [
  "core-foundation 0.10.0",
  "core-foundation-sys",
@@ -2331,7 +2331,7 @@ dependencies = [
  "rustls-webpki",
  "security-framework 3.2.0",
  "security-framework-sys",
- "webpki-root-certs",
+ "webpki-root-certs 0.26.11",
  "windows-sys 0.59.0",
 ]
 
@@ -2352,9 +2352,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.1"
+version = "0.103.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fef8b8769aaccf73098557a87cd1816b4f9c7c16811c9c77142aa695c16f2c03"
+checksum = "7149975849f1abb3832b246010ef62ccc80d3a76169517ada7188252b9cfb437"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -2513,9 +2513,9 @@ dependencies = [
 
 [[package]]
 name = "s2n-tls"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2a05886fe90b529c7ffef6b8b5542e26e21e3b0e66612673395c7ecedde0e30"
+checksum = "e1c2355bbfcccc93a61d56a8e8b8a22325a5c68b693ddeba904a5aa293cc66c8"
 dependencies = [
  "errno",
  "hex",
@@ -2526,9 +2526,9 @@ dependencies = [
 
 [[package]]
 name = "s2n-tls-sys"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c69b480e275a5c3016307c589f2f71bbf9ea21c102e7ce3c19316d908bf0c21f"
+checksum = "65818edc12b815a4b2140a6a031f6e5fe3a59b31c28d7f01835b9aa38654f81f"
 dependencies = [
  "aws-lc-rs",
  "cc",
@@ -2867,9 +2867,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.44.2"
+version = "1.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48"
+checksum = "2513ca694ef9ede0fb23fe71a4ee4107cb102b9dc1930f6d0fd77aae068ae165"
 dependencies = [
  "backtrace",
  "bytes",
@@ -3238,18 +3238,36 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "0.26.10"
+version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c99403924bc5f23afefc319b8ac67ed0e50669f6e52a413314cccb1fdbc93ba0"
+checksum = "75c7f0ef91146ebfb530314f5f1d24528d7f0767efbfd31dce919275413e393e"
+dependencies = [
+ "webpki-root-certs 1.0.0",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01a83f7e1a9f8712695c03eabe9ed3fbca0feff0152f33f12593e5a6303cb1a4"
 dependencies = [
  "rustls-pki-types",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "0.26.10"
+version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37493cadf42a2a939ed404698ded7fb378bf301b5011f973361779a3a74f8c93"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.0",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2853738d1cc4f2da3a225c18ec6c3721abb31961096e9dbf5ab35fa88b19cfdb"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -3506,9 +3524,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.7.7"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb8234a863ea0e8cd7284fcdd4f145233eb00fee02bbdd9861aec44e6477bc5"
+checksum = "d9fb597c990f03753e08d3c29efbfcf2019a003b4bf4ba19225c158e1549f0f3"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -286,9 +286,9 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
@@ -732,12 +732,12 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea14ef9355e3beab063703aa9dab15afd25f0667c341310c1e5274bb1d0da18"
+checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1189,7 +1189,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots 1.0.0",
+ "webpki-roots 1.0.1",
 ]
 
 [[package]]
@@ -1462,9 +1462,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.173"
+version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8cfeafaffdbc32176b64fb251369d52ea9f0a8fbc6f8759edffef7b525d64bb"
+checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
 name = "libloading"
@@ -1854,9 +1854,9 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.34"
+version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6837b9e10d61f45f987d50808f83d1ee3d206c66acf650c3e4ae2e1f6ddedf55"
+checksum = "061c1221631e079b26479d25bbf2275bfe5917ae8419cd7e34f13bfc2aa7539a"
 dependencies = [
  "proc-macro2",
  "syn",
@@ -1923,9 +1923,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.12"
+version = "0.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee4e529991f949c5e25755532370b8af5d114acae52326361d68d47af64aa842"
+checksum = "fcebb1209ee276352ef14ff8732e24cc2b02bbac986cd74a4c81bcb2f9881970"
 dependencies = [
  "cfg_aliases",
  "libc",
@@ -1946,9 +1946,9 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
-version = "5.2.0"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
@@ -2362,7 +2362,7 @@ dependencies = [
  "rustls-webpki",
  "security-framework 3.2.0",
  "security-framework-sys",
- "webpki-root-certs 1.0.0",
+ "webpki-root-certs 1.0.1",
  "windows-sys 0.59.0",
 ]
 
@@ -2753,9 +2753,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.103"
+version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4307e30089d6fd6aff212f2da3a1f9e32f3223b1f010fb09b7c95f90f3ca1e8"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3039,9 +3039,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.29"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b1ffbcf9c6f6b99d386e7444eb608ba646ae452a36b39737deb9663b610f662"
+checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3272,14 +3272,14 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75c7f0ef91146ebfb530314f5f1d24528d7f0767efbfd31dce919275413e393e"
 dependencies = [
- "webpki-root-certs 1.0.0",
+ "webpki-root-certs 1.0.1",
 ]
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01a83f7e1a9f8712695c03eabe9ed3fbca0feff0152f33f12593e5a6303cb1a4"
+checksum = "86138b15b2b7d561bc4469e77027b8dd005a43dc502e9031d1f5afc8ce1f280e"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -3290,14 +3290,14 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
 dependencies = [
- "webpki-roots 1.0.0",
+ "webpki-roots 1.0.1",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2853738d1cc4f2da3a225c18ec6c3721abb31961096e9dbf5ab35fa88b19cfdb"
+checksum = "8782dd5a41a24eed3a4f40b606249b3e236ca61adf1f25ea4d45c73de122b502"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -3316,9 +3316,9 @@ dependencies = [
 
 [[package]]
 name = "wide"
-version = "0.7.32"
+version = "0.7.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41b5576b9a81633f3e8df296ce0063042a73507636cbe956c61133dd7034ab22"
+checksum = "0ce5da8ecb62bcd8ec8b7ea19f69a51275e91299be594ea5cc6ef7819e16cd03"
 dependencies = [
  "bytemuck",
  "safe_arch",
@@ -3439,6 +3439,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.2",
 ]
 
 [[package]]
@@ -3702,18 +3711,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.25"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
+checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.25"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
+checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -997,9 +997,9 @@ dependencies = [
 
 [[package]]
 name = "h3"
-version = "0.0.7"
+version = "0.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dfb059a4f28a66f186ed16ad912d142f490676acba59353831d7cb45a96b0d3"
+checksum = "10872b55cfb02a821b69dc7cf8dc6a71d6af25eb9a79662bec4a9d016056b3be"
 dependencies = [
  "bytes",
  "fastrand",
@@ -1012,9 +1012,9 @@ dependencies = [
 
 [[package]]
 name = "h3-quinn"
-version = "0.0.9"
+version = "0.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d482318ae94198fc8e3cbb0b7ba3099c865d744e6ec7c62039ca7b6b6c66fbf"
+checksum = "8b2e732c8d91a74731663ac8479ab505042fbf547b9a207213ab7fbcbfc4f8b4"
 dependencies = [
  "bytes",
  "futures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2913,9 +2913,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.46.0"
+version = "1.46.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1140bb80481756a8cbe10541f37433b459c5aa1e727b4c020fbfebdc25bf3ec4"
+checksum = "0cc3a2344dafbe23a245241fe8b09735b521110d30fcefbbd5feb1797ca35d17"
 dependencies = [
  "backtrace",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2700,9 +2700,9 @@ checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
 
 [[package]]
 name = "socket2"
-version = "0.5.9"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f5fd57c80058a56cf5c777ab8a126398ece8e442983605d280a44ce79d0edef"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -316,9 +316,9 @@ dependencies = [
 
 [[package]]
 name = "backtrace"
-version = "0.3.74"
+version = "0.3.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
+checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
 dependencies = [
  "addr2line",
  "cfg-if",
@@ -1492,9 +1492,9 @@ dependencies = [
 
 [[package]]
 name = "libm"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a25169bd5913a4b437588a7e3d127cd6e90127b60e0ffbd834a38f1599e016b8"
+checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
 name = "libmimalloc-sys"
@@ -3524,9 +3524,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.7.9"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9fb597c990f03753e08d3c29efbfcf2019a003b4bf4ba19225c158e1549f0f3"
+checksum = "c06928c8748d81b05c9be96aad92e1b6ff01833332f281e8cfca3be4b35fc9ec"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2879,9 +2879,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.45.0"
+version = "1.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2513ca694ef9ede0fb23fe71a4ee4107cb102b9dc1930f6d0fd77aae068ae165"
+checksum = "75ef51a33ef1da925cea3e4eb122833cb377c61439ca401b770f54902b806779"
 dependencies = [
  "backtrace",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -292,9 +292,9 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b756939cb2f8dc900aa6dcd505e6e2428e9cae7ff7b028c49e3946efa70878"
+checksum = "93fcc8f365936c834db5514fc45aee5b1202d677e6b40e48468aaaa8183ca8c7"
 dependencies = [
  "aws-lc-sys",
  "untrusted 0.7.1",
@@ -303,9 +303,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.28.2"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa9b6986f250236c27e5a204062434a773a13243d2ffc2955f37bdba4c5c6a1"
+checksum = "61b1d86e7705efe1be1b569bab41d4fa1e14e220b60a160f78de2db687add079"
 dependencies = [
  "bindgen",
  "cc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1518,9 +1518,9 @@ checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "lru"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f8cc7106155f10bdf99a6f379688f543ad6596a415375b36a59a054ceda1198"
+checksum = "0281c2e25e62316a5c9d98f2d2e9e95a37841afdaf4383c177dbb5c1dfab0568"
 dependencies = [
  "hashbrown",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,9 +13,9 @@ dependencies = [
 
 [[package]]
 name = "adler2"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "ahash"
@@ -394,9 +394,9 @@ checksum = "793db76d6187cd04dff33004d8e6c9cc4e05cd330500379d2394209271b4aeee"
 
 [[package]]
 name = "bytemuck"
-version = "1.23.0"
+version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9134a6ef01ce4b366b50689c94f82c14bc72bc5d0386829828a2e2752ef7958c"
+checksum = "5c76a5792e44e4abe34d3abf15636779261d45a7450612059293d1d2cfc63422"
 
 [[package]]
 name = "byteorder"
@@ -438,9 +438,9 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
 name = "cfg_aliases"
@@ -496,9 +496,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
+checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
 name = "cmake"
@@ -964,7 +964,7 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "wasm-bindgen",
 ]
 
@@ -1050,9 +1050,9 @@ checksum = "1b4b9ebce26001bad2e6366295f64e381c1e9c479109202149b9e15e154973e9"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.3"
+version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
+checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -1572,9 +1572,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
 ]
@@ -1586,7 +1586,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
 dependencies = [
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.59.0",
 ]
 
@@ -2202,9 +2202,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.24"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+checksum = "989e6739f80c4ad5b13e0fd7fe89531180375b18520cc8c82080e4dc4035b84f"
 
 [[package]]
 name = "rustc-hash"
@@ -2756,9 +2756,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.101"
+version = "2.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
+checksum = "f6397daf94fa90f058bd0fd88429dd9e5738999cca8d701813c80723add80462"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3189,9 +3189,9 @@ checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
+version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasi"
@@ -3632,9 +3632,9 @@ checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"
-version = "0.7.10"
+version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06928c8748d81b05c9be96aad92e1b6ff01833332f281e8cfca3be4b35fc9ec"
+checksum = "74c7b26e3480b707944fc872477815d29a8e429d2f93a1ce000f5fa84a15cbcd"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,15 +19,15 @@ checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
 name = "ahash"
-version = "0.8.11"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
- "getrandom 0.2.16",
+ "getrandom 0.3.2",
  "once_cell",
  "version_check",
- "zerocopy 0.7.35",
+ "zerocopy",
 ]
 
 [[package]]
@@ -1842,7 +1842,7 @@ version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
- "zerocopy 0.8.25",
+ "zerocopy",
 ]
 
 [[package]]
@@ -2380,7 +2380,7 @@ version = "0.57.0"
 dependencies = [
  "byteorder",
  "bytes",
- "zerocopy 0.8.25",
+ "zerocopy",
 ]
 
 [[package]]
@@ -2402,7 +2402,7 @@ dependencies = [
  "s2n-quic-tls-default",
  "s2n-quic-transport",
  "tokio",
- "zerocopy 0.8.25",
+ "zerocopy",
  "zeroize",
 ]
 
@@ -2422,7 +2422,7 @@ dependencies = [
  "pin-project-lite",
  "s2n-codec",
  "subtle",
- "zerocopy 0.8.25",
+ "zerocopy",
 ]
 
 [[package]]
@@ -3604,31 +3604,11 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.7.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
-dependencies = [
- "zerocopy-derive 0.7.35",
-]
-
-[[package]]
-name = "zerocopy"
 version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
 dependencies = [
- "zerocopy-derive 0.8.25",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.7.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "zerocopy-derive",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1529,9 +1529,9 @@ checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "lru"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0281c2e25e62316a5c9d98f2d2e9e95a37841afdaf4383c177dbb5c1dfab0568"
+checksum = "86ea4e65087ff52f3862caff188d489f1fab49a0cb09e01b2e3f1a617b10aaed"
 dependencies = [
  "hashbrown",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1211,9 +1211,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "497bbc33a26fdd4af9ed9c70d63f61cf56a938375fbb32df34db9b1cd6d643f2"
+checksum = "cf9f1e950e0d9d1d3c47184416723cf29c0d1f93bd8cccf37e4beb6b44f31710"
 dependencies = [
  "bytes",
  "futures-channel",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -996,9 +996,9 @@ checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "h2"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9421a676d1b147b16b82c9225157dc629087ef8ec4d5e2960f9437a90dac0a5"
+checksum = "17da50a276f1e01e0ba6c029e47b7100754904ee8a278f886546e98575380785"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1736,9 +1736,9 @@ checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-src"
-version = "300.5.0+3.5.0"
+version = "300.5.1+3.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8ce546f549326b0e6052b649198487d91320875da901e7bd11a06d1ee3f9c2f"
+checksum = "735230c832b28c000e3bc117119e6466a663ec73506bc0a9907ea4187508e42a"
 dependencies = [
  "cc",
 ]
@@ -2406,7 +2406,7 @@ checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "s2n-codec"
-version = "0.60.0"
+version = "0.61.0"
 dependencies = [
  "byteorder",
  "bytes",
@@ -2415,7 +2415,7 @@ dependencies = [
 
 [[package]]
 name = "s2n-quic"
-version = "1.60.0"
+version = "1.61.0"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -2438,7 +2438,7 @@ dependencies = [
 
 [[package]]
 name = "s2n-quic-core"
-version = "0.60.0"
+version = "0.61.0"
 dependencies = [
  "atomic-waker",
  "byteorder",
@@ -2457,7 +2457,7 @@ dependencies = [
 
 [[package]]
 name = "s2n-quic-crypto"
-version = "0.60.0"
+version = "0.61.0"
 dependencies = [
  "aws-lc-rs",
  "cfg-if",
@@ -2480,7 +2480,7 @@ dependencies = [
 
 [[package]]
 name = "s2n-quic-platform"
-version = "0.60.0"
+version = "0.61.0"
 dependencies = [
  "cfg-if",
  "futures",
@@ -2493,7 +2493,7 @@ dependencies = [
 
 [[package]]
 name = "s2n-quic-rustls"
-version = "0.60.0"
+version = "0.61.0"
 dependencies = [
  "bytes",
  "rustls",
@@ -2506,7 +2506,7 @@ dependencies = [
 
 [[package]]
 name = "s2n-quic-tls"
-version = "0.60.0"
+version = "0.61.0"
 dependencies = [
  "bytes",
  "errno",
@@ -2519,7 +2519,7 @@ dependencies = [
 
 [[package]]
 name = "s2n-quic-tls-default"
-version = "0.60.0"
+version = "0.61.0"
 dependencies = [
  "s2n-quic-rustls",
  "s2n-quic-tls",
@@ -2527,7 +2527,7 @@ dependencies = [
 
 [[package]]
 name = "s2n-quic-transport"
-version = "0.60.0"
+version = "0.61.0"
 dependencies = [
  "bytes",
  "futures-channel",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -388,9 +388,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.18.1"
+version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793db76d6187cd04dff33004d8e6c9cc4e05cd330500379d2394209271b4aeee"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
 name = "bytemuck"
@@ -2407,7 +2407,7 @@ checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "s2n-codec"
-version = "0.59.0"
+version = "0.60.0"
 dependencies = [
  "byteorder",
  "bytes",
@@ -2416,7 +2416,7 @@ dependencies = [
 
 [[package]]
 name = "s2n-quic"
-version = "1.59.0"
+version = "1.60.0"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -2439,7 +2439,7 @@ dependencies = [
 
 [[package]]
 name = "s2n-quic-core"
-version = "0.59.0"
+version = "0.60.0"
 dependencies = [
  "atomic-waker",
  "byteorder",
@@ -2458,7 +2458,7 @@ dependencies = [
 
 [[package]]
 name = "s2n-quic-crypto"
-version = "0.59.0"
+version = "0.60.0"
 dependencies = [
  "aws-lc-rs",
  "cfg-if",
@@ -2481,7 +2481,7 @@ dependencies = [
 
 [[package]]
 name = "s2n-quic-platform"
-version = "0.59.0"
+version = "0.60.0"
 dependencies = [
  "cfg-if",
  "futures",
@@ -2494,7 +2494,7 @@ dependencies = [
 
 [[package]]
 name = "s2n-quic-rustls"
-version = "0.59.0"
+version = "0.60.0"
 dependencies = [
  "bytes",
  "rustls",
@@ -2507,7 +2507,7 @@ dependencies = [
 
 [[package]]
 name = "s2n-quic-tls"
-version = "0.59.0"
+version = "0.60.0"
 dependencies = [
  "bytes",
  "errno",
@@ -2520,7 +2520,7 @@ dependencies = [
 
 [[package]]
 name = "s2n-quic-tls-default"
-version = "0.59.0"
+version = "0.60.0"
 dependencies = [
  "s2n-quic-rustls",
  "s2n-quic-tls",
@@ -2528,7 +2528,7 @@ dependencies = [
 
 [[package]]
 name = "s2n-quic-transport"
-version = "0.59.0"
+version = "0.60.0"
 dependencies = [
  "bytes",
  "futures-channel",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -412,9 +412,9 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cc"
-version = "1.2.24"
+version = "1.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16595d3be041c03b09d08d0858631facccee9221e579704070e6e9e4915d3bc7"
+checksum = "d0fc897dc1e865cc67c0e05a836d9d3f1df3cbe442aa4a9473b18e12624a4951"
 dependencies = [
  "jobserver",
  "libc",
@@ -1185,7 +1185,7 @@ dependencies = [
  "hyper-util",
  "rustls",
  "rustls-pki-types",
- "rustls-platform-verifier",
+ "rustls-platform-verifier 0.5.3",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -1854,9 +1854,9 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.32"
+version = "0.2.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "664ec5419c51e34154eec046ebcba56312d5a2fc3b09a06da188e1ad21afadf6"
+checksum = "9dee91521343f4c5c6a63edd65e54f31f5c92fe8978c40a4282f8372194c6a7d"
 dependencies = [
  "proc-macro2",
  "syn",
@@ -1913,7 +1913,7 @@ dependencies = [
  "rustc-hash 2.1.1",
  "rustls",
  "rustls-pki-types",
- "rustls-platform-verifier",
+ "rustls-platform-verifier 0.5.3",
  "slab",
  "thiserror 2.0.12",
  "tinyvec",
@@ -2126,7 +2126,7 @@ dependencies = [
  "blocking",
  "rustls",
  "rustls-acme",
- "rustls-platform-verifier",
+ "rustls-platform-verifier 0.6.0",
  "rustls-post-quantum",
  "thiserror 2.0.12",
  "tokio",
@@ -2346,6 +2346,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-platform-verifier"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eda84358ed17f1f354cf4b1909ad346e6c7bc2513e8c40eb08e0157aa13a9070"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework 3.2.0",
+ "security-framework-sys",
+ "webpki-root-certs 1.0.0",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "rustls-platform-verifier-android"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2523,9 +2544,9 @@ dependencies = [
 
 [[package]]
 name = "s2n-tls"
-version = "0.3.20"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c5b886e605d71d8e78e37c7f6195887112f4c9d0a3269057f6447d3dae99908"
+checksum = "23c23a50f9733440df3a1e8c94d71026b02e5080395f080f4f66d1fecc2fca86"
 dependencies = [
  "errno",
  "hex",
@@ -2536,9 +2557,9 @@ dependencies = [
 
 [[package]]
 name = "s2n-tls-sys"
-version = "0.3.20"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "753c5eb4a0632b275ee3c503b0a108b2430b429566c86501f311f67cf579b35f"
+checksum = "00d42ff433e7a1267cc7105ee1aa8f8785473cee48376ddbb13e2d9f23e2291d"
 dependencies = [
  "aws-lc-rs",
  "cc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,9 +62,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.18"
+version = "0.6.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
+checksum = "301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -77,33 +77,33 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
+checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
 dependencies = [
  "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.8"
+version = "3.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6680de5231bd6ee4c6191b8a1325daa282b415391ec9d3a37bd34f2060dc73fa"
+checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
@@ -388,9 +388,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.17.0"
+version = "3.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
+checksum = "793db76d6187cd04dff33004d8e6c9cc4e05cd330500379d2394209271b4aeee"
 
 [[package]]
 name = "bytemuck"
@@ -412,9 +412,9 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cc"
-version = "1.2.25"
+version = "1.2.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0fc897dc1e865cc67c0e05a836d9d3f1df3cbe442aa4a9473b18e12624a4951"
+checksum = "956a5e21988b87f372569b66183b78babf23ebc2e744b733e4350a752c4dafac"
 dependencies = [
  "jobserver",
  "libc",
@@ -511,9 +511,9 @@ dependencies = [
 
 [[package]]
 name = "colorchoice"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "combine"
@@ -1044,9 +1044,9 @@ dependencies = [
 
 [[package]]
 name = "hash_hasher"
-version = "2.0.3"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74721d007512d0cb3338cd20f0654ac913920061a4c4d0d8708edb3f2a698c0c"
+checksum = "1b4b9ebce26001bad2e6366295f64e381c1e9c479109202149b9e15e154973e9"
 
 [[package]]
 name = "hashbrown"
@@ -1176,16 +1176,16 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.6"
+version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03a01595e11bdcec50946522c32dde3fc6914743000a68b93000965f2f02406d"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
  "http",
  "hyper",
  "hyper-util",
  "rustls",
  "rustls-pki-types",
- "rustls-platform-verifier 0.5.3",
+ "rustls-platform-verifier 0.6.0",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -2672,9 +2672,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
  "serde",
 ]
@@ -2722,9 +2722,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.15.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
@@ -2991,9 +2991,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.22"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05ae329d1f08c4d17a59bed7ff5b5a769d062e64a62d34a3261b219e62cd5aae"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -3003,18 +3003,18 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.9"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3da5db5a963e24bc68be8b17b6fa82814bb22ee8660f192bb182771d498f09a3"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.22.26"
+version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "310068873db2c5b3e7659d2cc35d21855dbafa50d1ce336397c666e3cb08137e"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap",
  "serde",
@@ -3043,9 +3043,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.28"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
+checksum = "1b1ffbcf9c6f6b99d386e7444eb608ba646ae452a36b39737deb9663b610f662"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3054,9 +3054,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.33"
+version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
+checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
 dependencies = [
  "once_cell",
  "valuable",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2101,7 +2101,6 @@ dependencies = [
  "clap",
  "futures-util",
  "hot_reload",
- "libmimalloc-sys",
  "mimalloc",
  "rpxy-acme",
  "rpxy-certs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -360,9 +360,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.9.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
+checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 
 [[package]]
 name = "block-buffer"
@@ -732,9 +732,9 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.11"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
+checksum = "cea14ef9355e3beab063703aa9dab15afd25f0667c341310c1e5274bb1d0da18"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
@@ -3334,9 +3334,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
-version = "0.61.0"
+version = "0.61.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4763c1de310c86d75a878046489e2e5ba02c649d185f21c67d4cf8a56d098980"
+checksum = "46ec44dc15085cea82cf9c78f85a9114c463a369786585ad2882d1ff0b0acf40"
 dependencies = [
  "windows-implement",
  "windows-interface",
@@ -3375,18 +3375,18 @@ checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
 
 [[package]]
 name = "windows-result"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c64fd11a4fd95df68efcfee5f44a294fe71b8bc6a91993e2791938abcc712252"
+checksum = "4b895b5356fc36103d0f64dd1e94dfa7ac5633f1c9dd6e80fe9ec4adef69e09d"
 dependencies = [
  "windows-link",
 ]
 
 [[package]]
 name = "windows-strings"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2ba9642430ee452d5a7aa78d72907ebe8cfda358e8cb7918a2050581322f97"
+checksum = "2a7ab927b2637c19b3dbe0965e75d8f2d30bdd697a1516191cad2ec4df8fb28a"
 dependencies = [
  "windows-link",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.10.0"
+version = "0.10.1"
 authors = ["Jun Kurihara"]
 homepage = "https://github.com/junkurihara/rust-rpxy"
 repository = "https://github.com/junkurihara/rust-rpxy"

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Supported features are summarized as follows:
 
 [^sanitization]: By default, `rpxy` provides the *TLS connection sanitization* by correctly binding a certificate used to establish a secure channel with the backend application. Specifically, it always keeps the consistency between the given SNI (server name indication) in `ClientHello` of the underlying TLS and the domain name given by the overlaid HTTP HOST header (or URL in Request line). We should note that NGINX doesn't guarantee such a consistency by default. To this end, you have to add `if` statement in the configuration file in NGINX.
 
- This project is still *work-in-progress*. But it is already working in some production environments and serves a number of domain names. Furthermore it *significantly outperforms* NGINX and Caddy, e.g., *1.5x faster than NGINX*, in the setting of a very simple HTTP reverse-proxy scenario (See [`bench`](./bench/) directory).
+ This project is still *work-in-progress*. But it is already working in some production environments and serves a number of domain names. Furthermore it *significantly outperforms* NGINX and Caddy, e.g., *30% or more faster than NGINX*, in the setting of a very simple HTTP reverse-proxy scenario (See [`bench`](./bench/) directory).
 
 ## Installing/Building an Executable Binary of `rpxy`
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Supported features are summarized as follows:
 
 [^sanitization]: By default, `rpxy` provides the *TLS connection sanitization* by correctly binding a certificate used to establish a secure channel with the backend application. Specifically, it always keeps the consistency between the given SNI (server name indication) in `ClientHello` of the underlying TLS and the domain name given by the overlaid HTTP HOST header (or URL in Request line). We should note that NGINX doesn't guarantee such a consistency by default. To this end, you have to add `if` statement in the configuration file in NGINX.
 
- This project is still *work-in-progress*. But it is already working in some production environments and serves a number of domain names. Furthermore it *significantly outperforms* NGINX and Caddy, e.g., *30% or more faster than NGINX*, in the setting of a very simple HTTP reverse-proxy scenario (See [`bench`](./bench/) directory).
+ This project is still *work-in-progress*. But it is already working in some production environments and serves a number of domain names. Furthermore it *significantly outperforms* NGINX and Caddy, e.g., *30% ~ 60% or more faster than NGINX*, in the setting of a very simple HTTP reverse-proxy scenario (See [`bench`](./bench/) directory).
 
 ## Installing/Building an Executable Binary of `rpxy`
 

--- a/README.md
+++ b/README.md
@@ -13,20 +13,20 @@
 
 ## Introduction
 
-`rpxy` [ahr-pik-see] is an implementation of simple and lightweight reverse-proxy with some additional features. The implementation is based on [`hyper`](https://github.com/hyperium/hyper), [`rustls`](https://github.com/rustls/rustls) and [`tokio`](https://github.com/tokio-rs/tokio), i.e., written in Rust [^pure_rust]. Our `rpxy` routes multiple host names to appropriate backend application servers while serving TLS connections.
+`rpxy` [ahr-pik-see] is a simple and lightweight reverse-proxy implementation with additional features. The implementation is based on [`hyper`](https://github.com/hyperium/hyper), [`rustls`](https://github.com/rustls/rustls) and [`tokio`](https://github.com/tokio-rs/tokio), i.e., written in Rust [^pure_rust]. `rpxy` routes multiple hostnames to appropriate backend application servers while serving TLS connections.
 
-[^pure_rust]: Doubtfully can be claimed to be written in pure Rust since current `rpxy` is based on `aws-lc-rs` for cryptographic operations.
+[^pure_rust]: It is questionable whether this can be claimed to be written in pure Rust since the current `rpxy` is based on `aws-lc-rs` for cryptographic operations.
 
-Supported features are summarized as follows:
+The supported features are summarized as follows:
 
-- Supported HTTP(S) protocols: HTTP/1.1, HTTP/2 and brand-new HTTP/3 [^h3lib]
+- Supported HTTP(S) protocols: HTTP/1.1, HTTP/2, and the brand-new HTTP/3 [^h3lib]
 - gRPC is also supported
 - Serving multiple domain names with TLS termination
 - Mutual TLS authentication with client certificates
 - Automated certificate issuance and renewal via TLS-ALPN-01 ACME protocol [^acme]
 - Post-quantum key exchange for TLS/QUIC [^kyber]
-- TLS connection sanitization to avoid the domain fronting [^sanitization]
-- Load balancing with round-robin, random, and sticky session
+- TLS connection sanitization to avoid domain fronting [^sanitization]
+- Load balancing with round-robin, random, and sticky sessions
 - and more...
 
 [^h3lib]: HTTP/3 is enabled thanks to [`quinn`](https://github.com/quinn-rs/quinn), [`s2n-quic`](https://github.com/aws/s2n-quic) and [`hyperium/h3`](https://github.com/hyperium/h3). HTTP/3 libraries are mutually exclusive. You need to explicitly specify `s2n-quic` with `--no-default-features` flag. Also note that if you build `rpxy` with `s2n-quic`, then it requires `openssl` just for building the package.
@@ -35,9 +35,9 @@ Supported features are summarized as follows:
 
 [^kyber]: `rpxy` supports the hybridized post-quantum key exchange [`X25519MLKEM768`](https://www.ietf.org/archive/id/draft-kwiatkowski-tls-ecdhe-mlkem-02.html)[^kyber] for TLS/QUIC incoming and outgoing initiation thanks to [`rustls-post-quantum`](https://docs.rs/rustls-post-quantum/latest/rustls_post_quantum/). This is already a default feature.  Also note that `X25519MLKEM768` is still a draft version yet this is widely used on the Internet.
 
-[^sanitization]: By default, `rpxy` provides the *TLS connection sanitization* by correctly binding a certificate used to establish a secure channel with the backend application. Specifically, it always keeps the consistency between the given SNI (server name indication) in `ClientHello` of the underlying TLS and the domain name given by the overlaid HTTP HOST header (or URL in Request line). We should note that NGINX doesn't guarantee such a consistency by default. To this end, you have to add `if` statement in the configuration file in NGINX.
+[^sanitization]: By default, `rpxy` provides *TLS connection sanitization* by correctly binding a certificate used to establish a secure channel with the backend application. Specifically, it always maintains consistency between the given SNI (server name indication) in `ClientHello` of the underlying TLS and the domain name given by the overlaid HTTP HOST header (or URL in Request line). We should note that NGINX doesn't guarantee such consistency by default. To achieve this, you have to add an `if` statement in the NGINX configuration file.
 
- This project is still *work-in-progress*. But it is already working in some production environments and serves a number of domain names. Furthermore it *significantly outperforms* NGINX and Caddy, e.g., *30% ~ 60% or more faster than NGINX*, in the setting of a very simple HTTP reverse-proxy scenario (See [`bench`](./bench/) directory).
+This project is still *work-in-progress*. However, it is already working in some production environments and serves a number of domain names. Furthermore, it *significantly outperforms* NGINX and Caddy, e.g., *30% ~ 60% or more faster than NGINX*, in very simple HTTP reverse-proxy scenarios (See [`bench`](./bench/) directory).
 
 ## Installing/Building an Executable Binary of `rpxy`
 
@@ -60,15 +60,15 @@ You can build an executable binary yourself by checking out this Git repository.
 % cargo build --no-default-features --features http3-s2n --release
 ```
 
-Then you have an executive binary `rust-rpxy/target/release/rpxy`.
+Then you have an executable binary `rust-rpxy/target/release/rpxy`.
 
 ### Package Installation for Linux (RPM/DEB)
 
-You can find the Jenkins CI/CD build scripts for `rpxy` in the [./build](./.build) directory.
+You can find the Jenkins CI/CD build scripts for `rpxy` in the [./.build](./.build) directory.
 
 Prebuilt packages for Linux RPM and DEB are available at [https://rpxy.gamerboy59.dev](https://rpxy.gamerboy59.dev), provided by [@Gamerboy59](https://github.com/Gamerboy59).
 
-Note that we do not have an option of installation via [`crates.io`](https://crates.io/), i.e., `cargo install`, at this point since some dependencies are not published yet. Alternatively, you can use docker image (see below) as the easiest way for `amd64` environment.
+Note that we do not have an installation option via [`crates.io`](https://crates.io/), i.e., `cargo install`, at this point since some dependencies are not yet published. Alternatively, you can use the docker image (see below) as the easiest way for `amd64` environments.
 
 ## Usage
 
@@ -80,9 +80,9 @@ You can run `rpxy` with a configuration file like
 % ./target/release/rpxy --config config.toml
 ```
 
-`rpxy` tracks the change of `config.toml` in the real-time manner and apply the change immediately without restarting the process.
+`rpxy` tracks changes to `config.toml` in real-time and applies changes immediately without restarting the process.
 
-The full help messages are given follows.
+The full help message is as follows.
 
 ```bash:
 usage: rpxy [OPTIONS] --config <FILE>
@@ -116,8 +116,8 @@ server_name = 'app1.example.com'
 reverse_proxy = [{ upstream = [{ location = 'app1.local:8080' }] }]
 ```
 
-In the above setting, `rpxy` listens on port 80 (TCP) and serves incoming cleartext HTTP request including a `app1.example.com` in its HOST header or URL in its Request line.
-For example, request messages like the followings.
+In the above setting, `rpxy` listens on port 80 (TCP) and serves incoming cleartext HTTP requests that include `app1.example.com` in their HOST header or URL in their Request line.
+For example, request messages like the following.
 
 ```http
 GET http://app1.example.com/path/to HTTP/1.1\r\n
@@ -130,9 +130,9 @@ GET /path/to HTTP/1.1\r\n
 HOST: app1.example.com\r\n
 ```
 
-Otherwise, say, a request to `other.example.com` is simply rejected with the status code `40x`.
+Otherwise, a request to `other.example.com` is simply rejected with status code `40x`.
 
-If you want to host multiple and distinct domain names in a single IP address/port, simply create multiple `app."<app_name>"` entries in config file like
+If you want to host multiple distinct domain names on a single IP address/port, simply create multiple `app."<app_name>"` entries in the config file like
 
 ```toml
 default_app = "app1"
@@ -146,11 +146,11 @@ server_name = "app2.example.org"
 #...
 ```
 
-Here we note that by specifying `default_app` entry, *HTTP* requests will be served by the specified application if HOST header or URL in Request line doesn't match any `server_name`s in `reverse_proxy` entries. For HTTPS requests, it will be rejected since the secure connection cannot be established for the unknown server name.
+Note that by specifying a `default_app` entry, *HTTP* requests will be served by the specified application if the HOST header or URL in the Request line doesn't match any `server_name`s in `reverse_proxy` entries. For HTTPS requests, it will be rejected since a secure connection cannot be established for an unknown server name.
 
 #### HTTPS to Backend Application
 
-The request message will be routed to the backend application specified with the domain name `app1.localdomain:8080` or IP address over cleartext HTTP. If the backend channel needs to serve TLS like forwarding to `https://app1.localdomain:8080`, you need to enable a `tls` option for the location.
+The request message will be routed to the backend application specified with the domain name `app1.localdomain:8080` or IP address over cleartext HTTP. If the backend channel needs to serve TLS, like forwarding to `https://app1.localdomain:8080`, you need to enable the `tls` option for the location.
 
 ```toml
 revese_proxy = [
@@ -160,7 +160,7 @@ revese_proxy = [
 
 #### Load Balancing
 
-You can specify multiple backend locations in the `reverse_proxy` array for *load-balancing* with an appropriate `load_balance` option. Currently it works in the manner of round-robin, in the random fashion, or round-robin with *session-persistance* using cookie. if `load_balance` is not specified, the first backend location is always chosen.
+You can specify multiple backend locations in the `reverse_proxy` array for *load-balancing* with an appropriate `load_balance` option. Currently it works in a round-robin manner, randomly, or round-robin with *session-persistence* using cookies. If `load_balance` is not specified, the first backend location is always chosen.
 
 ```toml
 [apps."app_name"]
@@ -174,7 +174,7 @@ load_balance = 'round_robin' # or 'random' or 'sticky'
 
 ### Second Step: Terminating TLS
 
-First of all, you need to specify a port `listen_port_tls` listening the HTTPS traffic, separately from HTTP port (`listen_port`). Then, serving an HTTPS endpoint can be easily done for your desired application just by specifying TLS certificates and private keys in PEM files.
+First of all, you need to specify a port `listen_port_tls` listening for HTTPS traffic, separately from the HTTP port (`listen_port`). Then, serving an HTTPS endpoint can be easily done for your desired application by simply specifying TLS certificates and private keys in PEM files.
 
 ```toml
 listen_port = 80
@@ -186,23 +186,23 @@ tls = { tls_cert_path = 'server.crt',  tls_cert_key_path = 'server.key' }
 reverse_proxy = [{ upstream = [{ location = 'app1.local:8080' }] }]
 ```
 
-In the above setting, both cleartext HTTP requests to port 80 and ciphertext HTTPS requests to port 443 are routed to the backend `app1.local:8080` in the same fashion. If you don't need to serve cleartext requests, just remove `listen_port = 80` and specify only `listen_port_tls = 443`.
+In the above setting, both cleartext HTTP requests to port 80 and encrypted HTTPS requests to port 443 are routed to the backend `app1.local:8080` in the same manner. If you don't need to serve cleartext requests, just remove `listen_port = 80` and specify only `listen_port_tls = 443`.
 
-We should note that the private key specified by `tls_cert_key_path` must be *in PKCS8 format*. (See TIPS to convert PKCS1 formatted private key to PKCS8 one.)
+Note that the private key specified by `tls_cert_key_path` must be *in PKCS8 format*. (See TIPS to convert PKCS1 formatted private keys to PKCS8 format.)
 
 #### Redirecting Cleartext HTTP Requests to HTTPS
 
-In the current Web, we believe it is common to serve everything through HTTPS rather than HTTP, and hence *https redirection* is often used for HTTP requests. When you specify both `listen_port` and `listen_port_tls`, you can enable an option of such  redirection by making `https_redirection` true.
+In the current Web, it is common to serve everything through HTTPS rather than HTTP, and hence *HTTPS redirection* is often used for HTTP requests. When you specify both `listen_port` and `listen_port_tls`, you can enable such redirection by setting `https_redirection` to true.
 
 ```toml
 tls = { https_redirection = true, tls_cert_path = 'server.crt', tls_cert_key_path = 'server.key' }
 ```
 
-If it is true, `rpxy` returns the status code `301` to the cleartext request with new location `https://<requested_host>/<requested_query_and_path>` served over TLS.
+If it is true, `rpxy` returns status code `301` to the cleartext request with the new location `https://<requested_host>/<requested_query_and_path>` served over TLS.
 
 ### Third Step: More Flexible Routing Based on URL Path
 
-`rpxy` can serves, of course, routes requests to multiple backend destination according to the path information. The routing information can be specified for each application (`server_name`) as follows.
+`rpxy` can, of course, route requests to multiple backend destinations according to path information. The routing information can be specified for each application (`server_name`) as follows.
 
 ```toml
 listen_port_tls = 443
@@ -230,15 +230,15 @@ upstream = [
 ]
 ```
 
-In the above example, a request to `https://app1.example.com/path/to?query=ok` matches the second `reverse_proxy` entry in the longest-prefix-matching manner, and will be routed to `path.backend.local` with preserving path and query information, i.e., served as `http://path.backend.local/path/to?query=ok`.
+In the above example, a request to `https://app1.example.com/path/to?query=ok` matches the second `reverse_proxy` entry in a longest-prefix-matching manner, and will be routed to `path.backend.local` while preserving path and query information, i.e., served as `http://path.backend.local/path/to?query=ok`.
 
-On the other hand, a request to `https://app1.example.com/path/another/xx?query=ng` matching the third entry is routed with *being rewritten its path information* specified by `replace_path` option. Namely, the matched `/path/another` part is rewritten with `/path`, and it is served as `http://another.backend.local/path/xx?query=ng`.
+On the other hand, a request to `https://app1.example.com/path/another/xx?query=ng` matching the third entry is routed with *its path information being rewritten* as specified by the `replace_path` option. Namely, the matched `/path/another` part is rewritten to `/path`, and it is served as `http://another.backend.local/path/xx?query=ng`.
 
-Requests that doesn't match any paths will be routed by the first entry that doesn't have the `path` option, which means the *default destination*. In other words, unless every `reverse_proxy` entry has an explicit `path` option, `rpxy` rejects requests that don't match any paths.
+Requests that don't match any paths will be routed by the first entry that doesn't have the `path` option, which serves as the *default destination*. In other words, unless every `reverse_proxy` entry has an explicit `path` option, `rpxy` rejects requests that don't match any paths.
 
 #### Simple Path-based Routing
 
-This path-based routing option would be enough in many cases. For example, you can serve multiple applications with one domain by specifying unique path to each application. More specifically, see an example below.
+This path-based routing option would be sufficient in many cases. For example, you can serve multiple applications with one domain by specifying a unique path for each application. More specifically, see the example below.
 
 ```toml
 [apps.app]
@@ -261,25 +261,25 @@ replace_path = '/'
 upstream = [ { location = 'subapp3.local' } ]
 ```
 
-This example configuration explains a very frequent situation of path-based routing. When a request to `app.example.com/subappN` routes to `sbappN.local` by replacing a path part `/subappN` to `/`.
+This example configuration demonstrates a very common path-based routing situation. When a request to `app.example.com/subappN` is routed to `subappN.local` by replacing the path part `/subappN` with `/`.
 
 ## More Options
 
-Since it is currently a work-in-progress project, we are frequently adding new options. We first add new option entries in the `config-example.toml` as examples. So please refer to it for up-to-date options. We will prepare a comprehensive documentation for all options.
+Since this is currently a work-in-progress project, we are frequently adding new options. We first add new option entries in `config-example.toml` as examples. Please refer to it for up-to-date options. We will prepare comprehensive documentation for all options.
 
 ## Using Docker Image
 
-You can also use `docker` image hosted on [Docker Hub](https://hub.docker.com/r/jqtype/rpxy) and [GitHub Container Registry](https://github.com/junkurihara/rust-rpxy/pkgs/container/rust-rpxy) instead of directly executing the binary. See [`./docker`](./docker/README.md) directory for more details.
+You can also use the `docker` image hosted on [Docker Hub](https://hub.docker.com/r/jqtype/rpxy) and [GitHub Container Registry](https://github.com/junkurihara/rust-rpxy/pkgs/container/rust-rpxy) instead of directly executing the binary. See the [`./docker`](./docker/README.md) directory for more details.
 
 ## Example
 
-[`./bench`](./bench/) directory could be a very simple example of configuration of `rpxy`. This can also be an example of an example of docker use case.
+The [`./bench`](./bench/) directory contains a very simple example of `rpxy` configuration. This can also serve as an example of a docker use case.
 
 ## Experimental Features and Caveats
 
 ### HTTP/3
 
-`rpxy` can serves HTTP/3 requests thanks to `quinn`, `s2n-quic` and `hyperium/h3`. To enable this experimental feature, add an entry `experimental.h3` in your `config.toml` like follows. Any values in the entry like `alt_svc_max_age` are optional.
+`rpxy` can serve HTTP/3 requests thanks to `quinn`, `s2n-quic` and `hyperium/h3`. To enable this experimental feature, add an entry `experimental.h3` in your `config.toml` as follows. Any values in the entry like `alt_svc_max_age` are optional.
 
 ```toml
 [experimental.h3]
@@ -301,7 +301,7 @@ server_name = 'localhost' # Domain name
 tls = { https_redirection = true, tls_cert_path = './server.crt', tls_cert_key_path = './server.key', client_ca_cert_path = './client_cert.ca.crt' }
 ```
 
- However, currently we have a limitation on HTTP/3 support for applications that enables client authentication. If an application is set with client authentication, HTTP/3 doesn't work for the application.
+However, currently we have a limitation on HTTP/3 support for applications that enable client authentication. If an application is configured with client authentication, HTTP/3 doesn't work for that application.
 
 ### Hybrid Caching Feature with Temporary File and On-Memory Cache
 
@@ -316,11 +316,11 @@ max_cache_each_size = 65535          # optional. default is 64k
 max_cache_each_size_on_memory = 4096 # optional. default is 4k if 0, it is always file cache.
 ```
 
-A *storable* (in the context of an HTTP message) response is stored if its size is less than or equal to `max_cache_each_size` in bytes. If it is also less than or equal to `max_cache_each_size_on_memory`, it is stored as an on-memory object. Otherwise, it is stored as a temporary file. Note that `max_cache_each_size` must be larger or equal to `max_cache_each_size_on_memory`. Also note that once `rpxy` restarts or the config is updated, the cache is totally eliminated not only from the on-memory table but also from the file system.
+A *storable* (in the context of an HTTP message) response is stored if its size is less than or equal to `max_cache_each_size` in bytes. If it is also less than or equal to `max_cache_each_size_on_memory`, it is stored as an in-memory object. Otherwise, it is stored as a temporary file. Note that `max_cache_each_size` must be greater than or equal to `max_cache_each_size_on_memory`. Also note that once `rpxy` restarts or the config is updated, the cache is completely eliminated not only from the in-memory table but also from the file system.
 
-### Automated Certificate Issuance and Renewal via TLS-ALPN-01 ACME protocol
+### Automated Certificate Issuance and Renewal via TLS-ALPN-01 ACME Protocol
 
-This is a brand-new feature and maybe still unstable. Thanks to the [`rustls-acme`](https://github.com/FlorianUekermann/rustls-acme), the automatic issuance and renewal of certificates are finally available in `rpxy`. To enable this feature, you need to specify the following entries in `config.toml`.
+This is a brand-new feature and may still be unstable. Thanks to [`rustls-acme`](https://github.com/FlorianUekermann/rustls-acme), automatic issuance and renewal of certificates are finally available in `rpxy`. To enable this feature, you need to specify the following entries in `config.toml`.
 
 ```toml
 # ACME enabled domain name.
@@ -342,13 +342,13 @@ email = "test@example.com"
 registry_path = "./acme_registry"       # optional. default is "./acme_registry" relative to the current working directory
 ```
 
-The above configuration is common to all ACME enabled domains. Note that the https port must be open to the public to verify the domain ownership.
+The above configuration is common to all ACME-enabled domains. Note that the HTTPS port must be open to the public to verify domain ownership.
 
 ## TIPS
 
-### Set custom port for HTTPS redirection
+### Set Custom Port for HTTPS Redirection
 
-Consider a case where `rpxy` is running on a container. Then when the container manager maps port A (e.g., 80/443) of the host to port B (e.g., 8080/8443) of the container for http and https, `rpxy` must be configured with port B for `listen_port` and `listen_port_tls`. However, when you want to set `http_redirection=true` for some backend apps, `rpxy` issues the redirection response 301 with the port B by default, which is not accessible from the outside of the container. To avoid this, you can set a custom port for the redirection response by specifying `https_redirection_port` in `config.toml`. In this case, port A should be set for `https_redirection_port`, then the redirection response 301 will be issued with the port A.
+Consider a case where `rpxy` is running in a container. When the container manager maps port A (e.g., 80/443) of the host to port B (e.g., 8080/8443) of the container for HTTP and HTTPS, `rpxy` must be configured with port B for `listen_port` and `listen_port_tls`. However, when you want to set `https_redirection=true` for some backend apps, `rpxy` issues redirection response 301 with port B by default, which is not accessible from outside the container. To avoid this, you can set a custom port for the redirection response by specifying `https_redirection_port` in `config.toml`. In this case, port A should be set for `https_redirection_port`, then redirection response 301 will be issued with port A.
 
 ```toml
 listen_port = 8080
@@ -356,25 +356,25 @@ listen_port_tls = 8443
 https_redirection_port = 443
 ```
 
-### Using Private Key Issued by Let's Encrypt
+### Using Private Keys Issued by Let's Encrypt
 
-If you obtain certificates and private keys from [Let's Encrypt](https://letsencrypt.org/), you have PKCS1-formatted private keys. So you need to convert such retrieved private keys into PKCS8 format to use in `rpxy`.
+If you obtain certificates and private keys from [Let's Encrypt](https://letsencrypt.org/), you have PKCS1-formatted private keys. You need to convert such retrieved private keys into PKCS8 format to use them in `rpxy`.
 
-The easiest way is to use `openssl` by
+The easiest way is to use `openssl`:
 
 ```bash
 % openssl pkcs8 -topk8 -nocrypt \
-    -in yoru_domain_from_le.key \
+    -in your_domain_from_le.key \
     -inform PEM \
     -out your_domain_pkcs8.key.pem \
     -outform PEM
 ```
 
-### Client Authentication using Client Certificate Signed by Your Own Root CA
+### Client Authentication Using Client Certificates Signed by Your Own Root CA
 
-First, you need to prepare a CA certificate used to verify client certificate. If you do not have one, you can generate CA key and certificate by OpenSSL commands as follows. *Note that `rustls` accepts X509v3 certificates and reject SHA-1, and that `rpxy` relys on Version 3 extension fields of `KeyID`s of `Subject Key Identifier` and `Authority Key Identifier`.*
+First, you need to prepare a CA certificate used to verify client certificates. If you do not have one, you can generate a CA key and certificate using OpenSSL commands as follows. *Note that `rustls` accepts X509v3 certificates and rejects SHA-1, and that `rpxy` relies on Version 3 extension fields of `KeyID`s of `Subject Key Identifier` and `Authority Key Identifier`.*
 
-1. Generate CA key of `secp256v1`, CSR, and then generate CA certificate that will be set for `tls.client_ca_cert_path` for each server app in `config.toml`.
+1. Generate a CA key of `secp256v1`, CSR, and then generate a CA certificate that will be set for `tls.client_ca_cert_path` for each server app in `config.toml`.
 
   ```bash
   % openssl genpkey -algorithm EC -pkeyopt ec_paramgen_curve:prime256v1 -out client.ca.key
@@ -393,7 +393,7 @@ First, you need to prepare a CA certificate used to verify client certificate. I
   % openssl x509 -req -days 3650 -sha256 -in client.ca.csr -signkey client.ca.key -out client.ca.crt -extfile client.ca.ext
   ```
 
-2. Generate a client key of `secp256v1` and certificate signed by CA key.
+2. Generate a client key of `secp256v1` and certificate signed by the CA key.
 
   ```bash
   % openssl genpkey -algorithm EC -pkeyopt ec_paramgen_curve:prime256v1 -out client.key
@@ -412,32 +412,32 @@ First, you need to prepare a CA certificate used to verify client certificate. I
   % openssl x509 -req -days 365 -sha256 -in client.csr -CA client.ca.crt -CAkey client.ca.key -CAcreateserial -out client.crt -extfile client.ext
   ```
 
-  Now you have a client key `client.key` and certificate `client.crt` (version 3). `pfx` (`p12`) file can be retrieved as
+  Now you have a client key `client.key` and certificate `client.crt` (version 3). A `pfx` (`p12`) file can be generated as follows:
 
   ```bash
   % openssl pkcs12 -export -inkey client.key -in client.crt -certfile client.ca.crt -out client.pfx
   ```
 
-  Note that on MacOS, a `pfx` generated by `OpenSSL 3.0.6` cannot be imported to MacOS KeyChain Access. We generated the sample `pfx` using `LibreSSL 2.8.3` instead `OpenSSL`.
+  Note that on macOS, a `pfx` generated by `OpenSSL 3.0.6` cannot be imported to macOS Keychain Access. We generated the sample `pfx` using `LibreSSL 2.8.3` instead of `OpenSSL`.
 
-  All of sample certificate files are found in `./example-certs/` directory.
+  All sample certificate files can be found in the `./example-certs/` directory.
 
-### (Work Around) Deployment on Ubuntu 22.04LTS using docker behind `ufw`
+### (Work Around) Deployment on Ubuntu 22.04 LTS Using Docker Behind `ufw`
 
-Basically, docker automatically manage your iptables if you use the port-mapping option, i.e., `--publish` for `docker run` or `ports` in `docker-compose.yml`. This means you do not need to manually expose your port, e.g., 443 TCP/UDP for HTTPS, using `ufw`-like management command.
+Basically, Docker automatically manages your iptables if you use the port-mapping option, i.e., `--publish` for `docker run` or `ports` in `docker-compose.yml`. This means you do not need to manually expose your port, e.g., 443 TCP/UDP for HTTPS, using `ufw`-like management commands.
 
-However, we found that if you want to use the brand-new UDP-based protocol, HTTP/3, on `rpxy`, you need to explicitly expose your HTTPS port by using `ufw`-like command.
+However, we found that if you want to use the brand-new UDP-based protocol, HTTP/3, on `rpxy`, you need to explicitly expose your HTTPS port using `ufw`-like commands.
 
 ```bash
 % sudo ufw allow 443
 % sudo ufw enable
 ```
 
-Your docker container can receive only TCP-based connection, i.e., HTTP/2 or before, unless you manually manage the port. We see that this is weird and expect that it is a kind of bug (of docker? ubuntu? or something else?). But at least for Ubuntu 22.04LTS, you need to handle it as above.
+Your Docker container can receive only TCP-based connections, i.e., HTTP/2 or earlier, unless you manually manage the port. We see that this is strange and expect that it is some kind of bug (of Docker? Ubuntu? or something else?). But at least for Ubuntu 22.04 LTS, you need to handle it as described above.
 
-### Managing `rpxy` via web interface
+### Managing `rpxy` via Web Interface
 
-Check a third party project [`Gamerboy59/rpxy-webui`](https://github.com/Gamerboy59/rpxy-webui) to manage `rpxy` via web interface.
+Check the third-party project [`Gamerboy59/rpxy-webui`](https://github.com/Gamerboy59/rpxy-webui) to manage `rpxy` via a web interface.
 
 ### Other TIPS
 

--- a/bench/Caddyfile
+++ b/bench/Caddyfile
@@ -2,9 +2,13 @@
   auto_https off
 }
 
+
 :80 {
 
 	# Proxy everything else to Rocket
 	reverse_proxy backend-nginx
+  log {
+    level ERROR
+  }
 
 }

--- a/bench/README.md
+++ b/bench/README.md
@@ -8,43 +8,40 @@ $ rewrk -c 512 -t 4 -d 15s -h http://localhost:8080 --pct
 
 ## Tests on `linux/arm64/v8`
 
-Done at Jul. 15, 2023
+Done at May. 17, 2025
 
 ### Environment
 
-- `rpxy` commit id: `1da7e5bfb77d1ce4ee8d6cfc59b1c725556fc192`
-- Docker Desktop 4.21.1 (114176)
+- `rpxy` commit id: `e259e0b58897258d98fdb7504a1cbcbd7c5b37db`
+- Docker Desktop 4.41.2 (191736)
 - ReWrk 0.3.2
-- Macbook Pro '14 (2021, M1 Max, 64GB RAM)
+- MacBook Pro '14 (2021, M1 Max, 64GB RAM)
 
 The docker images of `nginx` and `caddy` for `linux/arm64/v8` are pulled from the official registry.
 
 ### Result for `rpxy`, `nginx` and `caddy`
 
-```
-----------------------------
+```bash
 Benchmark on rpxy
 Beginning round 1...
 Benchmarking 512 connections @ http://localhost:8080 for 15 second(s)
   Latencies:
     Avg      Stdev    Min      Max
-    19.64ms  8.85ms   0.67ms   113.22ms
+    10.62ms  4.47ms   0.47ms   73.01ms
   Requests:
-    Total: 390078  Req/Sec: 26011.25
+    Total: 720148  Req/Sec: 48025.92
   Transfer:
-    Total: 304.85 MB Transfer Rate: 20.33 MB/Sec
+    Total: 563.85 MB Transfer Rate: 37.60 MB/Sec
 + --------------- + --------------- +
 |   Percentile    |   Avg Latency   |
 + --------------- + --------------- +
-|      99.9%      |     79.24ms     |
-|       99%       |     54.28ms     |
-|       95%       |     42.50ms     |
-|       90%       |     37.82ms     |
-|       75%       |     31.54ms     |
-|       50%       |     26.37ms     |
+|      99.9%      |     54.78ms     |
+|       99%       |     35.86ms     |
+|       95%       |     23.09ms     |
+|       90%       |     19.82ms     |
+|       75%       |     16.14ms     |
+|       50%       |     13.54ms     |
 + --------------- + --------------- +
-
-721 Errors: error shutting down connection: Socket is not connected (os error 57)
 
 sleep 3 secs
 ----------------------------
@@ -53,23 +50,23 @@ Beginning round 1...
 Benchmarking 512 connections @ http://localhost:8090 for 15 second(s)
   Latencies:
     Avg      Stdev    Min      Max
-    33.26ms  15.18ms  1.40ms   118.94ms
+    14.55ms  13.05ms  0.57ms   255.24ms
   Requests:
-    Total: 230268  Req/Sec: 15356.08
+    Total: 525866  Req/Sec: 35073.37
   Transfer:
-    Total: 186.77 MB Transfer Rate: 12.46 MB/Sec
+    Total: 427.78 MB Transfer Rate: 28.53 MB/Sec
 + --------------- + --------------- +
 |   Percentile    |   Avg Latency   |
 + --------------- + --------------- +
-|      99.9%      |     99.91ms     |
-|       99%       |     83.74ms     |
-|       95%       |     70.67ms     |
-|       90%       |     64.03ms     |
-|       75%       |     54.32ms     |
-|       50%       |     45.19ms     |
+|      99.9%      |    235.17ms     |
+|       99%       |     91.77ms     |
+|       95%       |     48.86ms     |
+|       90%       |     39.08ms     |
+|       75%       |     28.78ms     |
+|       50%       |     21.77ms     |
 + --------------- + --------------- +
 
-677 Errors: error shutting down connection: Socket is not connected (os error 57)
+227 Errors: connection closed
 
 sleep 3 secs
 ----------------------------
@@ -78,23 +75,21 @@ Beginning round 1...
 Benchmarking 512 connections @ http://localhost:8100 for 15 second(s)
   Latencies:
     Avg      Stdev    Min      Max
-    48.51ms  50.74ms  0.34ms   554.58ms
+    70.44ms  220.19ms  0.67ms   4140.08ms
   Requests:
-    Total: 157239  Req/Sec: 10485.98
+    Total:  79980  Req/Sec: 5334.74
   Transfer:
-    Total: 125.99 MB Transfer Rate: 8.40 MB/Sec
+    Total: 64.45 MB Transfer Rate: 4.30 MB/Sec
 + --------------- + --------------- +
 |   Percentile    |   Avg Latency   |
 + --------------- + --------------- +
-|      99.9%      |    473.82ms     |
-|       99%       |    307.16ms     |
-|       95%       |    212.28ms     |
-|       90%       |    169.05ms     |
-|       75%       |    115.92ms     |
-|       50%       |     80.24ms     |
+|      99.9%      |    3550.19ms    |
+|       99%       |    1847.80ms    |
+|       95%       |    672.82ms     |
+|       90%       |    440.34ms     |
+|       75%       |    224.81ms     |
+|       50%       |    128.79ms     |
 + --------------- + --------------- +
-
-708 Errors: error shutting down connection: Socket is not connected (os error 57)
 ```
 
 ## Results on `linux/amd64`

--- a/bench/README.md
+++ b/bench/README.md
@@ -3,7 +3,7 @@
 This test simply measures the performance of several reverse proxy through HTTP/1.1 by the following command using [`rewrk`](https://github.com/lnx-search/rewrk).
 
 ```sh:
-$ rewrk -c 512 -t 4 -d 15s -h http://localhost:8080 --pct
+rewrk -c 512 -t 4 -d 15s -h http://localhost:8080 --pct
 ```
 
 ## Tests on `linux/arm64/v8`
@@ -94,12 +94,12 @@ Benchmarking 512 connections @ http://localhost:8100 for 15 second(s)
 
 ## Results on `linux/amd64`
 
-Done at Jul. 24, 2023
+Done at May 20, 2025
 
 ### Environment
 
 - `rpxy` commit id: `7c0945a5124418aa9a1024568c1989bb77cf312f`
-- Docker Desktop 4.21.1 (114176)
+- Docker Desktop 4.41.2 (192736)
 - ReWrk 0.3.2 and Wrk 0.4.2
 - iMac '27 (2020, 10-Core Intel Core i9, 128GB RAM)
 
@@ -107,8 +107,8 @@ The docker images of `nginx` and `caddy` for `linux/amd64` were pulled from the 
 
 Also, when `Sozu` is configured as an HTTP reverse proxy, it cannot handle HTTP request messages emit from `ReWrk` due to hostname parsing errors though it can correctly handle messages dispatched from `curl` and browsers. So, we additionally test using [`Wrk`](https://github.com/wg/wrk) to examine `Sozu` with the following command.
 
-```sh:
-$ wrk -c 512 -t 4 -d 15s http://localhost:8110
+```bash
+wrk -c 512 -t 4 -d 15s http://localhost:8110
 ```
 
 <!-- ```
@@ -119,7 +119,7 @@ ERROR  Error connecting to backend: Could not get cluster id from request: Host 
 
 #### With ReWrk for `rpxy`, `nginx` and `caddy`
 
-```
+```bash
 ----------------------------
 Benchmark [x86_64] with ReWrk
 ----------------------------
@@ -128,23 +128,21 @@ Beginning round 1...
 Benchmarking 512 connections @ http://localhost:8080 for 15 second(s)
   Latencies:
     Avg      Stdev    Min      Max
-    20.37ms  8.95ms   1.63ms   160.27ms
+    15.75ms  6.75ms   1.75ms   124.25ms
   Requests:
-    Total: 376345  Req/Sec: 25095.19
+    Total: 486635  Req/Sec: 32445.33
   Transfer:
-    Total: 295.61 MB Transfer Rate: 19.71 MB/Sec
+    Total: 381.02 MB Transfer Rate: 25.40 MB/Sec
 + --------------- + --------------- +
 |   Percentile    |   Avg Latency   |
 + --------------- + --------------- +
-|      99.9%      |    112.50ms     |
-|       99%       |     61.33ms     |
-|       95%       |     44.26ms     |
-|       90%       |     38.74ms     |
-|       75%       |     32.00ms     |
-|       50%       |     26.82ms     |
+|      99.9%      |     91.91ms     |
+|       99%       |     55.53ms     |
+|       95%       |     34.87ms     |
+|       90%       |     29.55ms     |
+|       75%       |     23.99ms     |
+|       50%       |     20.17ms     |
 + --------------- + --------------- +
-
-626 Errors: error shutting down connection: Socket is not connected (os error 57)
 
 sleep 3 secs
 ----------------------------
@@ -153,23 +151,21 @@ Beginning round 1...
 Benchmarking 512 connections @ http://localhost:8090 for 15 second(s)
   Latencies:
     Avg      Stdev    Min      Max
-    23.45ms  12.42ms  1.18ms   154.44ms
+    24.02ms  15.84ms  1.31ms   207.97ms
   Requests:
-    Total: 326685  Req/Sec: 21784.73
+    Total: 318516  Req/Sec: 21236.67
   Transfer:
-    Total: 265.22 MB Transfer Rate: 17.69 MB/Sec
+    Total: 259.11 MB Transfer Rate: 17.28 MB/Sec
 + --------------- + --------------- +
 |   Percentile    |   Avg Latency   |
 + --------------- + --------------- +
-|      99.9%      |     96.85ms     |
-|       99%       |     73.93ms     |
-|       95%       |     57.57ms     |
-|       90%       |     50.36ms     |
-|       75%       |     40.57ms     |
-|       50%       |     32.70ms     |
+|      99.9%      |    135.56ms     |
+|       99%       |     92.59ms     |
+|       95%       |     68.54ms     |
+|       90%       |     58.75ms     |
+|       75%       |     45.88ms     |
+|       50%       |     35.64ms     |
 + --------------- + --------------- +
-
-657 Errors: error shutting down connection: Socket is not connected (os error 57)
 
 sleep 3 secs
 ----------------------------
@@ -178,30 +174,26 @@ Beginning round 1...
 Benchmarking 512 connections @ http://localhost:8100 for 15 second(s)
   Latencies:
     Avg      Stdev    Min      Max
-    45.71ms  50.47ms  0.88ms   908.49ms
+    74.60ms  181.26ms  0.94ms   2723.20ms
   Requests:
-    Total: 166917  Req/Sec: 11129.80
+    Total: 101893  Req/Sec: 6792.16
   Transfer:
-    Total: 133.77 MB Transfer Rate: 8.92 MB/Sec
+    Total: 82.03 MB Transfer Rate: 5.47 MB/Sec
 + --------------- + --------------- +
 |   Percentile    |   Avg Latency   |
 + --------------- + --------------- +
-|      99.9%      |    608.92ms     |
-|       99%       |    351.18ms     |
-|       95%       |    210.56ms     |
-|       90%       |    162.68ms     |
-|       75%       |    106.97ms     |
-|       50%       |     73.90ms     |
+|      99.9%      |    2232.12ms    |
+|       99%       |    1517.73ms    |
+|       95%       |    624.63ms     |
+|       90%       |    406.69ms     |
+|       75%       |    222.42ms     |
+|       50%       |    133.46ms     |
 + --------------- + --------------- +
-
-646 Errors: error shutting down connection: Socket is not connected (os error 57)
-
-sleep 3 secs
 ```
 
 #### With Wrk for `rpxy`, `nginx`, `caddy` and `sozu`
 
-```
+```bash
 ----------------------------
 Benchmark [x86_64] with Wrk
 ----------------------------
@@ -209,12 +201,11 @@ Benchmark on rpxy
 Running 15s test @ http://localhost:8080
   4 threads and 512 connections
   Thread Stats   Avg      Stdev     Max   +/- Stdev
-    Latency    18.68ms    8.09ms 122.64ms   74.03%
-    Req/Sec     6.95k   815.23     8.45k    83.83%
-  414819 requests in 15.01s, 326.37MB read
-  Socket errors: connect 0, read 608, write 0, timeout 0
-Requests/sec:  27627.79
-Transfer/sec:     21.74MB
+    Latency    15.65ms    6.94ms 104.73ms   81.28%
+    Req/Sec     8.36k     0.90k    9.90k    77.83%
+  499550 requests in 15.02s, 391.14MB read
+Requests/sec:  33267.61
+Transfer/sec:     26.05MB
 
 sleep 3 secs
 ----------------------------
@@ -222,12 +213,11 @@ Benchmark on nginx
 Running 15s test @ http://localhost:8090
   4 threads and 512 connections
   Thread Stats   Avg      Stdev     Max   +/- Stdev
-    Latency    23.34ms   13.80ms 126.06ms   74.66%
-    Req/Sec     5.71k   607.41     7.07k    73.17%
-  341127 requests in 15.03s, 277.50MB read
-  Socket errors: connect 0, read 641, write 0, timeout 0
-Requests/sec:  22701.54
-Transfer/sec:     18.47MB
+    Latency    24.26ms   15.29ms 167.43ms   73.34%
+    Req/Sec     5.53k   493.14     6.91k    69.67%
+  330569 requests in 15.02s, 268.91MB read
+Requests/sec:  22014.96
+Transfer/sec:     17.91MB
 
 sleep 3 secs
 ----------------------------
@@ -235,13 +225,13 @@ Benchmark on caddy
 Running 15s test @ http://localhost:8100
   4 threads and 512 connections
   Thread Stats   Avg      Stdev     Max   +/- Stdev
-    Latency    54.19ms   55.63ms 674.53ms   88.55%
-    Req/Sec     2.92k     1.40k    5.57k    56.17%
-  174748 requests in 15.03s, 140.61MB read
-  Socket errors: connect 0, read 660, write 0, timeout 0
-  Non-2xx or 3xx responses: 70
-Requests/sec:  11624.63
-Transfer/sec:      9.35MB
+    Latency   212.89ms  300.23ms   1.99s    86.56%
+    Req/Sec     1.31k     1.64k    5.72k    78.79%
+  67749 requests in 15.04s, 51.97MB read
+  Socket errors: connect 0, read 0, write 0, timeout 222
+  Non-2xx or 3xx responses: 3686
+Requests/sec:   4505.12
+Transfer/sec:      3.46MB
 
 sleep 3 secs
 ----------------------------
@@ -249,10 +239,9 @@ Benchmark on sozu
 Running 15s test @ http://localhost:8110
   4 threads and 512 connections
   Thread Stats   Avg      Stdev     Max   +/- Stdev
-    Latency    19.78ms    4.89ms  98.09ms   76.88%
-    Req/Sec     6.49k   824.75     8.11k    76.17%
-  387744 requests in 15.02s, 329.11MB read
-  Socket errors: connect 0, read 647, write 0, timeout 0
-Requests/sec:  25821.93
-Transfer/sec:     21.92MB
+    Latency    34.68ms    6.30ms  90.21ms   72.49%
+    Req/Sec     3.69k   397.85     5.08k    73.00%
+  220655 requests in 15.01s, 187.29MB read
+Requests/sec:  14699.17
+Transfer/sec:     12.48MB
 ```

--- a/bench/README.md
+++ b/bench/README.md
@@ -98,7 +98,7 @@ Done at May 20, 2025
 
 ### Environment
 
-- `rpxy` commit id: `7c0945a5124418aa9a1024568c1989bb77cf312f`
+- `rpxy` commit id: `e259e0b58897258d98fdb7504a1cbcbd7c5b37db`
 - Docker Desktop 4.41.2 (192736)
 - ReWrk 0.3.2 and Wrk 0.4.2
 - iMac '27 (2020, 10-Core Intel Core i9, 128GB RAM)

--- a/bench/README.md
+++ b/bench/README.md
@@ -15,7 +15,7 @@ Done at May. 17, 2025
 - `rpxy` commit id: `e259e0b58897258d98fdb7504a1cbcbd7c5b37db`
 - Docker Desktop 4.41.2 (191736)
 - ReWrk 0.3.2
-- MacBook Pro '14 (2021, M1 Max, 64GB RAM)
+- Mac mini (2024, M4 Pro, 64GB RAM)
 
 The docker images of `nginx` and `caddy` for `linux/arm64/v8` are pulled from the official registry.
 
@@ -27,20 +27,20 @@ Beginning round 1...
 Benchmarking 512 connections @ http://localhost:8080 for 15 second(s)
   Latencies:
     Avg      Stdev    Min      Max
-    10.62ms  4.47ms   0.47ms   73.01ms
+    6.90ms   3.42ms   0.78ms   80.26ms
   Requests:
-    Total: 720148  Req/Sec: 48025.92
+    Total: 1107885 Req/Sec: 73866.03
   Transfer:
-    Total: 563.85 MB Transfer Rate: 37.60 MB/Sec
+    Total: 867.44 MB Transfer Rate: 57.83 MB/Sec
 + --------------- + --------------- +
 |   Percentile    |   Avg Latency   |
 + --------------- + --------------- +
-|      99.9%      |     54.78ms     |
-|       99%       |     35.86ms     |
-|       95%       |     23.09ms     |
-|       90%       |     19.82ms     |
-|       75%       |     16.14ms     |
-|       50%       |     13.54ms     |
+|      99.9%      |     49.76ms     |
+|       99%       |     29.57ms     |
+|       95%       |     15.78ms     |
+|       90%       |     13.05ms     |
+|       75%       |     10.41ms     |
+|       50%       |     8.72ms      |
 + --------------- + --------------- +
 
 sleep 3 secs
@@ -50,23 +50,23 @@ Beginning round 1...
 Benchmarking 512 connections @ http://localhost:8090 for 15 second(s)
   Latencies:
     Avg      Stdev    Min      Max
-    14.55ms  13.05ms  0.57ms   255.24ms
+    11.65ms  14.04ms  0.40ms   205.93ms
   Requests:
-    Total: 525866  Req/Sec: 35073.37
+    Total: 654978  Req/Sec: 43666.56
   Transfer:
-    Total: 427.78 MB Transfer Rate: 28.53 MB/Sec
+    Total: 532.81 MB Transfer Rate: 35.52 MB/Sec
 + --------------- + --------------- +
 |   Percentile    |   Avg Latency   |
 + --------------- + --------------- +
-|      99.9%      |    235.17ms     |
-|       99%       |     91.77ms     |
-|       95%       |     48.86ms     |
-|       90%       |     39.08ms     |
-|       75%       |     28.78ms     |
-|       50%       |     21.77ms     |
+|      99.9%      |    151.00ms     |
+|       99%       |    102.80ms     |
+|       95%       |     62.44ms     |
+|       90%       |     42.98ms     |
+|       75%       |     26.44ms     |
+|       50%       |     18.25ms     |
 + --------------- + --------------- +
 
-227 Errors: connection closed
+512 Errors: connection closed
 
 sleep 3 secs
 ----------------------------
@@ -75,20 +75,20 @@ Beginning round 1...
 Benchmarking 512 connections @ http://localhost:8100 for 15 second(s)
   Latencies:
     Avg      Stdev    Min      Max
-    70.44ms  220.19ms  0.67ms   4140.08ms
+    77.54ms  368.11ms  0.37ms   6770.73ms
   Requests:
-    Total:  79980  Req/Sec: 5334.74
+    Total:  86963  Req/Sec: 5798.35
   Transfer:
-    Total: 64.45 MB Transfer Rate: 4.30 MB/Sec
+    Total: 70.00 MB Transfer Rate: 4.67 MB/Sec
 + --------------- + --------------- +
 |   Percentile    |   Avg Latency   |
 + --------------- + --------------- +
-|      99.9%      |    3550.19ms    |
-|       99%       |    1847.80ms    |
-|       95%       |    672.82ms     |
-|       90%       |    440.34ms     |
-|       75%       |    224.81ms     |
-|       50%       |    128.79ms     |
+|      99.9%      |    5789.65ms    |
+|       99%       |    3407.02ms    |
+|       95%       |    1022.31ms    |
+|       90%       |    608.17ms     |
+|       75%       |    281.95ms     |
+|       50%       |    149.29ms     |
 + --------------- + --------------- +
 ```
 

--- a/bench/docker-compose.amd64.yml
+++ b/bench/docker-compose.amd64.yml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   nginx:
     image: nginx:alpine
@@ -28,7 +27,7 @@ services:
       dockerfile: docker/Dockerfile
     restart: unless-stopped
     environment:
-      - LOG_LEVEL=info
+      - LOG_LEVEL=error # almost nolog
       - LOG_TO_FILE=false
     ports:
       - 127.0.0.1:8080:8080
@@ -47,7 +46,7 @@ services:
     tty: false
     privileged: true
     volumes:
-      - ./nginx.conf:/etc/nginx/conf.d/default.conf:ro
+      - ./nginx.conf:/etc/nginx/conf.d/default.conf:ro # set as almost nolog
       - /var/run/docker.sock:/tmp/docker.sock:ro
     logging:
       options:
@@ -64,7 +63,7 @@ services:
     restart: unless-stopped
     tty: false
     volumes:
-      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro # set as almost no log
     networks:
       bench-nw:
 
@@ -82,7 +81,7 @@ services:
         max-size: "10m"
         max-file: "3"
     volumes:
-      - ./sozu-config.toml:/etc/sozu/config.toml
+      - ./sozu-config.toml:/etc/sozu/config.toml # set as almost nolog
     networks:
       bench-nw:
 

--- a/bench/docker-compose.yml
+++ b/bench/docker-compose.yml
@@ -28,7 +28,7 @@ services:
       dockerfile: docker/Dockerfile
     restart: unless-stopped
     environment:
-      - LOG_LEVEL=info
+      - LOG_LEVEL=error # almost nolog
       - LOG_TO_FILE=false
     ports:
       - 127.0.0.1:8080:8080
@@ -47,7 +47,7 @@ services:
     tty: false
     privileged: true
     volumes:
-      - ./nginx.conf:/etc/nginx/conf.d/default.conf:ro
+      - ./nginx.conf:/etc/nginx/conf.d/default.conf:ro # set as almost nolog
       - /var/run/docker.sock:/tmp/docker.sock:ro
     logging:
       options:
@@ -64,7 +64,7 @@ services:
     restart: unless-stopped
     tty: false
     volumes:
-      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro # set as almost no log
     networks:
       bench-nw:
 

--- a/bench/docker-compose.yml
+++ b/bench/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   nginx:
     image: nginx:alpine

--- a/bench/nginx.conf
+++ b/bench/nginx.conf
@@ -31,11 +31,14 @@
 #                  '"$request" $status $body_bytes_sent '
 #                  '"$http_referer" "$http_user_agent" '
 #                  '"$upstream_addr"';
-# access_log off;
+access_log off;
+
 # 		ssl_protocols TLSv1.2 TLSv1.3;
 # 		ssl_ciphers 'ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384';
 # 		ssl_prefer_server_ciphers off;
 # error_log /dev/stderr;
+error_log   /dev/null crit;
+
 # resolver 127.0.0.11;
 # # HTTP 1.1 support
 # proxy_http_version 1.1;

--- a/bench/sozu-config.toml
+++ b/bench/sozu-config.toml
@@ -1,4 +1,4 @@
-log_level = "info"
+log_level = "error"
 log_target = "stdout"
 max_connections = 512
 activate_listeners = true

--- a/config-example.toml
+++ b/config-example.toml
@@ -83,7 +83,8 @@ load_balance = "random" # or "round_robin" or "sticky" (sticky session) or "none
 upstream_options = [
   "upgrade_insecure_requests",
   "force_http11_upstream",
-  "set_upstream_host",         # overwrite HOST value with upstream hostname (like www.yahoo.com)
+  "set_upstream_host",        # overwrite HOST value with upstream hostname (like www.yahoo.com)
+  "forwarded_header"          # add Forwarded header (by default, this is not added. However, if the incoming request has Forwarded header, it would be preserved and updated)
 ]
 ######################################################################
 

--- a/docker/Dockerfile-slim
+++ b/docker/Dockerfile-slim
@@ -5,7 +5,7 @@ LABEL maintainer="Jun Kurihara"
 
 ARG TARGETARCH
 ARG CARGO_FEATURES
-ENV CARGO_FEATURES ${CARGO_FEATURES}
+ENV CARGO_FEATURES=${CARGO_FEATURES}
 
 RUN if [ $TARGETARCH = "amd64" ]; then \
   echo "x86_64" > /arch; \
@@ -22,7 +22,7 @@ WORKDIR /tmp
 
 COPY . /tmp/
 
-ENV RUSTFLAGS "-C link-arg=-s"
+ENV RUSTFLAGS="-C link-arg=-s"
 
 RUN echo "Building rpxy from source" && \
   cargo update && \
@@ -34,7 +34,7 @@ RUN echo "Building rpxy from source" && \
 FROM --platform=$TARGETPLATFORM alpine:latest AS runner
 LABEL maintainer="Jun Kurihara"
 
-ENV RUNTIME_DEPS logrotate ca-certificates su-exec
+ENV RUNTIME_DEPS="logrotate ca-certificates su-exec"
 
 RUN apk add --no-cache ${RUNTIME_DEPS} && \
   update-ca-certificates && \

--- a/rpxy-acme/Cargo.toml
+++ b/rpxy-acme/Cargo.toml
@@ -28,11 +28,14 @@ rustls = { version = "0.23.27", default-features = false, features = [
   "std",
   "aws_lc_rs",
 ] }
-rustls-platform-verifier = { version = "0.5.3" }
+rustls-platform-verifier = { version = "0.6.0" }
 rustls-acme = { path = "../submodules/rustls-acme/", default-features = false, features = [
   "aws-lc-rs",
 ] }
 rustls-post-quantum = { version = "0.2.2", optional = true }
-tokio = { version = "1.45.1", default-features = false }
+tokio = { version = "1.45.1", default-features = false, features = [
+  "rt",
+  "macros",
+] }
 tokio-util = { version = "0.7.15", default-features = false }
 tokio-stream = { version = "0.1.17", default-features = false }

--- a/rpxy-acme/Cargo.toml
+++ b/rpxy-acme/Cargo.toml
@@ -33,6 +33,6 @@ rustls-acme = { path = "../submodules/rustls-acme/", default-features = false, f
   "aws-lc-rs",
 ] }
 rustls-post-quantum = { version = "0.2.2", optional = true }
-tokio = { version = "1.45.0", default-features = false }
+tokio = { version = "1.45.1", default-features = false }
 tokio-util = { version = "0.7.15", default-features = false }
 tokio-stream = { version = "0.1.17", default-features = false }

--- a/rpxy-acme/Cargo.toml
+++ b/rpxy-acme/Cargo.toml
@@ -33,7 +33,7 @@ rustls-acme = { path = "../submodules/rustls-acme/", default-features = false, f
   "aws-lc-rs",
 ] }
 rustls-post-quantum = { version = "0.2.2", optional = true }
-tokio = { version = "1.46.0", default-features = false, features = [
+tokio = { version = "1.46.1", default-features = false, features = [
   "rt",
   "macros",
 ] }

--- a/rpxy-acme/Cargo.toml
+++ b/rpxy-acme/Cargo.toml
@@ -24,15 +24,15 @@ aws-lc-rs = { version = "1.13.0", default-features = false, features = [
   "aws-lc-sys",
 ] }
 blocking = "1.6.1"
-rustls = { version = "0.23.26", default-features = false, features = [
+rustls = { version = "0.23.27", default-features = false, features = [
   "std",
   "aws_lc_rs",
 ] }
-rustls-platform-verifier = { version = "0.5.2" }
+rustls-platform-verifier = { version = "0.5.3" }
 rustls-acme = { path = "../submodules/rustls-acme/", default-features = false, features = [
   "aws-lc-rs",
 ] }
 rustls-post-quantum = { version = "0.2.2", optional = true }
-tokio = { version = "1.44.2", default-features = false }
+tokio = { version = "1.45.0", default-features = false }
 tokio-util = { version = "0.7.15", default-features = false }
 tokio-stream = { version = "0.1.17", default-features = false }

--- a/rpxy-acme/Cargo.toml
+++ b/rpxy-acme/Cargo.toml
@@ -15,7 +15,7 @@ post-quantum = ["rustls-post-quantum"]
 
 [dependencies]
 url = { version = "2.5.4" }
-ahash = "0.8.11"
+ahash = "0.8.12"
 thiserror = "2.0.12"
 tracing = "0.1.41"
 async-trait = "0.1.88"

--- a/rpxy-acme/Cargo.toml
+++ b/rpxy-acme/Cargo.toml
@@ -20,7 +20,7 @@ thiserror = "2.0.12"
 tracing = "0.1.41"
 async-trait = "0.1.88"
 base64 = "0.22.1"
-aws-lc-rs = { version = "1.13.0", default-features = false, features = [
+aws-lc-rs = { version = "1.13.1", default-features = false, features = [
   "aws-lc-sys",
 ] }
 blocking = "1.6.1"

--- a/rpxy-acme/Cargo.toml
+++ b/rpxy-acme/Cargo.toml
@@ -24,7 +24,7 @@ aws-lc-rs = { version = "1.13.1", default-features = false, features = [
   "aws-lc-sys",
 ] }
 blocking = "1.6.1"
-rustls = { version = "0.23.27", default-features = false, features = [
+rustls = { version = "0.23.28", default-features = false, features = [
   "std",
   "aws_lc_rs",
 ] }

--- a/rpxy-acme/Cargo.toml
+++ b/rpxy-acme/Cargo.toml
@@ -33,7 +33,7 @@ rustls-acme = { path = "../submodules/rustls-acme/", default-features = false, f
   "aws-lc-rs",
 ] }
 rustls-post-quantum = { version = "0.2.2", optional = true }
-tokio = { version = "1.45.1", default-features = false, features = [
+tokio = { version = "1.46.0", default-features = false, features = [
   "rt",
   "macros",
 ] }

--- a/rpxy-acme/src/error.rs
+++ b/rpxy-acme/src/error.rs
@@ -12,4 +12,7 @@ pub enum RpxyAcmeError {
   /// IO error
   #[error("IO error: {0}")]
   Io(#[from] std::io::Error),
+  /// TLS client configuration error
+  #[error("TLS client configuration error: {0}")]
+  TlsClientConfig(String),
 }

--- a/rpxy-acme/src/manager.rs
+++ b/rpxy-acme/src/manager.rs
@@ -79,11 +79,7 @@ impl AcmeManager {
     &self,
     cancel_token: tokio_util::sync::CancellationToken,
   ) -> (Vec<tokio::task::JoinHandle<()>>, HashMap<String, Arc<ServerConfig>>) {
-    let rustls_client_config = rustls::ClientConfig::builder()
-      .dangerous() // The `Verifier` we're using is actually safe
-      .with_custom_certificate_verifier(Arc::new(rustls_platform_verifier::Verifier::new()))
-      .with_no_client_auth();
-    let rustls_client_config = Arc::new(rustls_client_config);
+    let rustls_client_config = Self::create_tls_client_config().expect("Failed to create TLS client configuration for ACME");
 
     let mut server_configs_for_challenge: HashMap<String, Arc<ServerConfig>> = HashMap::default();
     let join_handles = self
@@ -126,6 +122,26 @@ impl AcmeManager {
       .collect::<Vec<_>>();
 
     (join_handles, server_configs_for_challenge)
+  }
+
+  /// Creates a TLS client configuration with platform certificate verification.
+  ///
+  /// This configuration uses the system's certificate store for verification,
+  /// which is appropriate for ACME certificate validation.
+  fn create_tls_client_config() -> Result<Arc<rustls::ClientConfig>, RpxyAcmeError> {
+    let crypto_provider = rustls::crypto::CryptoProvider::get_default().ok_or(RpxyAcmeError::TlsClientConfig(
+      "No default crypto provider available".to_string(),
+    ))?;
+
+    let verifier = rustls_platform_verifier::Verifier::new(crypto_provider.clone())
+      .map_err(|e| RpxyAcmeError::TlsClientConfig(format!("Failed to create certificate verifier: {}", e)))?;
+
+    let client_config = rustls::ClientConfig::builder()
+      .dangerous() // Safe: using platform certificate verifier
+      .with_custom_certificate_verifier(Arc::new(verifier))
+      .with_no_client_auth();
+
+    Ok(Arc::new(client_config))
   }
 }
 

--- a/rpxy-bin/Cargo.toml
+++ b/rpxy-bin/Cargo.toml
@@ -47,10 +47,10 @@ async-trait = "0.1.88"
 futures-util = { version = "0.3.31", default-features = false }
 
 # config
-clap = { version = "4.5.37", features = ["std", "cargo", "wrap_help"] }
+clap = { version = "4.5.38", features = ["std", "cargo", "wrap_help"] }
 toml = { version = "0.8.22", default-features = false, features = ["parse"] }
 hot_reload = "0.1.9"
-serde_ignored = "0.1.11"
+serde_ignored = "0.1.12"
 
 # logging
 tracing = { version = "0.1.41" }

--- a/rpxy-bin/Cargo.toml
+++ b/rpxy-bin/Cargo.toml
@@ -13,8 +13,8 @@ publish.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = ["http3-quinn", "cache", "rustls-backend", "acme", "post-quantum"]
-# default = ["http3-s2n", "cache", "rustls-backend", "acme", "post-quantum"]
+# default = ["http3-quinn", "cache", "rustls-backend", "acme", "post-quantum"]
+default = ["http3-s2n", "cache", "rustls-backend", "acme", "post-quantum"]
 http3-quinn = ["rpxy-lib/http3-quinn"]
 http3-s2n = ["rpxy-lib/http3-s2n"]
 native-tls-backend = ["rpxy-lib/native-tls-backend"]

--- a/rpxy-bin/Cargo.toml
+++ b/rpxy-bin/Cargo.toml
@@ -46,7 +46,7 @@ mimalloc = { version = "0.1.47", default-features = false }
 anyhow = "1.0.98"
 ahash = "0.8.12"
 serde = { version = "1.0.219", default-features = false, features = ["derive"] }
-tokio = { version = "1.45.1", default-features = false, features = [
+tokio = { version = "1.46.0", default-features = false, features = [
   "net",
   "rt-multi-thread",
   "time",

--- a/rpxy-bin/Cargo.toml
+++ b/rpxy-bin/Cargo.toml
@@ -46,7 +46,7 @@ mimalloc = { version = "0.1.47", default-features = false }
 anyhow = "1.0.98"
 ahash = "0.8.12"
 serde = { version = "1.0.219", default-features = false, features = ["derive"] }
-tokio = { version = "1.46.0", default-features = false, features = [
+tokio = { version = "1.46.1", default-features = false, features = [
   "net",
   "rt-multi-thread",
   "time",

--- a/rpxy-bin/Cargo.toml
+++ b/rpxy-bin/Cargo.toml
@@ -35,7 +35,7 @@ libmimalloc-sys = { version = "=0.1.40" }
 anyhow = "1.0.98"
 ahash = "0.8.11"
 serde = { version = "1.0.219", default-features = false, features = ["derive"] }
-tokio = { version = "1.44.2", default-features = false, features = [
+tokio = { version = "1.45.0", default-features = false, features = [
   "net",
   "rt-multi-thread",
   "time",

--- a/rpxy-bin/Cargo.toml
+++ b/rpxy-bin/Cargo.toml
@@ -35,7 +35,7 @@ libmimalloc-sys = { version = "=0.1.40" }
 anyhow = "1.0.98"
 ahash = "0.8.12"
 serde = { version = "1.0.219", default-features = false, features = ["derive"] }
-tokio = { version = "1.45.0", default-features = false, features = [
+tokio = { version = "1.45.1", default-features = false, features = [
   "net",
   "rt-multi-thread",
   "time",

--- a/rpxy-bin/Cargo.toml
+++ b/rpxy-bin/Cargo.toml
@@ -43,7 +43,6 @@ sticky-cookie = ["rpxy-lib/sticky-cookie"]
 rpxy-lib = { path = "../rpxy-lib/", default-features = false }
 
 mimalloc = { version = "0.1.47", default-features = false }
-libmimalloc-sys = { version = "0.1.43" }
 anyhow = "1.0.98"
 ahash = "0.8.12"
 serde = { version = "1.0.219", default-features = false, features = ["derive"] }

--- a/rpxy-bin/Cargo.toml
+++ b/rpxy-bin/Cargo.toml
@@ -13,8 +13,8 @@ publish.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-# default = ["http3-quinn", "cache", "rustls-backend", "acme", "post-quantum"]
-default = ["http3-s2n", "cache", "rustls-backend", "acme", "post-quantum"]
+default = ["http3-quinn", "cache", "rustls-backend", "acme", "post-quantum"]
+# default = ["http3-s2n", "cache", "rustls-backend", "acme", "post-quantum"]
 http3-quinn = ["rpxy-lib/http3-quinn"]
 http3-s2n = ["rpxy-lib/http3-s2n"]
 native-tls-backend = ["rpxy-lib/native-tls-backend"]

--- a/rpxy-bin/Cargo.toml
+++ b/rpxy-bin/Cargo.toml
@@ -60,7 +60,7 @@ async-trait = "0.1.88"
 futures-util = { version = "0.3.31", default-features = false }
 
 # config
-clap = { version = "4.5.39", features = ["std", "cargo", "wrap_help"] }
+clap = { version = "4.5.40", features = ["std", "cargo", "wrap_help"] }
 toml = { version = "0.8.23", default-features = false, features = ["parse"] }
 hot_reload = "0.1.9"
 serde_ignored = "0.1.12"

--- a/rpxy-bin/Cargo.toml
+++ b/rpxy-bin/Cargo.toml
@@ -33,7 +33,7 @@ rpxy-lib = { path = "../rpxy-lib/", default-features = false, features = [
 mimalloc = { version = "=0.1.44", default-features = false }
 libmimalloc-sys = { version = "=0.1.40" }
 anyhow = "1.0.98"
-ahash = "0.8.11"
+ahash = "0.8.12"
 serde = { version = "1.0.219", default-features = false, features = ["derive"] }
 tokio = { version = "1.45.0", default-features = false, features = [
   "net",

--- a/rpxy-bin/Cargo.toml
+++ b/rpxy-bin/Cargo.toml
@@ -61,7 +61,7 @@ futures-util = { version = "0.3.31", default-features = false }
 # config
 clap = { version = "4.5.40", features = ["std", "cargo", "wrap_help"] }
 toml = { version = "0.8.23", default-features = false, features = ["parse"] }
-hot_reload = "0.1.9"
+hot_reload = "0.2.0"
 serde_ignored = "0.1.12"
 
 # logging

--- a/rpxy-bin/Cargo.toml
+++ b/rpxy-bin/Cargo.toml
@@ -13,8 +13,22 @@ publish.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = ["http3-quinn", "cache", "rustls-backend", "acme", "post-quantum"]
-# default = ["http3-s2n", "cache", "rustls-backend", "acme", "post-quantum"]
+default = [
+  "http3-quinn",
+  "cache",
+  "rustls-backend",
+  "sticky-cookie",
+  "acme",
+  "post-quantum",
+]
+# default = [
+#   "http3-s2n",
+#   "cache",
+#   "rustls-backend",
+#   "sticky-cookie",
+#   "acme",
+#   "post-quantum",
+# ]
 http3-quinn = ["rpxy-lib/http3-quinn"]
 http3-s2n = ["rpxy-lib/http3-s2n"]
 native-tls-backend = ["rpxy-lib/native-tls-backend"]
@@ -23,11 +37,10 @@ webpki-roots = ["rpxy-lib/webpki-roots"]
 cache = ["rpxy-lib/cache"]
 acme = ["rpxy-lib/acme", "rpxy-acme"]
 post-quantum = ["rpxy-lib/post-quantum"]
+sticky-cookie = ["rpxy-lib/sticky-cookie"]
 
 [dependencies]
-rpxy-lib = { path = "../rpxy-lib/", default-features = false, features = [
-  "sticky-cookie",
-] }
+rpxy-lib = { path = "../rpxy-lib/", default-features = false }
 
 # TODO: pin mimalloc due to compilation failure by musl
 mimalloc = { version = "=0.1.44", default-features = false }

--- a/rpxy-bin/Cargo.toml
+++ b/rpxy-bin/Cargo.toml
@@ -42,9 +42,8 @@ sticky-cookie = ["rpxy-lib/sticky-cookie"]
 [dependencies]
 rpxy-lib = { path = "../rpxy-lib/", default-features = false }
 
-# TODO: pin mimalloc due to compilation failure by musl
-mimalloc = { version = "=0.1.44", default-features = false }
-libmimalloc-sys = { version = "=0.1.40" }
+mimalloc = { version = "0.1.47", default-features = false }
+libmimalloc-sys = { version = "0.1.43" }
 anyhow = "1.0.98"
 ahash = "0.8.12"
 serde = { version = "1.0.219", default-features = false, features = ["derive"] }

--- a/rpxy-bin/Cargo.toml
+++ b/rpxy-bin/Cargo.toml
@@ -47,7 +47,7 @@ async-trait = "0.1.88"
 futures-util = { version = "0.3.31", default-features = false }
 
 # config
-clap = { version = "4.5.38", features = ["std", "cargo", "wrap_help"] }
+clap = { version = "4.5.39", features = ["std", "cargo", "wrap_help"] }
 toml = { version = "0.8.22", default-features = false, features = ["parse"] }
 hot_reload = "0.1.9"
 serde_ignored = "0.1.12"

--- a/rpxy-bin/Cargo.toml
+++ b/rpxy-bin/Cargo.toml
@@ -61,7 +61,7 @@ futures-util = { version = "0.3.31", default-features = false }
 
 # config
 clap = { version = "4.5.39", features = ["std", "cargo", "wrap_help"] }
-toml = { version = "0.8.22", default-features = false, features = ["parse"] }
+toml = { version = "0.8.23", default-features = false, features = ["parse"] }
 hot_reload = "0.1.9"
 serde_ignored = "0.1.12"
 

--- a/rpxy-bin/src/config/parse.rs
+++ b/rpxy-bin/src/config/parse.rs
@@ -1,4 +1,4 @@
-use super::toml::ConfigToml;
+use super::toml::{ConfigToml, ConfigTomlExt};
 use crate::error::{anyhow, ensure};
 use ahash::HashMap;
 use clap::Arg;
@@ -52,8 +52,6 @@ pub fn parse_opts() -> Result<Opts, anyhow::Error> {
     log_dir_path,
   })
 }
-
-use super::toml::ConfigTomlExt;
 
 /// Build proxy and app settings from config using ConfigTomlExt
 pub fn build_settings(config: &ConfigToml) -> Result<(ProxyConfig, AppConfigList), anyhow::Error> {

--- a/rpxy-bin/src/config/parse.rs
+++ b/rpxy-bin/src/config/parse.rs
@@ -4,18 +4,26 @@ use ahash::HashMap;
 use clap::Arg;
 use hot_reload::{ReloaderReceiver, ReloaderService};
 use rpxy_certs::{CryptoFileSourceBuilder, CryptoReloader, ServerCryptoBase, build_cert_reloader};
-use rpxy_lib::{AppConfig, AppConfigList, ProxyConfig};
+use rpxy_lib::{AppConfigList, ProxyConfig};
 
 #[cfg(feature = "acme")]
 use rpxy_acme::{ACME_DIR_URL, ACME_REGISTRY_PATH, AcmeManager};
 
-/// Parsed options
+/// Parsed options from CLI
+/// Options for configuring the application.
+///
+/// # Fields
+/// - `config_file_path`: Path to the configuration file.
+/// - `log_dir_path`: Optional path to the log directory.
 pub struct Opts {
   pub config_file_path: String,
   pub log_dir_path: Option<String>,
 }
 
-/// Parse arg values passed from cli
+/// Parses command-line arguments into an [`Opts`](rpxy-bin/src/config/parse.rs:13) struct.
+///
+/// Returns a populated [`Opts`](rpxy-bin/src/config/parse.rs:13) on success, or an error if parsing fails.
+/// Expects a required `--config` argument and an optional `--log-dir` argument.
 pub fn parse_opts() -> Result<Opts, anyhow::Error> {
   let _ = include_str!("../../Cargo.toml");
   let options = clap::command!()
@@ -36,7 +44,6 @@ pub fn parse_opts() -> Result<Opts, anyhow::Error> {
     );
   let matches = options.get_matches();
 
-  ///////////////////////////////////
   let config_file_path = matches.get_one::<String>("config_file").unwrap().to_owned();
   let log_dir_path = matches.get_one::<String>("log_dir").map(|v| v.to_owned());
 
@@ -46,63 +53,45 @@ pub fn parse_opts() -> Result<Opts, anyhow::Error> {
   })
 }
 
-pub fn build_settings(config: &ConfigToml) -> std::result::Result<(ProxyConfig, AppConfigList), anyhow::Error> {
-  // build proxy config
-  let proxy_config: ProxyConfig = config.try_into()?;
+use super::toml::ConfigTomlExt;
 
-  // backend_apps
-  let apps = config.apps.clone().ok_or(anyhow!("Missing application spec"))?;
-
-  // assertions for all backend apps
-  ensure!(!apps.0.is_empty(), "Wrong application spec.");
-  // if only https_port is specified, tls must be configured for all apps
-  if proxy_config.http_port.is_none() {
-    ensure!(
-      apps.0.iter().all(|(_, app)| app.tls.is_some()),
-      "Some apps serves only plaintext HTTP"
-    );
-  }
-  // https redirection port must be configured only when both http_port and https_port are configured.
-  if proxy_config.https_redirection_port.is_some() {
-    ensure!(
-      proxy_config.https_port.is_some() && proxy_config.http_port.is_some(),
-      "https_redirection_port can be specified only when both http_port and https_port are specified"
-    );
-  }
-  // https redirection can be configured if both ports are active
-  if !(proxy_config.https_port.is_some() && proxy_config.http_port.is_some()) {
-    ensure!(
-      apps.0.iter().all(|(_, app)| {
-        if let Some(tls) = app.tls.as_ref() {
-          tls.https_redirection.is_none()
-        } else {
-          true
-        }
-      }),
-      "https_redirection can be specified only when both http_port and https_port are specified"
-    );
-  }
-
-  // build applications
-  let mut app_config_list_inner = Vec::<AppConfig>::new();
-
-  for (app_name, app) in apps.0.iter() {
-    let _server_name_string = app.server_name.as_ref().ok_or(anyhow!("No server name"))?;
-    let registered_app_name = app_name.to_ascii_lowercase();
-    let app_config = app.build_app_config(&registered_app_name)?;
-    app_config_list_inner.push(app_config);
-  }
-
-  let app_config_list = AppConfigList {
-    inner: app_config_list_inner,
-    default_app: config.default_app.clone().map(|v| v.to_ascii_lowercase()), // default backend application for plaintext http requests
-  };
-
-  Ok((proxy_config, app_config_list))
+/// Build proxy and app settings from config using ConfigTomlExt
+pub fn build_settings(config: &ConfigToml) -> Result<(ProxyConfig, AppConfigList), anyhow::Error> {
+  config.validate_and_build_settings()
 }
 
 /* ----------------------- */
+
+/// Helper to build a CryptoFileSource for an app, handling ACME if enabled
+#[cfg(feature = "acme")]
+fn build_tls_for_app_acme(
+  tls: &mut super::toml::TlsOption,
+  acme_option: &Option<super::toml::AcmeOption>,
+  server_name: &str,
+  acme_registry_path: &str,
+  acme_dir_url: &str,
+) -> Result<(), anyhow::Error> {
+  if let Some(true) = tls.acme {
+    ensure!(acme_option.is_some() && tls.tls_cert_key_path.is_none() && tls.tls_cert_path.is_none());
+    let subdir = format!("{}/{}", acme_registry_path, server_name.to_ascii_lowercase());
+    let file_name =
+      rpxy_acme::DirCache::cached_cert_file_name(&[server_name.to_ascii_lowercase()], acme_dir_url.to_ascii_lowercase());
+    let cert_path = format!("{}/{}", subdir, file_name);
+    tls.tls_cert_key_path = Some(cert_path.clone());
+    tls.tls_cert_path = Some(cert_path);
+  }
+  Ok(())
+}
+
 /// Build cert map
+/// Builds the certificate manager for TLS applications.
+///
+/// # Arguments
+/// * `config` - Reference to the parsed configuration.
+///
+/// # Returns
+/// Returns an option containing a tuple of certificate reloader service and receiver, or `None` if TLS is not enabled.
+/// Returns an error if configuration is invalid or required fields are missing.
 pub async fn build_cert_manager(
   config: &ConfigToml,
 ) -> Result<
@@ -139,19 +128,9 @@ pub async fn build_cert_manager(
       ensure!(tls.tls_cert_key_path.is_some() && tls.tls_cert_path.is_some());
 
       #[cfg(feature = "acme")]
-      let tls = {
-        let mut tls = tls.clone();
-        if let Some(true) = tls.acme {
-          ensure!(acme_option.is_some() && tls.tls_cert_key_path.is_none() && tls.tls_cert_path.is_none());
-          // Both of tls_cert_key_path and tls_cert_path must be the same for ACME since it's a single file
-          let subdir = format!("{}/{}", acme_registry_path, server_name.to_ascii_lowercase());
-          let file_name =
-            rpxy_acme::DirCache::cached_cert_file_name(&[server_name.to_ascii_lowercase()], acme_dir_url.to_ascii_lowercase());
-          tls.tls_cert_key_path = Some(format!("{}/{}", subdir, file_name));
-          tls.tls_cert_path = Some(format!("{}/{}", subdir, file_name));
-        }
-        tls
-      };
+      let mut tls = tls.clone();
+      #[cfg(feature = "acme")]
+      build_tls_for_app_acme(&mut tls, &acme_option, server_name, acme_registry_path, acme_dir_url)?;
 
       let crypto_file_source = CryptoFileSourceBuilder::default()
         .tls_cert_path(tls.tls_cert_path.as_ref().unwrap())
@@ -168,24 +147,31 @@ pub async fn build_cert_manager(
 /* ----------------------- */
 #[cfg(feature = "acme")]
 /// Build acme manager
+/// Builds the ACME manager for automatic certificate management (enabled with the `acme` feature).
+///
+/// # Arguments
+/// * `config` - Reference to the parsed configuration.
+/// * `runtime_handle` - Tokio runtime handle for async operations.
+///
+/// # Returns
+/// Returns an option containing an [`AcmeManager`](rpxy-bin/src/config/parse.rs:153) if ACME is configured, or `None` otherwise.
+/// Returns an error if configuration is invalid or required fields are missing.
 pub async fn build_acme_manager(
   config: &ConfigToml,
   runtime_handle: tokio::runtime::Handle,
 ) -> Result<Option<AcmeManager>, anyhow::Error> {
   let acme_option = config.experimental.as_ref().and_then(|v| v.acme.clone());
-  if acme_option.is_none() {
+  let Some(acme_option) = acme_option else {
     return Ok(None);
-  }
-  let acme_option = acme_option.unwrap();
+  };
 
-  let domains = config
+  let domains: Vec<String> = config
     .apps
     .as_ref()
     .unwrap()
     .0
     .values()
     .filter_map(|app| {
-      //
       if let Some(tls) = app.tls.as_ref() {
         if let Some(true) = tls.acme {
           return Some(app.server_name.as_ref().unwrap().to_owned());
@@ -193,7 +179,7 @@ pub async fn build_acme_manager(
       }
       None
     })
-    .collect::<Vec<_>>();
+    .collect();
 
   if domains.is_empty() {
     return Ok(None);

--- a/rpxy-bin/src/constants.rs
+++ b/rpxy-bin/src/constants.rs
@@ -1,9 +1,12 @@
+/// Default IPv4 listen addresses for the server.
 pub const LISTEN_ADDRESSES_V4: &[&str] = &["0.0.0.0"];
+/// Default IPv6 listen addresses for the server.
 pub const LISTEN_ADDRESSES_V6: &[&str] = &["[::]"];
+/// Delay in seconds before reloading the configuration after changes.
 pub const CONFIG_WATCH_DELAY_SECS: u32 = 15;
 
 #[cfg(feature = "cache")]
-// Cache directory
+/// Directory path for cache storage (enabled with "cache" feature).
 pub const CACHE_DIR: &str = "./cache";
 
 pub(crate) const ACCESS_LOG_FILE: &str = "access.log";

--- a/rpxy-bin/src/error.rs
+++ b/rpxy-bin/src/error.rs
@@ -1,2 +1,2 @@
 #[allow(unused)]
-pub use anyhow::{anyhow, bail, ensure, Context};
+pub use anyhow::{Context, anyhow, bail, ensure};

--- a/rpxy-bin/src/log.rs
+++ b/rpxy-bin/src/log.rs
@@ -8,92 +8,92 @@ pub use tracing::{debug, error, info, warn};
 
 /// Initialize the logger with the RUST_LOG environment variable.
 pub fn init_logger(log_dir_path: Option<&str>) {
-  let level_string = std::env::var("RUST_LOG").unwrap_or_else(|_| "info".to_string());
-  let level = tracing::Level::from_str(level_string.as_str()).unwrap_or(tracing::Level::INFO);
+  let level = std::env::var("RUST_LOG")
+    .ok()
+    .and_then(|s| tracing::Level::from_str(&s).ok())
+    .unwrap_or(tracing::Level::INFO);
 
   match log_dir_path {
-    // log to stdout
     None => init_stdio_logger(level),
-    // log to files
-    Some(log_dir_path) => init_file_logger(level, log_dir_path),
+    Some(path) => init_file_logger(level, path),
   }
 }
 
 /// file logging
 fn init_file_logger(level: tracing::Level, log_dir_path: &str) {
-  println!("Activate logging to files: {log_dir_path}");
-  let log_dir_path = std::path::PathBuf::from(log_dir_path);
-  // create the directory if it does not exist
-  if !log_dir_path.exists() {
-    println!("Directory does not exist, creating: {}", log_dir_path.display());
-    std::fs::create_dir_all(&log_dir_path).expect("Failed to create log directory");
+  println!("Activate logging to files: {}", log_dir_path);
+  let log_dir = std::path::Path::new(log_dir_path);
+
+  if !log_dir.exists() {
+    println!("Directory does not exist, creating: {}", log_dir.display());
+    std::fs::create_dir_all(log_dir).expect("Failed to create log directory");
   }
-  let access_log_path = log_dir_path.join(ACCESS_LOG_FILE);
-  let system_log_path = log_dir_path.join(SYSTEM_LOG_FILE);
+
+  let access_log_path = log_dir.join(ACCESS_LOG_FILE);
+  let system_log_path = log_dir.join(SYSTEM_LOG_FILE);
+
   println!("Access log: {}", access_log_path.display());
   println!("System and error log: {}", system_log_path.display());
 
   let access_log = open_log_file(&access_log_path);
   let system_log = open_log_file(&system_log_path);
 
-  let reg = tracing_subscriber::registry();
-
-  let access_log_base = fmt::layer()
+  let access_layer = fmt::layer()
     .with_line_number(false)
     .with_thread_ids(false)
     .with_thread_names(false)
     .with_target(false)
     .with_level(false)
     .compact()
-    .with_ansi(false);
-  let reg = reg.with(access_log_base.with_writer(access_log).with_filter(AccessLogFilter));
+    .with_ansi(false)
+    .with_writer(access_log)
+    .with_filter(AccessLogFilter);
 
-  let system_log_base = fmt::layer()
+  let system_layer = fmt::layer()
     .with_line_number(false)
     .with_thread_ids(false)
     .with_thread_names(false)
     .with_target(false)
-    .with_level(true) // with level for system log
+    .with_level(true)
     .compact()
-    .with_ansi(false);
-  let reg = reg.with(
-    system_log_base
-      .with_writer(system_log)
-      .with_filter(filter_fn(move |metadata| {
-        (is_cargo_pkg(metadata) && metadata.name() != log_event_names::ACCESS_LOG && metadata.level() <= &level)
-          || metadata.level() <= &tracing::Level::WARN.min(level)
-      })),
-  );
+    .with_ansi(false)
+    .with_writer(system_log)
+    .with_filter(filter_fn(move |metadata| {
+      (is_cargo_pkg(metadata) && metadata.name() != log_event_names::ACCESS_LOG && metadata.level() <= &level)
+        || metadata.level() <= &tracing::Level::WARN.min(level)
+    }));
 
-  reg.init();
+  tracing_subscriber::registry().with(access_layer).with(system_layer).init();
 }
 
 /// stdio logging
 fn init_stdio_logger(level: tracing::Level) {
-  // This limits the logger to emits only this crate with any level above RUST_LOG, for included crates it will emit only ERROR (in prod)/INFO (in dev) or above level.
-  let stdio_layer = fmt::layer().with_level(true).with_thread_ids(false);
-  if level <= tracing::Level::INFO {
-    // in normal deployment environment
-    let stdio_layer = stdio_layer
-      .with_target(false)
-      .compact()
-      .with_filter(filter_fn(move |metadata| {
-        (is_cargo_pkg(metadata) && metadata.level() <= &level) || metadata.level() <= &tracing::Level::WARN.min(level)
-      }));
-    tracing_subscriber::registry().with(stdio_layer).init();
-  } else {
-    // debugging
-    let stdio_layer = stdio_layer
+  // This limits the logger to emit only this crate with any level above RUST_LOG,
+  // for included crates it will emit only ERROR (in prod)/INFO (in dev) or above level.
+  let base_layer = fmt::layer().with_level(true).with_thread_ids(false);
+
+  let debug = level > tracing::Level::INFO;
+  let filter = filter_fn(move |metadata| {
+    if debug {
+      (is_cargo_pkg(metadata) && metadata.level() <= &level) || metadata.level() <= &tracing::Level::INFO.min(level)
+    } else {
+      (is_cargo_pkg(metadata) && metadata.level() <= &level) || metadata.level() <= &tracing::Level::WARN.min(level)
+    }
+  });
+
+  let stdio_layer = if debug {
+    base_layer
       .with_line_number(true)
       .with_target(true)
       .with_thread_names(true)
       .with_target(true)
       .compact()
-      .with_filter(filter_fn(move |metadata| {
-        (is_cargo_pkg(metadata) && metadata.level() <= &level) || metadata.level() <= &tracing::Level::INFO.min(level)
-      }));
-    tracing_subscriber::registry().with(stdio_layer).init();
+      .with_filter(filter)
+  } else {
+    base_layer.with_target(false).compact().with_filter(filter)
   };
+
+  tracing_subscriber::registry().with(stdio_layer).init();
 }
 
 /// Access log filter
@@ -110,7 +110,7 @@ fn open_log_file<P>(path: P) -> std::fs::File
 where
   P: AsRef<std::path::Path>,
 {
-  // crate a file if it does not exist
+  // create a file if it does not exist
   std::fs::OpenOptions::new()
     .create(true)
     .append(true)
@@ -119,9 +119,8 @@ where
 }
 
 #[inline]
-/// Mached with cargo package name with `_` instead of `-`
+/// Matches cargo package name with `_` instead of `-`
 fn is_cargo_pkg(metadata: &tracing::Metadata<'_>) -> bool {
-  metadata
-    .target()
-    .starts_with(env!("CARGO_PKG_NAME").replace('-', "_").as_str())
+  let pkg_name = env!("CARGO_PKG_NAME").replace('-', "_");
+  metadata.target().starts_with(&pkg_name)
 }

--- a/rpxy-bin/src/log.rs
+++ b/rpxy-bin/src/log.rs
@@ -1,7 +1,7 @@
 use crate::constants::{ACCESS_LOG_FILE, SYSTEM_LOG_FILE};
 use rpxy_lib::log_event_names;
 use std::str::FromStr;
-use tracing_subscriber::{fmt, prelude::*};
+use tracing_subscriber::{filter::filter_fn, fmt, prelude::*};
 
 #[allow(unused)]
 pub use tracing::{debug, error, info, warn};
@@ -12,20 +12,16 @@ pub fn init_logger(log_dir_path: Option<&str>) {
   let level = tracing::Level::from_str(level_string.as_str()).unwrap_or(tracing::Level::INFO);
 
   match log_dir_path {
-    None => {
-      // log to stdout
-      init_stdio_logger(level);
-    }
-    Some(log_dir_path) => {
-      // log to files
-      println!("Activate logging to files: {log_dir_path}");
-      init_file_logger(level, log_dir_path);
-    }
+    // log to stdout
+    None => init_stdio_logger(level),
+    // log to files
+    Some(log_dir_path) => init_file_logger(level, log_dir_path),
   }
 }
 
-/// file logging TODO:
+/// file logging
 fn init_file_logger(level: tracing::Level, log_dir_path: &str) {
+  println!("Activate logging to files: {log_dir_path}");
   let log_dir_path = std::path::PathBuf::from(log_dir_path);
   // create the directory if it does not exist
   if !log_dir_path.exists() {
@@ -63,12 +59,8 @@ fn init_file_logger(level: tracing::Level, log_dir_path: &str) {
   let reg = reg.with(
     system_log_base
       .with_writer(system_log)
-      .with_filter(tracing_subscriber::filter::filter_fn(move |metadata| {
-        (metadata
-          .target()
-          .starts_with(env!("CARGO_PKG_NAME").replace('-', "_").as_str())
-          && metadata.name() != log_event_names::ACCESS_LOG
-          && metadata.level() <= &level)
+      .with_filter(filter_fn(move |metadata| {
+        (is_cargo_pkg(metadata) && metadata.name() != log_event_names::ACCESS_LOG && metadata.level() <= &level)
           || metadata.level() <= &tracing::Level::WARN.min(level)
       })),
   );
@@ -85,12 +77,8 @@ fn init_stdio_logger(level: tracing::Level) {
     let stdio_layer = stdio_layer
       .with_target(false)
       .compact()
-      .with_filter(tracing_subscriber::filter::filter_fn(move |metadata| {
-        (metadata
-          .target()
-          .starts_with(env!("CARGO_PKG_NAME").replace('-', "_").as_str())
-          && metadata.level() <= &level)
-          || metadata.level() <= &tracing::Level::WARN.min(level)
+      .with_filter(filter_fn(move |metadata| {
+        (is_cargo_pkg(metadata) && metadata.level() <= &level) || metadata.level() <= &tracing::Level::WARN.min(level)
       }));
     tracing_subscriber::registry().with(stdio_layer).init();
   } else {
@@ -101,12 +89,8 @@ fn init_stdio_logger(level: tracing::Level) {
       .with_thread_names(true)
       .with_target(true)
       .compact()
-      .with_filter(tracing_subscriber::filter::filter_fn(move |metadata| {
-        (metadata
-          .target()
-          .starts_with(env!("CARGO_PKG_NAME").replace('-', "_").as_str())
-          && metadata.level() <= &level)
-          || metadata.level() <= &tracing::Level::INFO.min(level)
+      .with_filter(filter_fn(move |metadata| {
+        (is_cargo_pkg(metadata) && metadata.level() <= &level) || metadata.level() <= &tracing::Level::INFO.min(level)
       }));
     tracing_subscriber::registry().with(stdio_layer).init();
   };
@@ -116,11 +100,7 @@ fn init_stdio_logger(level: tracing::Level) {
 struct AccessLogFilter;
 impl<S> tracing_subscriber::layer::Filter<S> for AccessLogFilter {
   fn enabled(&self, metadata: &tracing::Metadata<'_>, _: &tracing_subscriber::layer::Context<'_, S>) -> bool {
-    metadata
-      .target()
-      .starts_with(env!("CARGO_PKG_NAME").replace('-', "_").as_str())
-      && metadata.name().contains(log_event_names::ACCESS_LOG)
-      && metadata.level() <= &tracing::Level::INFO
+    is_cargo_pkg(metadata) && metadata.name().contains(log_event_names::ACCESS_LOG) && metadata.level() <= &tracing::Level::INFO
   }
 }
 
@@ -136,4 +116,12 @@ where
     .append(true)
     .open(path)
     .expect("Failed to open the log file")
+}
+
+#[inline]
+/// Mached with cargo package name with `_` instead of `-`
+fn is_cargo_pkg(metadata: &tracing::Metadata<'_>) -> bool {
+  metadata
+    .target()
+    .starts_with(env!("CARGO_PKG_NAME").replace('-', "_").as_str())
 }

--- a/rpxy-bin/src/main.rs
+++ b/rpxy-bin/src/main.rs
@@ -71,6 +71,7 @@ struct RpxyService {
 }
 
 impl RpxyService {
+  /// Create a new RpxyService from config and runtime handle.
   async fn new(config_toml: &ConfigToml, runtime_handle: tokio::runtime::Handle) -> Result<Self, anyhow::Error> {
     let (proxy_conf, app_conf) = build_settings(config_toml).map_err(|e| anyhow!("Invalid configuration: {e}"))?;
 
@@ -80,7 +81,7 @@ impl RpxyService {
       .map(|(s, r)| (Some(Arc::new(s)), Some(r)))
       .unwrap_or((None, None));
 
-    Ok(RpxyService {
+    Ok(Self {
       runtime_handle: runtime_handle.clone(),
       proxy_conf,
       app_conf,

--- a/rpxy-bin/src/main.rs
+++ b/rpxy-bin/src/main.rs
@@ -33,10 +33,9 @@ fn main() {
 
     init_logger(parsed_opts.log_dir_path.as_deref());
 
-    let (config_service, config_rx) = ReloaderService::<ConfigTomlReloader, ConfigToml, String>::new(
+    let (config_service, config_rx) = ReloaderService::<ConfigTomlReloader, ConfigToml, String>::with_delay(
       &parsed_opts.config_file_path,
       CONFIG_WATCH_DELAY_SECS,
-      false,
     )
     .await
     .unwrap();
@@ -256,7 +255,7 @@ async fn rpxy_service(
       }
       /* ---------- */
       _ = config_rx.changed() => {
-        let Some(new_config_toml) = config_rx.borrow().clone() else {
+        let Some(new_config_toml) = config_rx.get() else {
           error!("Something wrong in config reloader receiver");
           return Err(anyhow!("Something wrong in config reloader receiver"));
         };

--- a/rpxy-certs/Cargo.toml
+++ b/rpxy-certs/Cargo.toml
@@ -35,7 +35,7 @@ rustls-post-quantum = { version = "0.2.2", optional = true }
 x509-parser = { version = "0.17.0" }
 
 [dev-dependencies]
-tokio = { version = "1.45.1", default-features = false, features = [
+tokio = { version = "1.46.0", default-features = false, features = [
   "rt-multi-thread",
   "macros",
 ] }

--- a/rpxy-certs/Cargo.toml
+++ b/rpxy-certs/Cargo.toml
@@ -22,7 +22,7 @@ derive_builder = { version = "0.20.2" }
 thiserror = { version = "2.0.12" }
 hot_reload = { version = "0.1.9" }
 async-trait = { version = "0.1.88" }
-rustls = { version = "0.23.27", default-features = false, features = [
+rustls = { version = "0.23.28", default-features = false, features = [
   "std",
   "aws_lc_rs",
 ] }

--- a/rpxy-certs/Cargo.toml
+++ b/rpxy-certs/Cargo.toml
@@ -35,7 +35,7 @@ rustls-post-quantum = { version = "0.2.2", optional = true }
 x509-parser = { version = "0.17.0" }
 
 [dev-dependencies]
-tokio = { version = "1.46.0", default-features = false, features = [
+tokio = { version = "1.46.1", default-features = false, features = [
   "rt-multi-thread",
   "macros",
 ] }

--- a/rpxy-certs/Cargo.toml
+++ b/rpxy-certs/Cargo.toml
@@ -20,7 +20,7 @@ ahash = { version = "0.8.12" }
 tracing = { version = "0.1.41" }
 derive_builder = { version = "0.20.2" }
 thiserror = { version = "2.0.12" }
-hot_reload = { version = "0.1.9" }
+hot_reload = { version = "0.2.0" }
 async-trait = { version = "0.1.88" }
 rustls = { version = "0.23.28", default-features = false, features = [
   "std",

--- a/rpxy-certs/Cargo.toml
+++ b/rpxy-certs/Cargo.toml
@@ -16,7 +16,7 @@ post-quantum = ["rustls-post-quantum"]
 http3 = []
 
 [dependencies]
-ahash = { version = "0.8.11" }
+ahash = { version = "0.8.12" }
 tracing = { version = "0.1.41" }
 derive_builder = { version = "0.20.2" }
 thiserror = { version = "2.0.12" }

--- a/rpxy-certs/Cargo.toml
+++ b/rpxy-certs/Cargo.toml
@@ -22,12 +22,12 @@ derive_builder = { version = "0.20.2" }
 thiserror = { version = "2.0.12" }
 hot_reload = { version = "0.1.9" }
 async-trait = { version = "0.1.88" }
-rustls = { version = "0.23.26", default-features = false, features = [
+rustls = { version = "0.23.27", default-features = false, features = [
   "std",
   "aws_lc_rs",
 ] }
 rustls-pemfile = { version = "2.2.0" }
-rustls-webpki = { version = "0.103.1", default-features = false, features = [
+rustls-webpki = { version = "0.103.2", default-features = false, features = [
   "std",
   "aws-lc-rs",
 ] }
@@ -35,7 +35,7 @@ rustls-post-quantum = { version = "0.2.2", optional = true }
 x509-parser = { version = "0.17.0" }
 
 [dev-dependencies]
-tokio = { version = "1.44.2", default-features = false, features = [
+tokio = { version = "1.45.0", default-features = false, features = [
   "rt-multi-thread",
   "macros",
 ] }

--- a/rpxy-certs/Cargo.toml
+++ b/rpxy-certs/Cargo.toml
@@ -35,7 +35,7 @@ rustls-post-quantum = { version = "0.2.2", optional = true }
 x509-parser = { version = "0.17.0" }
 
 [dev-dependencies]
-tokio = { version = "1.45.0", default-features = false, features = [
+tokio = { version = "1.45.1", default-features = false, features = [
   "rt-multi-thread",
   "macros",
 ] }

--- a/rpxy-certs/Cargo.toml
+++ b/rpxy-certs/Cargo.toml
@@ -27,7 +27,7 @@ rustls = { version = "0.23.27", default-features = false, features = [
   "aws_lc_rs",
 ] }
 rustls-pemfile = { version = "2.2.0" }
-rustls-webpki = { version = "0.103.2", default-features = false, features = [
+rustls-webpki = { version = "0.103.3", default-features = false, features = [
   "std",
   "aws-lc-rs",
 ] }

--- a/rpxy-certs/src/certs.rs
+++ b/rpxy-certs/src/certs.rs
@@ -75,9 +75,7 @@ impl SingleServerCertsKeys {
   /* ------------------------------------------------ */
   /// Parse the client CA certificates and return a hashmap of pairs of a subject key identifier (key) and a trust anchor (value)
   pub fn rustls_client_certs_trust_anchors(&self) -> Result<TrustAnchors, RpxyCertError> {
-    let Some(certs) = self.client_ca_certs.as_ref() else {
-      return Err(RpxyCertError::NoClientCert);
-    };
+    let certs = self.client_ca_certs.as_ref().ok_or(RpxyCertError::NoClientCert)?;
     let certs = certs.iter().map(|c| Certificate::from(c.to_vec())).collect::<Vec<_>>();
 
     let trust_anchors = certs

--- a/rpxy-certs/src/lib.rs
+++ b/rpxy-certs/src/lib.rs
@@ -27,8 +27,6 @@ pub use crate::{
 // Constants
 /// Default delay in seconds to watch certificates
 const DEFAULT_CERTS_WATCH_DELAY_SECS: u32 = 60;
-/// Load certificates only when updated
-const LOAD_CERTS_ONLY_WHEN_UPDATED: bool = true;
 
 /// Result type inner of certificate reloader service
 type ReloaderServiceResultInner = (
@@ -62,6 +60,7 @@ where
   let certs_watch_period = certs_watch_period.unwrap_or(DEFAULT_CERTS_WATCH_DELAY_SECS);
 
   let (cert_reloader_service, cert_reloader_rx) =
-    ReloaderService::<CryptoReloader, ServerCryptoBase>::new(&source, certs_watch_period, !LOAD_CERTS_ONLY_WHEN_UPDATED).await?;
+    ReloaderService::<CryptoReloader, ServerCryptoBase>::with_delay(&source, certs_watch_period).await?;
+
   Ok((cert_reloader_service, cert_reloader_rx))
 }

--- a/rpxy-certs/src/server_crypto.rs
+++ b/rpxy-certs/src/server_crypto.rs
@@ -1,9 +1,9 @@
 use crate::{certs::SingleServerCertsKeys, error::*, log::*};
 use ahash::HashMap;
 use rustls::{
+  RootCertStore, ServerConfig,
   crypto::CryptoProvider,
   server::{ResolvesServerCertUsingSni, WebPkiClientVerifier},
-  RootCertStore, ServerConfig,
 };
 use std::sync::Arc;
 

--- a/rpxy-lib/Cargo.toml
+++ b/rpxy-lib/Cargo.toml
@@ -79,7 +79,7 @@ hyper-rustls = { version = "0.27.7", default-features = false, features = [
 
 # tls and cert management for server
 rpxy-certs = { path = "../rpxy-certs/", default-features = false }
-hot_reload = "0.1.9"
+hot_reload = "0.2.0"
 rustls = { version = "0.23.28", default-features = false }
 rustls-post-quantum = { version = "0.2.2", optional = true }
 tokio-rustls = { version = "0.26.2", features = ["early-data"] }

--- a/rpxy-lib/Cargo.toml
+++ b/rpxy-lib/Cargo.toml
@@ -80,7 +80,7 @@ hyper-rustls = { version = "0.27.7", default-features = false, features = [
 # tls and cert management for server
 rpxy-certs = { path = "../rpxy-certs/", default-features = false }
 hot_reload = "0.1.9"
-rustls = { version = "0.23.27", default-features = false }
+rustls = { version = "0.23.28", default-features = false }
 rustls-post-quantum = { version = "0.2.2", optional = true }
 tokio-rustls = { version = "0.26.2", features = ["early-data"] }
 

--- a/rpxy-lib/Cargo.toml
+++ b/rpxy-lib/Cargo.toml
@@ -108,7 +108,7 @@ socket2 = { version = "0.5.10", features = ["all"], optional = true }
 
 # cache
 http-cache-semantics = { path = "../submodules/rusty-http-cache-semantics", default-features = false, optional = true }
-lru = { version = "0.14.0", optional = true }
+lru = { version = "0.15.0", optional = true }
 sha2 = { version = "0.10.9", default-features = false, optional = true }
 
 # cookie handling for sticky cookie

--- a/rpxy-lib/Cargo.toml
+++ b/rpxy-lib/Cargo.toml
@@ -41,7 +41,7 @@ ahash = "0.8.12"
 bytes = "1.10.1"
 derive_builder = "0.20.2"
 futures = { version = "0.3.31", features = ["alloc", "async-await"] }
-tokio = { version = "1.45.1", default-features = false, features = [
+tokio = { version = "1.46.0", default-features = false, features = [
   "net",
   "rt-multi-thread",
   "time",

--- a/rpxy-lib/Cargo.toml
+++ b/rpxy-lib/Cargo.toml
@@ -37,7 +37,7 @@ post-quantum = [
 
 [dependencies]
 rand = "0.9.1"
-ahash = "0.8.11"
+ahash = "0.8.12"
 bytes = "1.10.1"
 derive_builder = "0.20.2"
 futures = { version = "0.3.31", features = ["alloc", "async-await"] }

--- a/rpxy-lib/Cargo.toml
+++ b/rpxy-lib/Cargo.toml
@@ -92,8 +92,8 @@ tracing = { version = "0.1.41" }
 
 # http/3
 quinn = { version = "0.11.7", optional = true }
-h3 = { version = "0.0.7", features = ["tracing"], optional = true }
-h3-quinn = { version = "0.0.9", optional = true }
+h3 = { version = "0.0.8", features = ["tracing"], optional = true }
+h3-quinn = { version = "0.0.10", optional = true }
 s2n-quic = { version = "1.57.0", path = "../submodules/s2n-quic/quic/s2n-quic/", default-features = false, features = [
   "provider-tls-rustls",
 ], optional = true }

--- a/rpxy-lib/Cargo.toml
+++ b/rpxy-lib/Cargo.toml
@@ -61,7 +61,7 @@ thiserror = "2.0.12"
 http = "1.3.1"
 http-body-util = "0.1.3"
 hyper = { version = "1.6.0", default-features = false }
-hyper-util = { version = "0.1.11", features = ["full"] }
+hyper-util = { version = "0.1.12", features = ["full"] }
 futures-util = { version = "0.3.31", default-features = false }
 futures-channel = { version = "0.3.31", default-features = false }
 

--- a/rpxy-lib/Cargo.toml
+++ b/rpxy-lib/Cargo.toml
@@ -41,7 +41,7 @@ ahash = "0.8.12"
 bytes = "1.10.1"
 derive_builder = "0.20.2"
 futures = { version = "0.3.31", features = ["alloc", "async-await"] }
-tokio = { version = "1.45.0", default-features = false, features = [
+tokio = { version = "1.45.1", default-features = false, features = [
   "net",
   "rt-multi-thread",
   "time",

--- a/rpxy-lib/Cargo.toml
+++ b/rpxy-lib/Cargo.toml
@@ -94,11 +94,11 @@ tracing = { version = "0.1.41" }
 quinn = { version = "0.11.8", optional = true }
 h3 = { version = "0.0.8", features = ["tracing"], optional = true }
 h3-quinn = { version = "0.0.10", optional = true }
-s2n-quic = { version = "1.59.0", path = "../submodules/s2n-quic/quic/s2n-quic/", default-features = false, features = [
+s2n-quic = { version = "1.60.0", path = "../submodules/s2n-quic/quic/s2n-quic/", default-features = false, features = [
   "provider-tls-rustls",
 ], optional = true }
-s2n-quic-core = { version = "0.59.0", path = "../submodules/s2n-quic/quic/s2n-quic-core", default-features = false, optional = true }
-s2n-quic-rustls = { version = "0.59.0", path = "../submodules/s2n-quic/quic/s2n-quic-rustls", optional = true }
+s2n-quic-core = { version = "0.60.0", path = "../submodules/s2n-quic/quic/s2n-quic-core", default-features = false, optional = true }
+s2n-quic-rustls = { version = "0.60.0", path = "../submodules/s2n-quic/quic/s2n-quic-rustls", optional = true }
 s2n-quic-h3 = { path = "../submodules/s2n-quic/quic/s2n-quic-h3/", features = [
   "tracing",
 ], optional = true }

--- a/rpxy-lib/Cargo.toml
+++ b/rpxy-lib/Cargo.toml
@@ -94,11 +94,11 @@ tracing = { version = "0.1.41" }
 quinn = { version = "0.11.8", optional = true }
 h3 = { version = "0.0.8", features = ["tracing"], optional = true }
 h3-quinn = { version = "0.0.10", optional = true }
-s2n-quic = { version = "1.60.0", path = "../submodules/s2n-quic/quic/s2n-quic/", default-features = false, features = [
+s2n-quic = { version = "1.61.0", path = "../submodules/s2n-quic/quic/s2n-quic/", default-features = false, features = [
   "provider-tls-rustls",
 ], optional = true }
-s2n-quic-core = { version = "0.60.0", path = "../submodules/s2n-quic/quic/s2n-quic-core", default-features = false, optional = true }
-s2n-quic-rustls = { version = "0.60.0", path = "../submodules/s2n-quic/quic/s2n-quic-rustls", optional = true }
+s2n-quic-core = { version = "0.61.0", path = "../submodules/s2n-quic/quic/s2n-quic-core", default-features = false, optional = true }
+s2n-quic-rustls = { version = "0.61.0", path = "../submodules/s2n-quic/quic/s2n-quic-rustls", optional = true }
 s2n-quic-h3 = { path = "../submodules/s2n-quic/quic/s2n-quic-h3/", features = [
   "tracing",
 ], optional = true }

--- a/rpxy-lib/Cargo.toml
+++ b/rpxy-lib/Cargo.toml
@@ -104,7 +104,7 @@ s2n-quic-h3 = { path = "../submodules/s2n-quic/quic/s2n-quic-h3/", features = [
 ], optional = true }
 ##########
 # for UDP socket wit SO_REUSEADDR when h3 with quinn
-socket2 = { version = "0.5.9", features = ["all"], optional = true }
+socket2 = { version = "0.5.10", features = ["all"], optional = true }
 
 # cache
 http-cache-semantics = { path = "../submodules/rusty-http-cache-semantics", default-features = false, optional = true }

--- a/rpxy-lib/Cargo.toml
+++ b/rpxy-lib/Cargo.toml
@@ -41,7 +41,7 @@ ahash = "0.8.12"
 bytes = "1.10.1"
 derive_builder = "0.20.2"
 futures = { version = "0.3.31", features = ["alloc", "async-await"] }
-tokio = { version = "1.46.0", default-features = false, features = [
+tokio = { version = "1.46.1", default-features = false, features = [
   "net",
   "rt-multi-thread",
   "time",

--- a/rpxy-lib/Cargo.toml
+++ b/rpxy-lib/Cargo.toml
@@ -61,7 +61,7 @@ thiserror = "2.0.12"
 http = "1.3.1"
 http-body-util = "0.1.3"
 hyper = { version = "1.6.0", default-features = false }
-hyper-util = { version = "0.1.12", features = ["full"] }
+hyper-util = { version = "0.1.13", features = ["full"] }
 futures-util = { version = "0.3.31", default-features = false }
 futures-channel = { version = "0.3.31", default-features = false }
 

--- a/rpxy-lib/Cargo.toml
+++ b/rpxy-lib/Cargo.toml
@@ -94,11 +94,11 @@ tracing = { version = "0.1.41" }
 quinn = { version = "0.11.8", optional = true }
 h3 = { version = "0.0.8", features = ["tracing"], optional = true }
 h3-quinn = { version = "0.0.10", optional = true }
-s2n-quic = { version = "1.58.0", path = "../submodules/s2n-quic/quic/s2n-quic/", default-features = false, features = [
+s2n-quic = { version = "1.59.0", path = "../submodules/s2n-quic/quic/s2n-quic/", default-features = false, features = [
   "provider-tls-rustls",
 ], optional = true }
-s2n-quic-core = { version = "0.58.0", path = "../submodules/s2n-quic/quic/s2n-quic-core", default-features = false, optional = true }
-s2n-quic-rustls = { version = "0.58.0", path = "../submodules/s2n-quic/quic/s2n-quic-rustls", optional = true }
+s2n-quic-core = { version = "0.59.0", path = "../submodules/s2n-quic/quic/s2n-quic-core", default-features = false, optional = true }
+s2n-quic-rustls = { version = "0.59.0", path = "../submodules/s2n-quic/quic/s2n-quic-rustls", optional = true }
 s2n-quic-h3 = { path = "../submodules/s2n-quic/quic/s2n-quic-h3/", features = [
   "tracing",
 ], optional = true }

--- a/rpxy-lib/Cargo.toml
+++ b/rpxy-lib/Cargo.toml
@@ -61,7 +61,7 @@ thiserror = "2.0.12"
 http = "1.3.1"
 http-body-util = "0.1.3"
 hyper = { version = "1.6.0", default-features = false }
-hyper-util = { version = "0.1.13", features = ["full"] }
+hyper-util = { version = "0.1.14", features = ["full"] }
 futures-util = { version = "0.3.31", default-features = false }
 futures-channel = { version = "0.3.31", default-features = false }
 

--- a/rpxy-lib/Cargo.toml
+++ b/rpxy-lib/Cargo.toml
@@ -108,7 +108,7 @@ socket2 = { version = "0.5.10", features = ["all"], optional = true }
 
 # cache
 http-cache-semantics = { path = "../submodules/rusty-http-cache-semantics", default-features = false, optional = true }
-lru = { version = "0.15.0", optional = true }
+lru = { version = "0.16.0", optional = true }
 sha2 = { version = "0.10.9", default-features = false, optional = true }
 
 # cookie handling for sticky cookie

--- a/rpxy-lib/Cargo.toml
+++ b/rpxy-lib/Cargo.toml
@@ -41,7 +41,7 @@ ahash = "0.8.11"
 bytes = "1.10.1"
 derive_builder = "0.20.2"
 futures = { version = "0.3.31", features = ["alloc", "async-await"] }
-tokio = { version = "1.44.2", default-features = false, features = [
+tokio = { version = "1.45.0", default-features = false, features = [
   "net",
   "rt-multi-thread",
   "time",
@@ -80,7 +80,7 @@ hyper-rustls = { version = "0.27.5", default-features = false, features = [
 # tls and cert management for server
 rpxy-certs = { path = "../rpxy-certs/", default-features = false }
 hot_reload = "0.1.9"
-rustls = { version = "0.23.26", default-features = false }
+rustls = { version = "0.23.27", default-features = false }
 rustls-post-quantum = { version = "0.2.2", optional = true }
 tokio-rustls = { version = "0.26.2", features = ["early-data"] }
 

--- a/rpxy-lib/Cargo.toml
+++ b/rpxy-lib/Cargo.toml
@@ -94,11 +94,11 @@ tracing = { version = "0.1.41" }
 quinn = { version = "0.11.7", optional = true }
 h3 = { version = "0.0.8", features = ["tracing"], optional = true }
 h3-quinn = { version = "0.0.10", optional = true }
-s2n-quic = { version = "1.57.0", path = "../submodules/s2n-quic/quic/s2n-quic/", default-features = false, features = [
+s2n-quic = { version = "1.58.0", path = "../submodules/s2n-quic/quic/s2n-quic/", default-features = false, features = [
   "provider-tls-rustls",
 ], optional = true }
-s2n-quic-core = { version = "0.57.0", path = "../submodules/s2n-quic/quic/s2n-quic-core", default-features = false, optional = true }
-s2n-quic-rustls = { version = "0.57.0", path = "../submodules/s2n-quic/quic/s2n-quic-rustls", optional = true }
+s2n-quic-core = { version = "0.58.0", path = "../submodules/s2n-quic/quic/s2n-quic-core", default-features = false, optional = true }
+s2n-quic-rustls = { version = "0.58.0", path = "../submodules/s2n-quic/quic/s2n-quic-rustls", optional = true }
 s2n-quic-h3 = { path = "../submodules/s2n-quic/quic/s2n-quic-h3/", features = [
   "tracing",
 ], optional = true }

--- a/rpxy-lib/Cargo.toml
+++ b/rpxy-lib/Cargo.toml
@@ -91,7 +91,7 @@ rpxy-acme = { path = "../rpxy-acme/", default-features = false, optional = true 
 tracing = { version = "0.1.41" }
 
 # http/3
-quinn = { version = "0.11.7", optional = true }
+quinn = { version = "0.11.8", optional = true }
 h3 = { version = "0.0.8", features = ["tracing"], optional = true }
 h3-quinn = { version = "0.0.10", optional = true }
 s2n-quic = { version = "1.58.0", path = "../submodules/s2n-quic/quic/s2n-quic/", default-features = false, features = [

--- a/rpxy-lib/Cargo.toml
+++ b/rpxy-lib/Cargo.toml
@@ -70,7 +70,7 @@ hyper-tls = { version = "0.6.0", features = [
   "alpn",
   "vendored",
 ], optional = true }
-hyper-rustls = { version = "0.27.5", default-features = false, features = [
+hyper-rustls = { version = "0.27.6", default-features = false, features = [
   "aws-lc-rs",
   "http1",
   "http2",

--- a/rpxy-lib/Cargo.toml
+++ b/rpxy-lib/Cargo.toml
@@ -109,7 +109,7 @@ socket2 = { version = "0.5.9", features = ["all"], optional = true }
 # cache
 http-cache-semantics = { path = "../submodules/rusty-http-cache-semantics", default-features = false, optional = true }
 lru = { version = "0.14.0", optional = true }
-sha2 = { version = "0.10.8", default-features = false, optional = true }
+sha2 = { version = "0.10.9", default-features = false, optional = true }
 
 # cookie handling for sticky cookie
 chrono = { version = "0.4.41", default-features = false, features = [

--- a/rpxy-lib/Cargo.toml
+++ b/rpxy-lib/Cargo.toml
@@ -70,7 +70,7 @@ hyper-tls = { version = "0.6.0", features = [
   "alpn",
   "vendored",
 ], optional = true }
-hyper-rustls = { version = "0.27.6", default-features = false, features = [
+hyper-rustls = { version = "0.27.7", default-features = false, features = [
   "aws-lc-rs",
   "http1",
   "http2",

--- a/rpxy-lib/src/backend/backend_main.rs
+++ b/rpxy-lib/src/backend/backend_main.rs
@@ -1,8 +1,8 @@
 use crate::{
+  AppConfig, AppConfigList,
   error::*,
   log::*,
   name_exp::{ByteName, ServerName},
-  AppConfig, AppConfigList,
 };
 use ahash::HashMap;
 use derive_builder::Builder;

--- a/rpxy-lib/src/backend/backend_main.rs
+++ b/rpxy-lib/src/backend/backend_main.rs
@@ -85,24 +85,27 @@ impl TryFrom<&AppConfigList> for BackendAppManager {
     }
 
     // default backend application for plaintext http requests
-    if let Some(default_app_name) = &config_list.default_app {
-      let default_server_name = manager
-        .apps
-        .iter()
-        .filter(|(_k, v)| &v.app_name == default_app_name)
-        .map(|(_, v)| v.server_name.clone())
-        .collect::<Vec<_>>();
+    let Some(default_app_name) = &config_list.default_app else {
+      return Ok(manager);
+    };
 
-      if !default_server_name.is_empty() {
-        info!(
-          "Serving plaintext http for requests to unconfigured server_name by app {} (server_name: {}).",
-          &default_app_name,
-          (&default_server_name[0]).try_into().unwrap_or_else(|_| "".to_string())
-        );
+    let default_server_name = manager
+      .apps
+      .iter()
+      .filter(|(_k, v)| &v.app_name == default_app_name)
+      .map(|(_, v)| v.server_name.clone())
+      .collect::<Vec<_>>();
 
-        manager.default_server_name = Some(default_server_name[0].clone());
-      }
+    if !default_server_name.is_empty() {
+      info!(
+        "Serving plaintext http for requests to unconfigured server_name by app {} (server_name: {}).",
+        &default_app_name,
+        (&default_server_name[0]).try_into().unwrap_or_else(|_| "".to_string())
+      );
+
+      manager.default_server_name = Some(default_server_name[0].clone());
     }
+
     Ok(manager)
   }
 }

--- a/rpxy-lib/src/backend/backend_main.rs
+++ b/rpxy-lib/src/backend/backend_main.rs
@@ -26,6 +26,7 @@ pub struct BackendApp {
   pub https_redirection: Option<bool>,
   /// tls settings: mutual TLS is enabled
   #[builder(default)]
+  #[allow(unused)]
   pub mutual_tls: Option<bool>,
 }
 impl<'a> BackendAppBuilder {

--- a/rpxy-lib/src/backend/load_balance/load_balance_main.rs
+++ b/rpxy-lib/src/backend/load_balance/load_balance_main.rs
@@ -7,8 +7,8 @@ pub use super::{
 use derive_builder::Builder;
 use rand::Rng;
 use std::sync::{
-  atomic::{AtomicUsize, Ordering},
   Arc,
+  atomic::{AtomicUsize, Ordering},
 };
 
 /// Constants to specify a load balance option

--- a/rpxy-lib/src/backend/load_balance/load_balance_main.rs
+++ b/rpxy-lib/src/backend/load_balance/load_balance_main.rs
@@ -131,6 +131,4 @@ impl LoadBalance {
 pub struct LoadBalanceContext {
   #[cfg(feature = "sticky-cookie")]
   pub sticky_cookie: StickyCookie,
-  #[cfg(not(feature = "sticky-cookie"))]
-  pub sticky_cookie: (),
 }

--- a/rpxy-lib/src/backend/load_balance/load_balance_sticky.rs
+++ b/rpxy-lib/src/backend/load_balance/load_balance_sticky.rs
@@ -1,7 +1,7 @@
 use super::{
+  Upstream,
   load_balance_main::{LoadBalanceContext, LoadBalanceWithPointer, PointerToUpstream},
   sticky_cookie::StickyCookieConfig,
-  Upstream,
 };
 use crate::{constants::STICKY_COOKIE_NAME, log::*};
 use ahash::HashMap;
@@ -9,8 +9,8 @@ use derive_builder::Builder;
 use std::{
   borrow::Cow,
   sync::{
-    atomic::{AtomicUsize, Ordering},
     Arc,
+    atomic::{AtomicUsize, Ordering},
   },
 };
 

--- a/rpxy-lib/src/backend/load_balance/load_balance_sticky.rs
+++ b/rpxy-lib/src/backend/load_balance/load_balance_sticky.rs
@@ -112,13 +112,16 @@ impl LoadBalanceWithPointer for LoadBalanceSticky {
       }
       Some(context) => {
         let server_id = &context.sticky_cookie.value.value;
-        if let Some(server_index) = self.get_server_index_from_id(server_id) {
-          debug!("Valid sticky cookie: id={}, index={}", server_id, server_index);
-          server_index
-        } else {
-          debug!("Invalid sticky cookie: id={}", server_id);
-          self.simple_increment_ptr()
-        }
+        self.get_server_index_from_id(server_id).map_or_else(
+          || {
+            debug!("Invalid sticky cookie: id={}", server_id);
+            self.simple_increment_ptr()
+          },
+          |server_index| {
+            debug!("Valid sticky cookie: id={}, index={}", server_id, server_index);
+            server_index
+          },
+        )
       }
     };
 

--- a/rpxy-lib/src/backend/load_balance/mod.rs
+++ b/rpxy-lib/src/backend/load_balance/mod.rs
@@ -8,7 +8,7 @@ use super::upstream::Upstream;
 use thiserror::Error;
 
 pub use load_balance_main::{
-  load_balance_options, LoadBalance, LoadBalanceContext, LoadBalanceRandomBuilder, LoadBalanceRoundRobinBuilder,
+  LoadBalance, LoadBalanceContext, LoadBalanceRandomBuilder, LoadBalanceRoundRobinBuilder, load_balance_options,
 };
 #[cfg(feature = "sticky-cookie")]
 pub use load_balance_sticky::LoadBalanceStickyBuilder;

--- a/rpxy-lib/src/backend/load_balance/mod.rs
+++ b/rpxy-lib/src/backend/load_balance/mod.rs
@@ -4,6 +4,7 @@ mod load_balance_sticky;
 #[cfg(feature = "sticky-cookie")]
 mod sticky_cookie;
 
+#[cfg(feature = "sticky-cookie")]
 use super::upstream::Upstream;
 use thiserror::Error;
 
@@ -16,6 +17,7 @@ pub use load_balance_sticky::LoadBalanceStickyBuilder;
 pub use sticky_cookie::{StickyCookie, StickyCookieValue};
 
 /// Result type for load balancing
+#[cfg(feature = "sticky-cookie")]
 type LoadBalanceResult<T> = std::result::Result<T, LoadBalanceError>;
 /// Describes things that can go wrong in the Load Balance
 #[derive(Debug, Error)]

--- a/rpxy-lib/src/backend/load_balance/sticky_cookie.rs
+++ b/rpxy-lib/src/backend/load_balance/sticky_cookie.rs
@@ -91,12 +91,7 @@ impl<'a> StickyCookieBuilder {
     self
   }
   /// Set the meta information of sticky cookie
-  pub fn info(
-    &mut self,
-    domain: impl Into<Cow<'a, str>>,
-    path: impl Into<Cow<'a, str>>,
-    duration_secs: i64,
-  ) -> &mut Self {
+  pub fn info(&mut self, domain: impl Into<Cow<'a, str>>, path: impl Into<Cow<'a, str>>, duration_secs: i64) -> &mut Self {
     let info = StickyCookieInfoBuilder::default()
       .domain(domain)
       .path(path)

--- a/rpxy-lib/src/backend/upstream.rs
+++ b/rpxy-lib/src/backend/upstream.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "sticky-cookie")]
 use super::load_balance::LoadBalanceStickyBuilder;
 use super::load_balance::{
-  load_balance_options as lb_opts, LoadBalance, LoadBalanceContext, LoadBalanceRandomBuilder, LoadBalanceRoundRobinBuilder,
+  LoadBalance, LoadBalanceContext, LoadBalanceRandomBuilder, LoadBalanceRoundRobinBuilder, load_balance_options as lb_opts,
 };
 // use super::{BytesName, LbContext, PathNameBytesExp, UpstreamOption};
 use super::upstream_opts::UpstreamOption;
@@ -13,7 +13,7 @@ use crate::{
 };
 use ahash::{HashMap, HashSet};
 #[cfg(feature = "sticky-cookie")]
-use base64::{engine::general_purpose, Engine as _};
+use base64::{Engine as _, engine::general_purpose};
 use derive_builder::Builder;
 #[cfg(feature = "sticky-cookie")]
 use sha2::{Digest, Sha256};

--- a/rpxy-lib/src/backend/upstream_opts.rs
+++ b/rpxy-lib/src/backend/upstream_opts.rs
@@ -13,6 +13,8 @@ pub enum UpstreamOption {
   ForceHttp11Upstream,
   /// Force HTTP/2 upstream
   ForceHttp2Upstream,
+  /// Add RFC 7239 Forwarded header
+  ForwardedHeader,
   // TODO: Adds more options for heder override
 }
 impl TryFrom<&str> for UpstreamOption {
@@ -24,6 +26,7 @@ impl TryFrom<&str> for UpstreamOption {
       "upgrade_insecure_requests" => Ok(Self::UpgradeInsecureRequests),
       "force_http11_upstream" => Ok(Self::ForceHttp11Upstream),
       "force_http2_upstream" => Ok(Self::ForceHttp2Upstream),
+      "forwarded_header" => Ok(Self::ForwardedHeader),
       _ => Err(RpxyError::UnsupportedUpstreamOption),
     }
   }

--- a/rpxy-lib/src/count.rs
+++ b/rpxy-lib/src/count.rs
@@ -1,6 +1,6 @@
 use std::sync::{
-  atomic::{AtomicUsize, Ordering},
   Arc,
+  atomic::{AtomicUsize, Ordering},
 };
 
 #[derive(Debug, Clone, Default)]

--- a/rpxy-lib/src/error.rs
+++ b/rpxy-lib/src/error.rs
@@ -37,8 +37,11 @@ pub enum RpxyError {
 
   // http/3 errors
   #[cfg(any(feature = "http3-quinn", feature = "http3-s2n"))]
-  #[error("H3 error: {0}")]
-  H3Error(#[from] h3::Error),
+  #[error("h3 connection error: {0}")]
+  H3ConnectionError(#[from] h3::error::ConnectionError),
+  #[cfg(any(feature = "http3-quinn", feature = "http3-s2n"))]
+  #[error("h3 connection error: {0}")]
+  H3StreamError(#[from] h3::error::StreamError),
   // #[cfg(feature = "http3-s2n")]
   // #[error("H3 error: {0}")]
   // H3Error(#[from] s2n_quic_h3::h3::Error),

--- a/rpxy-lib/src/forwarder/cache/mod.rs
+++ b/rpxy-lib/src/forwarder/cache/mod.rs
@@ -2,4 +2,4 @@ mod cache_error;
 mod cache_main;
 
 pub use cache_error::CacheError;
-pub(crate) use cache_main::{get_policy_if_cacheable, RpxyCache};
+pub(crate) use cache_main::{RpxyCache, get_policy_if_cacheable};

--- a/rpxy-lib/src/forwarder/client.rs
+++ b/rpxy-lib/src/forwarder/client.rs
@@ -9,13 +9,13 @@ use async_trait::async_trait;
 use http::{Request, Response, Version};
 use hyper::body::{Body, Incoming};
 use hyper_util::client::legacy::{
-  connect::{Connect, HttpConnector},
   Client,
+  connect::{Connect, HttpConnector},
 };
 use std::sync::Arc;
 
 #[cfg(feature = "cache")]
-use super::cache::{get_policy_if_cacheable, RpxyCache};
+use super::cache::{RpxyCache, get_policy_if_cacheable};
 
 #[async_trait]
 /// Definition of the forwarder that simply forward requests from downstream client to upstream app servers.

--- a/rpxy-lib/src/forwarder/client.rs
+++ b/rpxy-lib/src/forwarder/client.rs
@@ -126,9 +126,9 @@ where
     warn!(
       "
 --------------------------------------------------------------------------------------------------
-Request forwarder is working without TLS support!!!
-We recommend to use this just for testing.
-Please enable native-tls-backend or rustls-backend feature to enable TLS support.
+Request forwarder is working without TLS support!
+This mode is intended for testing only.
+Enable 'native-tls-backend' or 'rustls-backend' feature for TLS support.
 --------------------------------------------------------------------------------------------------"
     );
     let executor = LocalExecutor::new(_globals.runtime_handle.clone());
@@ -159,7 +159,7 @@ where
   /// Build forwarder
   pub async fn try_new(_globals: &Arc<Globals>) -> RpxyResult<Self> {
     // build hyper client with hyper-tls
-    info!("Native TLS support is enabled for the connection to backend applications");
+    info!("Native TLS support enabled for backend connections (native-tls)");
     let executor = LocalExecutor::new(_globals.runtime_handle.clone());
 
     let try_build_connector = |alpns: &[&str]| {
@@ -209,14 +209,14 @@ where
     #[cfg(feature = "webpki-roots")]
     let builder_h2 = hyper_rustls::HttpsConnectorBuilder::new().with_webpki_roots();
     #[cfg(feature = "webpki-roots")]
-    info!("Mozilla WebPKI root certs with rustls is used for the connection to backend applications");
+    info!("Rustls backend: Mozilla WebPKI root certs used for backend connections");
 
     #[cfg(not(feature = "webpki-roots"))]
     let builder = hyper_rustls::HttpsConnectorBuilder::new().with_platform_verifier();
     #[cfg(not(feature = "webpki-roots"))]
     let builder_h2 = hyper_rustls::HttpsConnectorBuilder::new().with_platform_verifier();
     #[cfg(not(feature = "webpki-roots"))]
-    info!("Platform verifier with rustls is used for the connection to backend applications");
+    info!("Rustls backend: Platform verifier used for backend connections");
 
     let mut http = HttpConnector::new();
     http.enforce_http(false);

--- a/rpxy-lib/src/hyper_ext/body_incoming_like.rs
+++ b/rpxy-lib/src/hyper_ext/body_incoming_like.rs
@@ -1,7 +1,7 @@
 use super::watch;
 use crate::error::*;
 use futures_channel::{mpsc, oneshot};
-use futures_util::{stream::FusedStream, Future, Stream};
+use futures_util::{Future, Stream, stream::FusedStream};
 use http::HeaderMap;
 use hyper::body::{Body, Bytes, Frame, SizeHint};
 use std::{

--- a/rpxy-lib/src/hyper_ext/body_type.rs
+++ b/rpxy-lib/src/hyper_ext/body_type.rs
@@ -1,7 +1,7 @@
 use super::body::IncomingLike;
 use crate::error::RpxyError;
 use futures::channel::mpsc::UnboundedReceiver;
-use http_body_util::{combinators, BodyExt, Empty, Full, StreamBody};
+use http_body_util::{BodyExt, Empty, Full, StreamBody, combinators};
 use hyper::body::{Body, Bytes, Frame, Incoming};
 use std::pin::Pin;
 

--- a/rpxy-lib/src/hyper_ext/mod.rs
+++ b/rpxy-lib/src/hyper_ext/mod.rs
@@ -12,5 +12,5 @@ pub(crate) mod rt {
 #[allow(unused)]
 pub(crate) mod body {
   pub(crate) use super::body_incoming_like::IncomingLike;
-  pub(crate) use super::body_type::{empty, full, BoxBody, RequestBody, ResponseBody, UnboundedStreamBody};
+  pub(crate) use super::body_type::{BoxBody, RequestBody, ResponseBody, UnboundedStreamBody, empty, full};
 }

--- a/rpxy-lib/src/hyper_ext/watch.rs
+++ b/rpxy-lib/src/hyper_ext/watch.rs
@@ -7,8 +7,8 @@
 
 use futures_util::task::AtomicWaker;
 use std::sync::{
-  atomic::{AtomicUsize, Ordering},
   Arc,
+  atomic::{AtomicUsize, Ordering},
 };
 use std::task;
 

--- a/rpxy-lib/src/lib.rs
+++ b/rpxy-lib/src/lib.rs
@@ -180,9 +180,5 @@ pub async fn entrypoint(
     }
   });
   // returns the first error as the representative error
-  if let Some(e) = errs.next() {
-    return Err(e);
-  }
-
-  Ok(())
+  errs.next().map_or(Ok(()), |e| Err(e))
 }

--- a/rpxy-lib/src/message_handler/canonical_address.rs
+++ b/rpxy-lib/src/message_handler/canonical_address.rs
@@ -44,10 +44,7 @@ mod tests {
   }
   #[test]
   fn ipv6_to_canonical() {
-    let socket = SocketAddr::new(
-      IpAddr::V6(Ipv6Addr::new(0x2001, 0x0db8, 0, 0, 0, 0, 0xdead, 0xbeef)),
-      8080,
-    );
+    let socket = SocketAddr::new(IpAddr::V6(Ipv6Addr::new(0x2001, 0x0db8, 0, 0, 0, 0, 0xdead, 0xbeef)), 8080);
     assert_eq!(socket.to_canonical(), socket);
   }
   #[test]

--- a/rpxy-lib/src/message_handler/handler_main.rs
+++ b/rpxy-lib/src/message_handler/handler_main.rs
@@ -107,9 +107,11 @@ where
     let backend_app = match self.app_manager.apps.get(&server_name) {
       Some(backend_app) => backend_app,
       None => {
-        let Some(default_server_name) = &self.app_manager.default_server_name else {
-          return Err(HttpError::NoMatchingBackendApp);
-        };
+        let default_server_name = self
+          .app_manager
+          .default_server_name
+          .as_ref()
+          .ok_or(HttpError::NoMatchingBackendApp)?;
         debug!("Serving by default app");
         self.app_manager.apps.get(default_server_name).unwrap()
       }
@@ -131,9 +133,7 @@ where
     // Find reverse proxy for given path and choose one of upstream host
     // Longest prefix match
     let path = req.uri().path();
-    let Some(upstream_candidates) = backend_app.path_manager.get(path) else {
-      return Err(HttpError::NoUpstreamCandidates);
-    };
+    let upstream_candidates = backend_app.path_manager.get(path).ok_or(HttpError::NoUpstreamCandidates)?;
 
     // Upgrade in request header
     let upgrade_in_request = extract_upgrade(req.headers());
@@ -147,19 +147,17 @@ where
     let req_on_upgrade = hyper::upgrade::on(&mut req);
 
     // Build request from destination information
-    let _context = match self.generate_request_forwarded(
-      &client_addr,
-      &listen_addr,
-      &mut req,
-      &upgrade_in_request,
-      upstream_candidates,
-      tls_enabled,
-    ) {
-      Err(e) => {
-        return Err(HttpError::FailedToGenerateUpstreamRequest(e.to_string()));
-      }
-      Ok(v) => v,
-    };
+    let _context = self
+      .generate_request_forwarded(
+        &client_addr,
+        &listen_addr,
+        &mut req,
+        &upgrade_in_request,
+        upstream_candidates,
+        tls_enabled,
+      )
+      .map_err(|e| HttpError::FailedToGenerateUpstreamRequest(e.to_string()))?;
+
     debug!(
       "Request to be forwarded: [uri {}, method: {}, version {:?}, headers {:?}]",
       req.uri(),
@@ -173,12 +171,12 @@ where
 
     //////////////
     // Forward request to a chosen backend
-    let mut res_backend = match self.forwarder.request(req).await {
-      Ok(v) => v,
-      Err(e) => {
-        return Err(HttpError::FailedToGetResponseFromBackend(e.to_string()));
-      }
-    };
+    let mut res_backend = self
+      .forwarder
+      .request(req)
+      .await
+      .map_err(|e| HttpError::FailedToGetResponseFromBackend(e.to_string()))?;
+
     //////////////
     // Process reverse proxy context generated during the forwarding request generation.
     #[cfg(feature = "sticky-cookie")]
@@ -191,9 +189,9 @@ where
 
     if res_backend.status() != StatusCode::SWITCHING_PROTOCOLS {
       // Generate response to client
-      if let Err(e) = self.generate_response_forwarded(&mut res_backend, backend_app) {
-        return Err(HttpError::FailedToGenerateDownstreamResponse(e.to_string()));
-      }
+      self
+        .generate_response_forwarded(&mut res_backend, backend_app)
+        .map_err(|e| HttpError::FailedToGenerateDownstreamResponse(e.to_string()))?;
       return Ok(res_backend);
     }
 

--- a/rpxy-lib/src/message_handler/handler_main.rs
+++ b/rpxy-lib/src/message_handler/handler_main.rs
@@ -24,10 +24,7 @@ use tokio::io::copy_bidirectional;
 #[derive(Debug)]
 /// Context object to handle sticky cookies at HTTP message handler
 pub(super) struct HandlerContext {
-  #[cfg(feature = "sticky-cookie")]
   pub(super) context_lb: Option<LoadBalanceContext>,
-  #[cfg(not(feature = "sticky-cookie"))]
-  pub(super) context_lb: Option<()>,
 }
 
 #[derive(Clone, Builder)]

--- a/rpxy-lib/src/message_handler/handler_manipulate_messages.rs
+++ b/rpxy-lib/src/message_handler/handler_manipulate_messages.rs
@@ -81,13 +81,13 @@ where
         .unwrap_or(false)
     };
 
-    let original_uri = req.uri().to_string();
+    let original_uri = req.uri().clone();
     let headers = req.headers_mut();
     // delete headers specified in header.connection
     remove_connection_header(headers);
     // delete hop headers including header.connection
     remove_hop_header(headers);
-    // X-Forwarded-For
+    // X-Forwarded-For (and Forwarded if exists)
     add_forwarding_header(headers, client_addr, listen_addr, tls_enabled, &original_uri)?;
 
     // Add te: trailer if te_trailer
@@ -126,8 +126,8 @@ where
 
     // apply upstream-specific headers given in upstream_option
     let headers = req.headers_mut();
-    // apply upstream options to header
-    apply_upstream_options_to_header(headers, &upstream_chosen.uri, upstream_candidates)?;
+    // apply upstream options to header, after X-Forwarded-For is added
+    apply_upstream_options_to_header(headers, &upstream_chosen.uri, upstream_candidates, &original_uri)?;
 
     // update uri in request
     ensure!(

--- a/rpxy-lib/src/message_handler/handler_manipulate_messages.rs
+++ b/rpxy-lib/src/message_handler/handler_manipulate_messages.rs
@@ -70,13 +70,15 @@ where
 
     // Add te: trailer if contained in original request
     let contains_te_trailers = {
-      if let Some(te) = req.headers().get(header::TE) {
-        te.as_bytes()
-          .split(|v| v == &b',' || v == &b' ')
-          .any(|x| x == "trailers".as_bytes())
-      } else {
-        false
-      }
+      req
+        .headers()
+        .get(header::TE)
+        .map(|te| {
+          te.as_bytes()
+            .split(|v| v == &b',' || v == &b' ')
+            .any(|x| x == "trailers".as_bytes())
+        })
+        .unwrap_or(false)
     };
 
     let original_uri = req.uri().to_string();
@@ -136,11 +138,7 @@ where
     let new_uri = Uri::builder()
       .scheme(upstream_chosen.uri.scheme().unwrap().as_str())
       .authority(upstream_chosen.uri.authority().unwrap().as_str());
-    let org_pq = match req.uri().path_and_query() {
-      Some(pq) => pq.to_string(),
-      None => "/".to_string(),
-    }
-    .into_bytes();
+    let org_pq = req.uri().path_and_query().map(|pq| pq.as_str()).unwrap_or("/").as_bytes();
 
     // replace some parts of path if opt_replace_path is enabled for chosen upstream
     let new_pq = match &upstream_candidates.replace_path {
@@ -155,7 +153,7 @@ where
         new_pq.extend_from_slice(&org_pq[matched_path.len()..]);
         new_pq
       }
-      None => org_pq,
+      None => org_pq.to_vec(),
     };
     *req.uri_mut() = new_uri.path_and_query(new_pq).build()?;
 

--- a/rpxy-lib/src/message_handler/synthetic_response.rs
+++ b/rpxy-lib/src/message_handler/synthetic_response.rs
@@ -1,7 +1,7 @@
 use super::http_result::{HttpError, HttpResult};
 use crate::{
   error::*,
-  hyper_ext::body::{empty, ResponseBody},
+  hyper_ext::body::{ResponseBody, empty},
   name_exp::ServerName,
 };
 use http::{Request, Response, StatusCode, Uri};

--- a/rpxy-lib/src/message_handler/utils_headers.rs
+++ b/rpxy-lib/src/message_handler/utils_headers.rs
@@ -3,9 +3,9 @@ use crate::{
   backend::{UpstreamCandidates, UpstreamOption},
   log::*,
 };
-use anyhow::{anyhow, ensure, Result};
+use anyhow::{Result, anyhow, ensure};
 use bytes::BufMut;
-use http::{header, HeaderMap, HeaderName, HeaderValue, Uri};
+use http::{HeaderMap, HeaderName, HeaderValue, Uri, header};
 use std::{borrow::Cow, net::SocketAddr};
 
 #[cfg(feature = "sticky-cookie")]

--- a/rpxy-lib/src/message_handler/utils_headers.rs
+++ b/rpxy-lib/src/message_handler/utils_headers.rs
@@ -3,7 +3,7 @@ use crate::{
   backend::{UpstreamCandidates, UpstreamOption},
   log::*,
 };
-use anyhow::{Result, anyhow, ensure};
+use anyhow::{Result, anyhow};
 use bytes::BufMut;
 use http::{HeaderMap, HeaderName, HeaderValue, Uri, header};
 use std::{borrow::Cow, net::SocketAddr};
@@ -35,7 +35,7 @@ pub(super) fn takeout_sticky_cookie_lb_context(
       if sticky_cookies.is_empty() {
         return Ok(None);
       }
-      ensure!(sticky_cookies.len() == 1, "Invalid cookie: Multiple sticky cookie values");
+      anyhow::ensure!(sticky_cookies.len() == 1, "Invalid cookie: Multiple sticky cookie values");
 
       let cookies_passed_to_upstream = without_sticky_cookies.join("; ");
       let cookie_passed_to_lb = sticky_cookies.first().unwrap();

--- a/rpxy-lib/src/message_handler/utils_headers.rs
+++ b/rpxy-lib/src/message_handler/utils_headers.rs
@@ -236,10 +236,9 @@ pub(super) fn add_forwarding_header(
 pub(super) fn remove_connection_header(headers: &mut HeaderMap) {
   if let Some(values) = headers.get(header::CONNECTION) {
     if let Ok(v) = values.clone().to_str() {
-      for m in v.split(',') {
-        if !m.is_empty() {
-          headers.remove(m.trim());
-        }
+      let keys = v.split(',').map(|m| m.trim()).filter(|m| !m.is_empty());
+      for m in keys {
+        headers.remove(m);
       }
     }
   }
@@ -274,11 +273,9 @@ pub(super) fn extract_upgrade(headers: &HeaderMap) -> Option<String> {
       .split(',')
       .any(|w| w.trim().eq_ignore_ascii_case(header::UPGRADE.as_str()))
     {
-      if let Some(u) = headers.get(header::UPGRADE) {
-        if let Ok(m) = u.to_str() {
-          debug!("Upgrade in request header: {}", m);
-          return Some(m.to_owned());
-        }
+      if let Some(Ok(m)) = headers.get(header::UPGRADE).map(|u| u.to_str()) {
+        debug!("Upgrade in request header: {}", m);
+        return Some(m.to_owned());
       }
     }
   }

--- a/rpxy-lib/src/message_handler/utils_request.rs
+++ b/rpxy-lib/src/message_handler/utils_request.rs
@@ -2,8 +2,8 @@ use crate::{
   backend::{Upstream, UpstreamCandidates, UpstreamOption},
   log::*,
 };
-use anyhow::{anyhow, ensure, Result};
-use http::{header, uri::Scheme, Request, Version};
+use anyhow::{Result, anyhow, ensure};
+use http::{Request, Version, header, uri::Scheme};
 
 /// Trait defining parser of hostname
 /// Inspect and extract hostname from either the request HOST header or request line

--- a/rpxy-lib/src/proxy/proxy_h3.rs
+++ b/rpxy-lib/src/proxy/proxy_h3.rs
@@ -68,7 +68,7 @@ where
             h3_conn.shutdown(0).await?;
             break;
           }
-          debug!("Request incoming: current # {}", request_count.current());
+          trace!("Request incoming: current # {}", request_count.current());
 
           let self_inner = self.clone();
           let tls_server_name_inner = tls_server_name.clone();
@@ -82,7 +82,7 @@ where
               warn!("HTTP/3 error on serve stream: {}", e);
             }
             request_count.decrement();
-            debug!("Request processed: current # {}", request_count.current());
+            trace!("Request processed: current # {}", request_count.current());
           });
         }
       }

--- a/rpxy-lib/src/proxy/proxy_main.rs
+++ b/rpxy-lib/src/proxy/proxy_main.rs
@@ -313,7 +313,7 @@ where
             error!("Reloader is broken");
             break;
           }
-          let server_crypto_base = server_crypto_rx.borrow().clone().unwrap();
+          let server_crypto_base = server_crypto_rx.get().unwrap();
           let Some(server_config): Option<Arc<ServerCrypto>> = (&server_crypto_base).try_into().ok() else {
             error!("Failed to update server crypto");
             break;

--- a/rpxy-lib/src/proxy/proxy_main.rs
+++ b/rpxy-lib/src/proxy/proxy_main.rs
@@ -11,7 +11,7 @@ use crate::{
   message_handler::HttpMessageHandler,
   name_exp::ServerName,
 };
-use futures::{select, FutureExt};
+use futures::{FutureExt, select};
 use http::{Request, Response};
 use hyper::{
   body::Incoming,

--- a/rpxy-lib/src/proxy/proxy_quic_quinn.rs
+++ b/rpxy-lib/src/proxy/proxy_quic_quinn.rs
@@ -102,7 +102,7 @@ where
             error!("Reloader is broken");
             break;
           }
-          let cert_keys_map = server_crypto_rx.borrow().clone().unwrap();
+          let cert_keys_map = server_crypto_rx.get().unwrap();
 
           server_crypto = (&cert_keys_map).try_into().ok();
           let Some(inner) = server_crypto.clone() else {

--- a/rpxy-lib/src/proxy/proxy_quic_s2n.rs
+++ b/rpxy-lib/src/proxy/proxy_quic_s2n.rs
@@ -52,7 +52,7 @@ where
 
   /// Receive server crypto from reloader
   fn receive_server_crypto(&self, server_crypto_rx: ReloaderReceiver<ServerCryptoBase>) -> RpxyResult<s2n_quic_rustls::Server> {
-    let cert_keys_map = server_crypto_rx.borrow().clone().ok_or_else(|| {
+    let cert_keys_map = server_crypto_rx.get().ok_or_else(|| {
       error!("Reloader is broken");
       RpxyError::CertificateReloadError(anyhow!("Reloader is broken").into())
     })?;

--- a/rpxy-lib/src/proxy/socket.rs
+++ b/rpxy-lib/src/proxy/socket.rs
@@ -16,10 +16,12 @@ pub(super) fn bind_tcp_socket(listening_on: &SocketAddr) -> RpxyResult<TcpSocket
   }?;
   tcp_socket.set_reuseaddr(true)?;
   tcp_socket.set_reuseport(true)?;
-  if let Err(e) = tcp_socket.bind(*listening_on) {
+
+  tcp_socket.bind(*listening_on).map_err(|e| {
     error!("Failed to bind TCP socket: {}", e);
-    return Err(RpxyError::Io(e));
-  };
+    RpxyError::Io(e)
+  })?;
+
   Ok(tcp_socket)
 }
 
@@ -36,11 +38,10 @@ pub(super) fn bind_udp_socket(listening_on: &SocketAddr) -> RpxyResult<UdpSocket
   socket.set_reuse_port(true)?;
   socket.set_nonblocking(true)?; // This was made true inside quinn. so this line isn't necessary here. but just in case.
 
-  if let Err(e) = socket.bind(&(*listening_on).into()) {
+  socket.bind(&(*listening_on).into()).map_err(|e| {
     error!("Failed to bind UDP socket: {}", e);
-    return Err(RpxyError::Io(e));
-  };
-  let udp_socket: UdpSocket = socket.into();
+    RpxyError::Io(e)
+  })?;
 
-  Ok(udp_socket)
+  Ok(socket.into())
 }


### PR DESCRIPTION
## Improvement

- Feat: Support `Forwarded` header in addition to `X-Forwarded-For` header. This is to support the standard forwarding header for reverse proxy applications (RFC 7239). Use the `forwarded_header` upstream option to enable this feature.
  By default, it is not appended to the outgoing header. However, if the incoming request has the forwarded header, it would be preserved and updated simultaneously with `x-forwarded-for` header. if both forwarded and x-forwarded-for headers exists (and they are inconsistent), x-forwarded-for is prioritized. This means that x-forwarded-for is first updated and it is then copied (overridden) to `for` param of forwarded header.
- Refactor: lots of minor improvements
- Deps