### PR TITLE
feat(proxy): add upstream concurrency limit and min request interval …

### DIFF
--- a/rpxy-bin/src/config/toml.rs
+++ b/rpxy-bin/src/config/toml.rs
@@ -220,6 +220,10 @@ pub struct ReverseProxyOption {
   pub upstream: Vec<UpstreamParams>,
   pub upstream_options: Option<Vec<String>>,
   pub load_balance: Option<String>,
+  /// Maximum number of concurrent requests forwarded to upstream. Must be >= 1 if specified.
+  pub max_upstream_concurrency: Option<usize>,
+  /// Minimum interval (in milliseconds) between consecutive forwarded requests. Must be > 0 if specified.
+  pub min_request_interval_ms: Option<u64>,
   #[cfg(feature = "health-check")]
   pub health_check: Option<HealthCheckOption>,
 }
@@ -579,6 +583,36 @@ impl TryInto<Vec<ReverseProxyConfig>> for &Application {
       }
       let upstream = upstream_res.into_iter().map(|v| v.unwrap()).collect();
 
+      // Validate max_upstream_concurrency
+      if let Some(n) = rpo.max_upstream_concurrency {
+        ensure!(
+          n >= 1,
+          "[{}] max_upstream_concurrency must be >= 1, got {}",
+          &_server_name_string,
+          n
+        );
+      }
+
+      // Validate min_request_interval_ms
+      let min_request_interval = match rpo.min_request_interval_ms {
+        Some(ms) => {
+          ensure!(
+            ms > 0,
+            "[{}] min_request_interval_ms must be > 0, got {}",
+            &_server_name_string,
+            ms
+          );
+          ensure!(
+            ms <= 60_000,
+            "[{}] min_request_interval_ms must be <= 60000 (60s), got {}",
+            &_server_name_string,
+            ms
+          );
+          Some(Duration::from_millis(ms))
+        }
+        None => None,
+      };
+
       #[cfg(feature = "health-check")]
       let health_check = rpo
         .health_check
@@ -593,6 +627,8 @@ impl TryInto<Vec<ReverseProxyConfig>> for &Application {
         upstream,
         upstream_options: rpo.upstream_options.clone(),
         load_balance: rpo.load_balance.clone(),
+        max_upstream_concurrency: rpo.max_upstream_concurrency,
+        min_request_interval,
         #[cfg(feature = "health-check")]
         health_check,
       })
@@ -955,6 +991,8 @@ mod tests {
         upstream: vec![],
         upstream_options: None,
         load_balance: None,
+        max_upstream_concurrency: None,
+        min_request_interval_ms: None,
         #[cfg(feature = "health-check")]
         health_check: None,
       }]),

--- a/rpxy-lib/src/backend/mod.rs
+++ b/rpxy-lib/src/backend/mod.rs
@@ -11,7 +11,7 @@ pub(crate) use self::load_balance::{StickyCookie, StickyCookieValue};
 #[allow(unused)]
 pub(crate) use self::{
   load_balance::{LoadBalance, LoadBalanceContext},
-  upstream::{PathManager, Upstream, UpstreamCandidates},
+  upstream::{ConcurrencyLimiter, PathManager, Upstream, UpstreamCandidates},
   upstream_opts::UpstreamOption,
 };
 pub(crate) use backend_main::{BackendApp, BackendAppBuilderError, BackendAppManager};

--- a/rpxy-lib/src/backend/upstream.rs
+++ b/rpxy-lib/src/backend/upstream.rs
@@ -19,8 +19,10 @@ use derive_builder::Builder;
 #[cfg(feature = "sticky-cookie")]
 use sha2::{Digest, Sha256};
 use std::borrow::Cow;
-#[cfg(feature = "health-check")]
-use std::sync::Arc;
+use std::sync::{
+  Arc,
+  atomic::{AtomicUsize, Ordering},
+};
 use std::time::Duration;
 
 #[derive(Debug, Clone)]
@@ -236,17 +238,97 @@ impl RequestIntervalTracker {
       }
     };
 
