### PR TITLE
feat: add stealth mode to hide proxy headers from upstream and responses

### DIFF
--- a/config-example.toml
+++ b/config-example.toml
@@ -63,6 +63,11 @@ default_app = 'another_localhost'
 [apps.localhost]
 server_name = 'localhost' # Domain name
 
+# Optional: Stealth mode. If true, proxy-related headers (X-Forwarded-For, X-Real-IP, etc.) will NOT be added
+# to requests forwarded to upstream, and the Server header in responses will NOT be overwritten.
+# Useful when you want the upstream server to not know it is being proxied.
+# stealth_mode = true
+
 # Optional: TLS setting. if https_port is specified and tls is true above, this must be given.
 # https_redirection can be specified only when both http_port and https_port are specified. If not explicitly specified, it is true by default.
 # if only https_port is given, https_redirection must not be specified.

--- a/rpxy-bin/src/config/toml.rs
+++ b/rpxy-bin/src/config/toml.rs
@@ -201,6 +201,7 @@ pub struct Application {
   pub server_name: Option<String>,
   pub reverse_proxy: Option<Vec<ReverseProxyOption>>,
   pub tls: Option<TlsOption>,
+  pub stealth_mode: Option<bool>,
 }
 
 #[derive(Deserialize, Debug, Default, PartialEq, Eq, Clone)]
@@ -556,6 +557,7 @@ impl Application {
       server_name: server_name_string.to_owned(),
       reverse_proxy: reverse_proxy_config,
       tls: tls_config,
+      stealth_mode: self.stealth_mode.unwrap_or(false),
     })
   }
 }
@@ -959,6 +961,7 @@ mod tests {
         health_check: None,
       }]),
       tls: None,
+      stealth_mode: None,
     };
     let result: Result<Vec<ReverseProxyConfig>, _> = (&app).try_into();
     assert!(result.is_err());

--- a/rpxy-lib/src/backend/backend_main.rs
+++ b/rpxy-lib/src/backend/backend_main.rs
@@ -28,6 +28,9 @@ pub struct BackendApp {
   #[builder(default)]
   #[allow(unused)]
   pub mutual_tls: Option<bool>,
+  /// stealth mode: hide proxy headers and server identity from backend
+  #[builder(default)]
+  pub stealth_mode: bool,
 }
 impl<'a> BackendAppBuilder {
   pub fn server_name(&mut self, server_name: impl Into<Cow<'a, str>>) -> &mut Self {
@@ -54,7 +57,8 @@ impl TryFrom<&AppConfig> for BackendApp {
     backend_builder
       .app_name(app_config.app_name.clone())
       .server_name(app_config.server_name.clone())
-      .path_manager(path_manager);
+      .path_manager(path_manager)
+      .stealth_mode(app_config.stealth_mode);
     // TLS settings and build backend instance
     let backend = if app_config.tls.is_none() {
       backend_builder.build()?

--- a/rpxy-lib/src/globals.rs
+++ b/rpxy-lib/src/globals.rs
@@ -162,6 +162,7 @@ pub struct AppConfig {
   pub server_name: String,
   pub reverse_proxy: Vec<ReverseProxyConfig>,
   pub tls: Option<TlsConfig>,
+  pub stealth_mode: bool,
 }
 
 /// Configuration parameters for single reverse proxy corresponding to the path

--- a/rpxy-lib/src/message_handler/handler_main.rs
+++ b/rpxy-lib/src/message_handler/handler_main.rs
@@ -152,6 +152,7 @@ where
         &upgrade_in_request,
         upstream_candidates,
         tls_enabled,
+        backend_app.stealth_mode,
       )
       .map_err(|e| HttpError::FailedToGenerateUpstreamRequest(e.to_string()))?;
 

--- a/rpxy-lib/src/message_handler/handler_manipulate_messages.rs
+++ b/rpxy-lib/src/message_handler/handler_manipulate_messages.rs
@@ -23,7 +23,9 @@ where
     let headers = response.headers_mut();
     remove_connection_header(headers);
     remove_hop_header(headers);
-    add_header_entry_overwrite_if_exist(headers, "server", RESPONSE_HEADER_SERVER)?;
+    if !backend_app.stealth_mode {
+      add_header_entry_overwrite_if_exist(headers, "server", RESPONSE_HEADER_SERVER)?;
+    }
 
     #[cfg(any(feature = "http3-quinn", feature = "http3-s2n"))]
     {
@@ -65,6 +67,7 @@ where
     upgrade: &Option<String>,
     upstream_candidates: &UpstreamCandidates,
     tls_enabled: bool,
+    stealth_mode: bool,
   ) -> Result<HandlerContext> {
     trace!("Generate request to be forwarded");
 
@@ -87,8 +90,10 @@ where
     remove_connection_header(headers);
     // delete hop headers including header.connection
     remove_hop_header(headers);
-    // X-Forwarded-For (and Forwarded if exists)
-    add_forwarding_header(headers, client_addr, listen_addr, tls_enabled, &original_uri)?;
+    // X-Forwarded-For (and Forwarded if exists), skipped in stealth mode
+    if !stealth_mode {
+      add_forwarding_header(headers, client_addr, listen_addr, tls_enabled, &original_uri)?;
+    }
 
     // Add te: trailer if te_trailer
     if contains_te_trailers {


### PR DESCRIPTION
# Stealth Mode

When `stealth_mode = true` is set for an app, rpxy acts as a transparent proxy at the HTTP layer — the upstream server cannot detect that requests are being proxied.

## Configuration

```toml
[apps.myapp]
server_name = "example.com"
stealth_mode = true
reverse_proxy = [{ upstream = [{ location = "http://backend:3000" }] }]
```

Default: `false`.

## What Changes

### Request Headers (not sent to upstream)

| Header | Description |
|---|---|
| `X-Forwarded-For` | Client IP address |
| `X-Real-IP` | Client IP address |
| `X-Forwarded-Proto` | Original protocol (`http` or `https`) |
| `X-Forwarded-Port` | Proxy listening port |
| `X-Forwarded-SSL` | TLS status (`on` or `off`) |
| `X-Original-URI` | Original full request URI |
| `proxy` | Empty proxy indicator |

### Response Headers (not overwritten)

| Header | Description |
|---|---|
| `Server` | Preserves the upstream's original `Server` value instead of overwriting it with `rpxy` |

All other headers are forwarded unchanged.
