### PR TITLE
remove "dep" prefix so package can be build with cargo-auditable

### DIFF
--- a/rpxy-lib/Cargo.toml
+++ b/rpxy-lib/Cargo.toml
@@ -27,7 +27,7 @@ sticky-cookie = ["base64", "sha2", "chrono"]
 native-tls-backend = ["hyper-tls"]
 rustls-backend = ["hyper-rustls"]
 webpki-roots = ["rustls-backend", "hyper-rustls/webpki-tokio"]
-acme = ["dep:rpxy-acme"]
+acme = ["rpxy-acme"]
 post-quantum = [
   "rustls-post-quantum",
   "rpxy-acme/post-quantum",


### PR DESCRIPTION
I wish to add `rpxy` to the Alpine aports, but `cargo-auditable` is a requirement there. building the project with `cargo-auditable` fails:

```
thread 'main' panicked at cargo-auditable/src/collect_audit_data.rs:96:9:
cargo metadata failure: error: package `rpxy-lib v0.10.2 (/home/strangeperson/rust-rpxy/rpxy-lib)` does not have feature `rpxy-acme`

help: an optional dependency with that name exists, but the `features` table includes it with the "dep:" syntax so it does not have an implicit feature with that name
Dependency `rpxy-acme` would be enabled by these features:
        - `acme`
        - `post-quantum`
```

`cargo-auditable` has the following [issue](https://github.com/rust-secure-code/cargo-auditable/issues/124), that tells it must be fixed in `cargo` itself.

`rpxy` builds successfully, if I remove `dep:` from `rpxy-lib/Cargo.toml`, so I suggest to remove it. but I'm not sure if it is a good thing to do.