-    if let Some((wait, reserved, _prev_start)) = wait_duration {
+    if let Some((wait, reserved, prev_start)) = wait_duration {
+      // RAII guard: if this future is dropped (cancelled) during sleep, roll back our reservation.
+      // Without rollback, each cancellation advances `last_request_at` by `duration` with no actual
+      // request forwarded, causing unbounded drift that permanently blocks subsequent requests.
+      struct RollbackGuard<'a> {
+        tracker: &'a RequestIntervalTracker,
+        reserved: tokio::time::Instant,
+        prev: Option<tokio::time::Instant>,
+        completed: bool,
+      }
+      impl Drop for RollbackGuard<'_> {
+        fn drop(&mut self) {
+          if !self.completed {
+            // The mutex is not held at the sleep await point, so try_lock() will succeed.
+            if let Ok(mut last) = self.tracker.last_request_at.try_lock()
+              && *last == Some(self.reserved)
+            {
+              *last = self.prev;
+            }
+          }
+        }
+      }
+
+      let mut guard = RollbackGuard {
+        tracker: self,
+        reserved,
+        prev: Some(prev_start),
+        completed: false,
+      };
+
       tokio::time::sleep(wait).await;
-      // After waking, update to actual start time (may differ slightly from reserved due to scheduling).
-      // If the sleep was cancelled (future dropped), this line won't execute and we need to roll back.
+
+      // Not cancelled — update to actual start time (may differ slightly from reserved due to scheduling).
       let mut last = self.last_request_at.lock().await;
       if *last == Some(reserved) {
-        // Still our reservation — we weren't cancelled. Update to actual start time.
         *last = Some(tokio::time::Instant::now());
       }
-      // If the reservation was already overwritten (e.g. by a timeout rollback), do nothing.
+      guard.completed = true;
     }
+  }
+}
+
+/// Wraps a semaphore with a waiting-request counter to expose queue depth for observability.
+pub struct ConcurrencyLimiter {
+  sem: tokio::sync::Semaphore,
+  /// Number of requests currently queued waiting to acquire a permit.
+  waiting: AtomicUsize,
+  capacity: usize,
+}
+
+impl std::fmt::Debug for ConcurrencyLimiter {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    f.debug_struct("ConcurrencyLimiter")
+      .field("capacity", &self.capacity)
+      .field("waiting", &self.waiting())
+      .field("in_flight", &self.in_flight())
+      .finish()
+  }
+}
+
+impl ConcurrencyLimiter {
+  pub fn new(capacity: usize) -> Arc<Self> {
+    Arc::new(Self {
+      sem: tokio::sync::Semaphore::new(capacity),
+      waiting: AtomicUsize::new(0),
+      capacity,
+    })
+  }
+
+  /// Increments the waiting counter. Returns the updated (new) waiting count.
+  pub(crate) fn enter_queue(&self) -> usize {
+    self.waiting.fetch_add(1, Ordering::Relaxed) + 1
+  }
+
+  /// Decrements the waiting counter. Returns the updated (new) waiting count.
+  pub(crate) fn leave_queue(&self) -> usize {
+    self.waiting.fetch_sub(1, Ordering::Relaxed) - 1
+  }
+
+  /// Number of requests currently waiting (queued) to acquire a permit.
+  pub(crate) fn waiting(&self) -> usize {
+    self.waiting.load(Ordering::Relaxed)
+  }
+
+  /// Number of requests currently holding a permit (actively being forwarded).
+  pub(crate) fn in_flight(&self) -> usize {
+    self.capacity.saturating_sub(self.sem.available_permits())
+  }
+
+  pub(crate) async fn acquire(&self) -> Result<tokio::sync::SemaphorePermit<'_>, tokio::sync::AcquireError> {
+    self.sem.acquire().await
   }
 }
 
@@ -274,9 +356,9 @@ pub struct UpstreamCandidates {
   pub options: HashSet<UpstreamOption>,
 
   /// Limits concurrent in-flight requests to upstream.
-  /// `None` = unlimited (default). `Some(Arc<Semaphore>)` = FIFO queue.
+  /// `None` = unlimited (default). `Some(Arc<ConcurrencyLimiter>)` = FIFO queue.
   #[builder(setter(custom), default)]
-  pub concurrency_limiter: Option<Arc<tokio::sync::Semaphore>>,
+  pub concurrency_limiter: Option<Arc<ConcurrencyLimiter>>,
 
   /// Minimum interval between consecutive forwarded requests.
   /// When `Some`, ensures at least this duration elapses between the START of each forwarded request.
@@ -372,7 +454,7 @@ impl UpstreamCandidatesBuilder {
 
   /// Set the maximum upstream concurrency from optional permit count
   pub fn concurrency_limiter(&mut self, v: &Option<usize>) -> &mut Self {
-    self.concurrency_limiter = Some(v.as_ref().map(|n| Arc::new(tokio::sync::Semaphore::new(*n))));
+    self.concurrency_limiter = Some(v.as_ref().map(|n| ConcurrencyLimiter::new(*n)));
     self
   }
 

--- a/rpxy-lib/src/backend/upstream.rs
+++ b/rpxy-lib/src/backend/upstream.rs
@@ -21,6 +21,7 @@ use sha2::{Digest, Sha256};
 use std::borrow::Cow;
 #[cfg(feature = "health-check")]
 use std::sync::Arc;
+use std::time::Duration;
 
 #[derive(Debug, Clone)]
 /// Handler for given path to route incoming request to path's corresponding upstream server(s).
@@ -58,7 +59,9 @@ impl TryFrom<&AppConfig> for PathManager {
         .path(&rpc.path)
         .replace_path(&rpc.replace_path)
         .load_balance(&rpc.load_balance, &upstream_vec, &app_config.server_name, &rpc.path)
-        .options(&rpc.upstream_options);
+        .options(&rpc.upstream_options)
+        .concurrency_limiter(&rpc.max_upstream_concurrency)
+        .min_request_interval(&rpc.min_request_interval);
 
       #[cfg(feature = "health-check")]
       builder.health_check_config(&rpc.health_check);
@@ -169,6 +172,84 @@ impl Upstream {
     general_purpose::URL_SAFE_NO_PAD.encode(digest)
   }
 }
+/// Tracks the minimum interval between consecutive forwarded requests.
+///
+/// Uses a "reserve timestamp" pattern: when a task needs to wait, it immediately
+/// reserves a future slot so the next task can compute its correct wait time,
+/// preventing thundering-herd issues when multiple tasks arrive simultaneously.
+///
+/// If the task is cancelled while sleeping, the reserved timestamp is rolled back
+/// to prevent unbounded drift that would block subsequent requests.
+pub struct RequestIntervalTracker {
+  /// The configured minimum interval duration
+  duration: Duration,
+  /// Timestamp of the last (or reserved) forwarded request start; `None` until the first request
+  last_request_at: tokio::sync::Mutex<Option<tokio::time::Instant>>,
+}
+
+impl std::fmt::Debug for RequestIntervalTracker {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    f.debug_struct("RequestIntervalTracker")
+      .field("duration", &self.duration)
+      .finish()
+  }
+}
+
+impl RequestIntervalTracker {
+  pub fn new(duration: Duration) -> Self {
+    Self {
+      duration,
+      last_request_at: tokio::sync::Mutex::new(None),
+    }
+  }
+
+  /// Enforces the minimum interval between consecutive forwarded requests.
+  ///
+  /// Must be called AFTER acquiring any concurrency semaphore and BEFORE forwarding.
+  /// The interval is measured between the *start* of each forwarded request.
+  ///
+  /// Cancellation-safe: if the caller's future is dropped while sleeping, the reserved
+  /// timestamp is rolled back so subsequent requests are not blocked by a phantom reservation.
+  pub async fn enforce_interval(&self) {
+    let wait_duration = {
+      let mut last = self.last_request_at.lock().await;
+      let now = tokio::time::Instant::now();
+      match *last {
+        Some(prev_start) => {
+          let earliest_start = prev_start + self.duration;
+          if now >= earliest_start {
+            // Enough time has elapsed — proceed immediately
+            *last = Some(now);
+            None
+          } else {
+            // Need to wait. Reserve our slot so next caller sees the correct timestamp.
+            let wait = earliest_start - now;
+            *last = Some(earliest_start);
+            Some((wait, earliest_start, prev_start))
+          }
+        }
+        None => {
+          // First request ever — no waiting needed
+          *last = Some(now);
+          None
+        }
+      }
+    };
+
+    if let Some((wait, reserved, _prev_start)) = wait_duration {
+      tokio::time::sleep(wait).await;
+      // After waking, update to actual start time (may differ slightly from reserved due to scheduling).
+      // If the sleep was cancelled (future dropped), this line won't execute and we need to roll back.
+      let mut last = self.last_request_at.lock().await;
+      if *last == Some(reserved) {
+        // Still our reservation — we weren't cancelled. Update to actual start time.
+        *last = Some(tokio::time::Instant::now());
+      }
+      // If the reservation was already overwritten (e.g. by a timeout rollback), do nothing.
+    }
+  }
+}
+
 #[derive(Debug, Clone, Builder)]
 /// Struct serving multiple upstream servers for, e.g., load balancing.
 pub struct UpstreamCandidates {
@@ -191,6 +272,16 @@ pub struct UpstreamCandidates {
   #[builder(setter(custom), default)]
   /// Activated upstream options defined in [[UpstreamOption]]
   pub options: HashSet<UpstreamOption>,
+
+  /// Limits concurrent in-flight requests to upstream.
+  /// `None` = unlimited (default). `Some(Arc<Semaphore>)` = FIFO queue.
+  #[builder(setter(custom), default)]
+  pub concurrency_limiter: Option<Arc<tokio::sync::Semaphore>>,
+
+  /// Minimum interval between consecutive forwarded requests.
+  /// When `Some`, ensures at least this duration elapses between the START of each forwarded request.
+  #[builder(setter(custom), default)]
+  pub min_request_interval: Option<Arc<RequestIntervalTracker>>,
 
   #[cfg(feature = "health-check")]
   #[builder(setter(custom), default)]
@@ -276,6 +367,18 @@ impl UpstreamCandidatesBuilder {
       },
     );
     self.options = Some(opts);
+    self
+  }
+
+  /// Set the maximum upstream concurrency from optional permit count
+  pub fn concurrency_limiter(&mut self, v: &Option<usize>) -> &mut Self {
+    self.concurrency_limiter = Some(v.as_ref().map(|n| Arc::new(tokio::sync::Semaphore::new(*n))));
+    self
+  }
+
+  /// Set the minimum request interval from optional duration
+  pub fn min_request_interval(&mut self, v: &Option<Duration>) -> &mut Self {
+    self.min_request_interval = Some(v.as_ref().map(|d| Arc::new(RequestIntervalTracker::new(*d))));
     self
   }
 }

--- a/rpxy-lib/src/backend/upstream.rs
+++ b/rpxy-lib/src/backend/upstream.rs
@@ -270,19 +270,22 @@ impl RequestIntervalTracker {
 
       tokio::time::sleep(wait).await;
 
+      // Mark completed immediately after sleep so a cancellation between here and the lock below
+      // cannot incorrectly roll back a sleep that has already been honoured.
+      guard.completed = true;
+
       // Not cancelled — update to actual start time (may differ slightly from reserved due to scheduling).
       let mut last = self.last_request_at.lock().await;
       if *last == Some(reserved) {
         *last = Some(tokio::time::Instant::now());
       }
-      guard.completed = true;
     }
   }
 }
 
 /// Wraps a semaphore with a waiting-request counter to expose queue depth for observability.
 pub struct ConcurrencyLimiter {
-  sem: tokio::sync::Semaphore,
+  sem: Arc<tokio::sync::Semaphore>,
   /// Number of requests currently queued waiting to acquire a permit.
   waiting: AtomicUsize,
   capacity: usize,
@@ -301,7 +304,7 @@ impl std::fmt::Debug for ConcurrencyLimiter {
 impl ConcurrencyLimiter {
   pub fn new(capacity: usize) -> Arc<Self> {
     Arc::new(Self {
-      sem: tokio::sync::Semaphore::new(capacity),
+      sem: Arc::new(tokio::sync::Semaphore::new(capacity)),
       waiting: AtomicUsize::new(0),
       capacity,
     })
@@ -327,8 +330,10 @@ impl ConcurrencyLimiter {
     self.capacity.saturating_sub(self.sem.available_permits())
   }
 
-  pub(crate) async fn acquire(&self) -> Result<tokio::sync::SemaphorePermit<'_>, tokio::sync::AcquireError> {
-    self.sem.acquire().await
+  /// Acquires an owned permit. The returned permit is lifetime-free and can be stored in a
+  /// response body wrapper so the concurrency slot stays held until the body is fully consumed.
+  pub(crate) async fn acquire_owned(&self) -> Result<tokio::sync::OwnedSemaphorePermit, tokio::sync::AcquireError> {
+    Arc::clone(&self.sem).acquire_owned().await
   }
 }
 

--- a/rpxy-lib/src/globals.rs
+++ b/rpxy-lib/src/globals.rs
@@ -172,6 +172,14 @@ pub struct ReverseProxyConfig {
   pub upstream: Vec<UpstreamUri>,
   pub upstream_options: Option<Vec<String>>,
   pub load_balance: Option<String>,
+  /// Maximum number of concurrent requests forwarded to upstream.
+  /// When `Some(n)`, excess requests queue (FIFO) until an in-flight slot frees.
+  /// When `None` (default), concurrency is unlimited.
+  pub max_upstream_concurrency: Option<usize>,
+  /// Minimum interval between consecutive forwarded requests.
+  /// When `Some(d)`, ensures at least this duration elapses between the START of each forwarded request.
+  /// When `None` (default), no interval is enforced.
+  pub min_request_interval: Option<Duration>,
   #[cfg(feature = "health-check")]
   pub health_check: Option<HealthCheckConfig>,
 }

--- a/rpxy-lib/src/hyper_ext/body_type.rs
+++ b/rpxy-lib/src/hyper_ext/body_type.rs
@@ -49,7 +49,7 @@ pub type UnboundedStreamBody = StreamBody<UnboundedReceiver<Result<Frame<bytes::
 #[allow(unused)]
 /// Response body use in this project
 /// - Incoming: just a type that only forwards the upstream response body to downstream.
-/// - Boxed: a type that is generated from cache or synthetic response body, e.g.,, small byte object.
+/// - Boxed: a type that is generated from cache or synthetic response body, e.g., small byte object.
 /// - Streamed: another type that is generated from stream, e.g., large byte object.
 pub enum ResponseBody {
   Incoming(Incoming),
@@ -66,10 +66,9 @@ impl Body for ResponseBody {
     cx: &mut std::task::Context<'_>,
   ) -> std::task::Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
     match self.get_mut() {
-      ResponseBody::Incoming(incoming) => Pin::new(incoming).poll_frame(cx),
-      ResponseBody::Boxed(boxed) => Pin::new(boxed).poll_frame(cx),
-      ResponseBody::Streamed(streamed) => Pin::new(streamed).poll_frame(cx),
+      ResponseBody::Incoming(incoming) => Pin::new(incoming).poll_frame(cx).map_err(RpxyError::HyperBodyError),
+      ResponseBody::Boxed(boxed) => Pin::new(boxed).poll_frame(cx).map_err(RpxyError::HyperBodyError),
+      ResponseBody::Streamed(streamed) => Pin::new(streamed).poll_frame(cx).map_err(RpxyError::HyperBodyError),
     }
-    .map_err(RpxyError::HyperBodyError)
   }
 }

--- a/rpxy-lib/src/message_handler/handler_main.rs
+++ b/rpxy-lib/src/message_handler/handler_main.rs
@@ -6,7 +6,7 @@ use super::{
   utils_request::InspectParseHost,
 };
 use crate::{
-  backend::{BackendAppManager, LoadBalanceContext},
+  backend::{BackendAppManager, ConcurrencyLimiter, LoadBalanceContext},
   error::*,
   forwarder::{ForwardRequest, Forwarder},
   globals::Globals,
@@ -136,15 +136,74 @@ where
     // Enforce maximum upstream concurrency (acquire permit first).
     // This ensures interval-wait only happens for tasks that actually hold a concurrency slot.
     // The permit is held until the function returns, covering the full forwarder.request() call.
-    // Queued tasks proceed in FIFO order.
-    let _concurrency_permit = match upstream_candidates.concurrency_limiter.as_ref() {
-      Some(sem) => Some(
-        sem
-          .acquire()
-          .await
-          .map_err(|e| HttpError::FailedToGetResponseFromBackend(format!("upstream concurrency semaphore closed: {e}")))?,
-      ),
-      None => None,
+    // Queued tasks proceed in FIFO order (Tokio Semaphore is fair).
+    let _concurrency_permit = if let Some(limiter) = upstream_candidates.concurrency_limiter.as_deref() {
+      // RAII guard: ensures leave_queue() is called even if this future is cancelled during acquire().
+      struct QueueGuard<'a> {
+        limiter: &'a ConcurrencyLimiter,
+        left: bool,
+      }
+      impl Drop for QueueGuard<'_> {
+        fn drop(&mut self) {
+          if !self.left {
+            self.limiter.leave_queue();
+          }
+        }
+      }
+
+      let queued = limiter.enter_queue();
+      debug!(
+        "Upstream concurrency [{}]: request queued, waiting={}, in_flight={}",
+        path,
+        queued,
+        limiter.in_flight()
+      );
+      let mut queue_guard = QueueGuard { limiter, left: false };
+
+      let permit = limiter
+        .acquire()
+        .await
+        .map_err(|e| HttpError::FailedToGetResponseFromBackend(format!("upstream concurrency semaphore closed: {e}")))?;
+
+      // Permit acquired — remove from the waiting count before forwarding.
+      queue_guard.left = true;
+      let waiting_now = limiter.leave_queue();
+      debug!(
+        "Upstream concurrency [{}]: permit acquired, waiting={}, in_flight={}",
+        path,
+        waiting_now,
+        limiter.in_flight()
+      );
+
+      // RAII permit guard: releases the semaphore permit and logs queue state when this request finishes.
+      // Note: for WebSocket upgrades the bidirectional copy runs in a spawned task beyond this scope,
+      // so serial enforcement covers only the HTTP handshake, not the full WebSocket session lifetime.
+      struct PermitGuard<'a> {
+        permit: std::mem::ManuallyDrop<tokio::sync::SemaphorePermit<'a>>,
+        limiter: &'a ConcurrencyLimiter,
+        path: String,
+      }
+      impl Drop for PermitGuard<'_> {
+        fn drop(&mut self) {
+          // Release the permit before reading counts so in_flight reflects the post-release state.
+          // SAFETY: permit is valid; this is the only drop site (completed=false path never runs twice).
+          unsafe { std::mem::ManuallyDrop::drop(&mut self.permit) };
+          debug!(
+            "Upstream concurrency [{}]: request finished, waiting={}, in_flight={}",
+            self.path,
+            self.limiter.waiting(),
+            self.limiter.in_flight()
+          );
+        }
+      }
+
+      Some(PermitGuard {
+        permit: std::mem::ManuallyDrop::new(permit),
+        limiter,
+        path: path.to_owned(),
+      })
+    } else {
+      None
     };
 
     /////////////////////////////////////////////////////

--- a/rpxy-lib/src/message_handler/handler_main.rs
+++ b/rpxy-lib/src/message_handler/handler_main.rs
@@ -133,12 +133,16 @@ where
     let upstream_candidates = backend_app.path_manager.get(path).ok_or(HttpError::NoUpstreamCandidates)?;
 
     /////////////////////////////////////////////////////
-    // Enforce maximum upstream concurrency (acquire permit first).
-    // This ensures interval-wait only happens for tasks that actually hold a concurrency slot.
-    // The permit is held until the function returns, covering the full forwarder.request() call.
-    // Queued tasks proceed in FIFO order (Tokio Semaphore is fair).
+    // Enforce maximum upstream concurrency.
+    // The permit is held as a local variable for the duration of handle_request_inner():
+    // it is released when this function returns, i.e., after upstream response headers are
+    // received. Body streaming to the downstream client happens after this function returns,
+    // so the next queued request can start as soon as the upstream has accepted the current one.
+    // This is intentional: serialising only the request/header phase lets streaming responses
+    // (SSE, large JSON) be delivered concurrently while still preventing thundering-herd sends
+    // to upstream.
     let _concurrency_permit = if let Some(limiter) = upstream_candidates.concurrency_limiter.as_deref() {
-      // RAII guard: ensures leave_queue() is called even if this future is cancelled during acquire().
+      // QueueGuard ensures leave_queue() is called even if this future is cancelled during acquire().
       struct QueueGuard<'a> {
         limiter: &'a ConcurrencyLimiter,
         left: bool,
@@ -161,11 +165,10 @@ where
       let mut queue_guard = QueueGuard { limiter, left: false };
 
       let permit = limiter
-        .acquire()
+        .acquire_owned()
         .await
         .map_err(|e| HttpError::FailedToGetResponseFromBackend(format!("upstream concurrency semaphore closed: {e}")))?;
 
-      // Permit acquired — remove from the waiting count before forwarding.
       queue_guard.left = true;
       let waiting_now = limiter.leave_queue();
       debug!(
@@ -175,33 +178,7 @@ where
         limiter.in_flight()
       );
 
-      // RAII permit guard: releases the semaphore permit and logs queue state when this request finishes.
-      // Note: for WebSocket upgrades the bidirectional copy runs in a spawned task beyond this scope,
-      // so serial enforcement covers only the HTTP handshake, not the full WebSocket session lifetime.
-      struct PermitGuard<'a> {
-        permit: std::mem::ManuallyDrop<tokio::sync::SemaphorePermit<'a>>,
-        limiter: &'a ConcurrencyLimiter,
-        path: String,
-      }
-      impl Drop for PermitGuard<'_> {
-        fn drop(&mut self) {
-          // Release the permit before reading counts so in_flight reflects the post-release state.
-          // SAFETY: permit is valid; this is the only drop site (completed=false path never runs twice).
-          unsafe { std::mem::ManuallyDrop::drop(&mut self.permit) };
-          debug!(
-            "Upstream concurrency [{}]: request finished, waiting={}, in_flight={}",
-            self.path,
-            self.limiter.waiting(),
-            self.limiter.in_flight()
-          );
-        }
-      }
-
-      Some(PermitGuard {
-        permit: std::mem::ManuallyDrop::new(permit),
-        limiter,
-        path: path.to_owned(),
-      })
+      Some(permit)
     } else {
       None
     };

--- a/rpxy-lib/src/message_handler/handler_main.rs
+++ b/rpxy-lib/src/message_handler/handler_main.rs
@@ -132,6 +132,28 @@ where
     let path = req.uri().path();
     let upstream_candidates = backend_app.path_manager.get(path).ok_or(HttpError::NoUpstreamCandidates)?;
 
+    /////////////////////////////////////////////////////
+    // Enforce maximum upstream concurrency (acquire permit first).
+    // This ensures interval-wait only happens for tasks that actually hold a concurrency slot.
+    // The permit is held until the function returns, covering the full forwarder.request() call.
+    // Queued tasks proceed in FIFO order.
+    let _concurrency_permit = match upstream_candidates.concurrency_limiter.as_ref() {
+      Some(sem) => Some(
+        sem
+          .acquire()
+          .await
+          .map_err(|e| HttpError::FailedToGetResponseFromBackend(format!("upstream concurrency semaphore closed: {e}")))?,
+      ),
+      None => None,
+    };
+
+    /////////////////////////////////////////////////////
+    // Enforce minimum request interval (rate limiting).
+    // Called AFTER acquiring the concurrency semaphore so only tasks with a slot pay the wait cost.
+    if let Some(tracker) = &upstream_candidates.min_request_interval {
+      tracker.enforce_interval().await;
+    }
+
     // Upgrade in request header
     let upgrade_in_request = extract_upgrade(req.headers());
     if upgrade_in_request.is_some() && req.version() != http::Version::HTTP_11 {


### PR DESCRIPTION
# Upstream Concurrency & Rate Limiter

Per-route controls for concurrent and rate-limited upstream forwarding.

## Config

```toml
[[apps.myapp.reverse_proxy]]
path = "/"
upstream = [{ location = "http://localhost:3000" }]
max_upstream_concurrency = 1     # max concurrent requests (default: unlimited)
min_request_interval_ms = 500    # min gap between request starts, max 60000 (default: unlimited)
```

- Excess requests queue in FIFO order, never rejected.
- Interval is measured between request **starts**, not ends.

## How it works

1. Acquire a concurrency semaphore slot (FIFO queue).
2. Enforce minimum interval using a reserve-timestamp algorithm (thundering-herd safe, cancellation safe).
3. Forward the request. Semaphore permit released on return.

Uses `tokio::sync::Mutex` for the interval tracker to avoid blocking async worker threads.

## Files

- `rpxy-lib/src/globals.rs` — config fields
- `rpxy-bin/src/config/toml.rs` — parsing & validation
- `rpxy-lib/src/backend/upstream.rs` — `RequestIntervalTracker` & semaphore setup
- `rpxy-lib/src/message_handler/handler_main.rs` — enforce limits before forwarding
