### PR TITLE
Add support for TLS 0-RTT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Important Changes
 
-- **Breaking: enable TLS 0-RTT by default** This improves security by encrypting the Server Name Indication (SNI) value used in TLS handshake for repeat visitors. This value contains the server / website hostname. You can disable this by setting the `tls_0rtt` option to `false`.
+- **Breaking: enable TLS 0-RTT by default** This improves performance by reducing round trips required during a TLS handshake from three to two for repeat visitors. However, this comes at the cost of a enabling a replay attack. Any web application should be idempotent to address this issue. You can disable this by setting the `tls_0rtt` option to `false`.
 
 ## 0.12.0 (To be released shortly)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.12.1 or 0.13.0 (Unreleased)
 
+### Important Changes
+
+- **Breaking: enable TLS 0-RTT by default** This improves security by encrypting the Server Name Indication (SNI) value used in TLS handshake for repeat visitors. This value contains the server / website hostname. You can disable this by setting the `tls_0rtt` option to `false`.
+
 ## 0.12.0 (To be released shortly)
 
 ### Important Changes

--- a/config-example.toml
+++ b/config-example.toml
@@ -37,6 +37,9 @@ listen_ipv6 = false
 # Otherwise, the server sends Alt-SVC and 301 with the same port as `listen_port_tls`.
 # https_redirection_port = 443
 
+# Optional. Reduce reconnection round trip time (RTT) by one trip during TLS connection. TLS 0-RTT is enabled by default.
+# tls_0rtt = false
+
 # Optional for h2 and http1.1
 tcp_listen_backlog = 1024
 

--- a/rpxy-bin/src/config/parse.rs
+++ b/rpxy-bin/src/config/parse.rs
@@ -104,6 +104,8 @@ pub async fn build_cert_manager(
     return Ok(None);
   }
 
+  let tls_0rtt = config.tls_0rtt.unwrap_or(true);
+
   #[cfg(feature = "acme")]
   let acme_option = config.experimental.as_ref().and_then(|v| v.acme.clone());
   #[cfg(feature = "acme")]
@@ -138,7 +140,7 @@ pub async fn build_cert_manager(
       crypto_source_map.insert(server_name.to_owned(), crypto_file_source);
     }
   }
-  let res = build_cert_reloader(&crypto_source_map, None).await?;
+  let res = build_cert_reloader(&crypto_source_map, tls_0rtt, None).await?;
   Ok(Some(res))
 }
 

--- a/rpxy-bin/src/config/toml.rs
+++ b/rpxy-bin/src/config/toml.rs
@@ -56,6 +56,7 @@ impl OneOrMany {
 /// - `listen_address_v6`: Optional IPv6 address(es) to bind (default: ::). Accepts a single string or an array.
 /// - `listen_ipv6`: Enable IPv6 listening. If listen_address_v6 is not specified, binds to '::' when true, and disables IPv6 when false (default: false).
 /// - `https_redirection_port`: Optional port for HTTP to HTTPS redirection.
+/// - `tls_0rtt`: Enable TLS 0-RTT
 /// - `tcp_listen_backlog`: Optional TCP backlog size.
 /// - `max_concurrent_streams`: Optional max concurrent streams.
 /// - `max_clients`: Optional max client connections.
@@ -70,6 +71,7 @@ pub struct ConfigToml {
   pub listen_address_v6: Option<OneOrMany>,
   pub listen_ipv6: Option<bool>,
   pub https_redirection_port: Option<u16>,
+  pub tls_0rtt: Option<bool>,
   pub tcp_listen_backlog: Option<u32>,
   pub max_concurrent_streams: Option<u32>,
   pub max_clients: Option<u32>,
@@ -276,6 +278,7 @@ impl TryInto<ProxyConfig> for &ConfigToml {
       } else {
         self.listen_port_tls
       },
+      tls_0rtt: self.tls_0rtt.unwrap_or(true),
       ..Default::default()
     };
     ensure!(
@@ -1093,5 +1096,27 @@ mod tests {
       healthy_threshold: 2,
     });
     assert!(validate_lb_health_check("example.com", Some(LOAD_BALANCE_PRIMARY_BACKUP), &health_check).is_ok());
+  }
+
+  #[test]
+  fn tls_0rtt_enabled() {
+    let alias = r#"
+      listen_port = 8080
+      tls_0rtt = true
+    "#;
+    let config: ConfigToml = toml::from_str(alias).unwrap();
+    let proxy_config: ProxyConfig = (&config).try_into().unwrap();
+    assert_eq!(proxy_config.tls_0rtt, true);
+  }
+
+  #[test]
+  fn tls_0rtt_disabled() {
+    let alias = r#"
+      listen_port = 8080
+      tls_0rtt = false
+    "#;
+    let config: ConfigToml = toml::from_str(alias).unwrap();
+    let proxy_config: ProxyConfig = (&config).try_into().unwrap();
+    assert_eq!(proxy_config.tls_0rtt, false);
   }
 }

--- a/rpxy-certs/src/lib.rs
+++ b/rpxy-certs/src/lib.rs
@@ -9,7 +9,7 @@ mod log {
   pub(super) use tracing::{debug, error, info, warn};
 }
 
-use crate::{error::*, log::*, reloader_service::DynCryptoSource};
+use crate::{error::*, log::*, reloader_service::{DynCryptoSource, ServerCryptoSource}};
 use ahash::HashMap;
 use hot_reload::{ReloaderReceiver, ReloaderService};
 use rustls::crypto::CryptoProvider;
@@ -36,6 +36,7 @@ type ReloaderServiceResultInner = (
 /// Build certificate reloader service, which accepts a map of server names to `CryptoSource` instances
 pub async fn build_cert_reloader<T>(
   crypto_source_map: &HashMap<String, T>,
+  tls_0rtt: bool,
   certs_watch_period: Option<u32>,
 ) -> Result<ReloaderServiceResultInner, RpxyCertError>
 where
@@ -48,7 +49,7 @@ where
   #[cfg(feature = "post-quantum")]
   let _ = CryptoProvider::install_default(rustls_post_quantum::provider());
 
-  let source = crypto_source_map
+  let inner = crypto_source_map
     .iter()
     .map(|(k, v)| {
       let server_name_bytes = k.as_bytes().to_vec().to_ascii_lowercase();
@@ -56,6 +57,11 @@ where
       (server_name_bytes, dyn_crypto_source)
     })
     .collect::<HashMap<_, _>>();
+
+  let source = ServerCryptoSource {
+      inner,
+      tls_0rtt,
+  };
 
   let certs_watch_period = certs_watch_period.unwrap_or(DEFAULT_CERTS_WATCH_DELAY_SECS);
 

--- a/rpxy-certs/src/reloader_service.rs
+++ b/rpxy-certs/src/reloader_service.rs
@@ -18,6 +18,7 @@ pub(super) type DynCryptoSource = dyn CryptoSource<Error = RpxyCertError> + Send
 /// Reloader service for certificates and keys for TLS
 pub struct CryptoReloader {
   inner: HashMap<ServerNameBytes, Arc<Box<DynCryptoSource>>>,
+  tls_0rtt: bool,
 }
 
 impl<T> Extend<(ServerNameBytes, T)> for CryptoReloader
@@ -32,18 +33,24 @@ where
   }
 }
 
+pub struct ServerCryptoSource {
+  pub(super) inner: HashMap<ServerNameBytes, Arc<Box<DynCryptoSource>>>,
+  pub(super) tls_0rtt: bool,
+}
+
 #[async_trait]
 impl Reload<ServerCryptoBase> for CryptoReloader {
-  type Source = HashMap<ServerNameBytes, Arc<Box<DynCryptoSource>>>;
+  type Source = ServerCryptoSource;
 
   async fn new(source: &Self::Source) -> Result<Self, ReloaderError<ServerCryptoBase>> {
     let mut inner = HashMap::default();
-    inner.extend(source.clone());
-    Ok(Self { inner })
+    inner.extend(source.inner.clone());
+    Ok(Self { inner, tls_0rtt: source.tls_0rtt, })
   }
 
   async fn reload(&self) -> Result<Option<ServerCryptoBase>, ReloaderError<ServerCryptoBase>> {
     let mut server_crypto_base = ServerCryptoBase::default();
+    server_crypto_base.tls_0rtt = self.tls_0rtt;
 
     for (server_name_bytes, crypto_source) in self.inner.iter() {
       let certs_keys = match crypto_source.read().await {
@@ -72,7 +79,8 @@ mod tests {
     let tls_cert_key_path = "../example-certs/server.key";
     let client_ca_cert_path = Some("../example-certs/client.ca.crt");
 
-    let mut crypto_reloader = CryptoReloader::new(&HashMap::default()).await.unwrap();
+    let server_crypto_source = ServerCryptoSource { inner: HashMap::default(), tls_0rtt: false };
+    let mut crypto_reloader = CryptoReloader::new(&server_crypto_source).await.unwrap();
     let crypto_source = CryptoFileSourceBuilder::default()
       .tls_cert_path(tls_cert_path)
       .tls_cert_key_path(tls_cert_key_path)
@@ -83,5 +91,6 @@ mod tests {
 
     let server_crypto_base = crypto_reloader.reload().await.unwrap().unwrap();
     assert_eq!(server_crypto_base.inner.len(), 1);
+    assert_eq!(server_crypto_base.tls_0rtt, false);
   }
 }

--- a/rpxy-certs/src/server_crypto.rs
+++ b/rpxy-certs/src/server_crypto.rs
@@ -29,11 +29,22 @@ pub struct ServerCrypto {
 
 /* ------------------------------------------------ */
 /// Reloader target for the certificate reloader service
-#[derive(Debug, PartialEq, Eq, Clone, Default)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct ServerCryptoBase {
   /// Map of server name to certs and keys
   pub(super) inner: HashMap<ServerNameBytes, SingleServerCertsKeys>,
+  pub(super) tls_0rtt: bool,
 }
+
+impl Default for ServerCryptoBase {
+  fn default() -> Self {
+    Self {
+      tls_0rtt: true,
+      inner: Default::default(),
+    }
+  }
+}
+
 
 impl TryInto<Arc<ServerCrypto>> for &ServerCryptoBase {
   type Error = RpxyCertError;
@@ -77,6 +88,14 @@ impl ServerCryptoBase {
           .with_no_client_auth()
           .with_cert_resolver(Arc::new(resolver_local));
 
+        if self.tls_0rtt {
+          // Limit up to 1000 bytes for early data
+          server_crypto_local.max_early_data_size = 1000;
+        } else {
+          // TLS 0-RTT is disabled by setting this to zero
+          server_crypto_local.max_early_data_size = 0;
+        }
+
         #[cfg(feature = "http3")]
         {
           server_crypto_local.alpn_protocols = vec![b"h3".to_vec(), b"h2".to_vec(), b"http/1.1".to_vec()];
@@ -108,6 +127,15 @@ impl ServerCryptoBase {
         .with_safe_default_protocol_versions()?
         .with_client_cert_verifier(client_cert_verifier)
         .with_cert_resolver(Arc::new(resolver_local));
+
+      if self.tls_0rtt {
+        // Limit up to 1000 bytes for early data
+        server_crypto_local.max_early_data_size = 1000;
+      } else {
+        // TLS 0-RTT is disabled by setting this to zero
+        server_crypto_local.max_early_data_size = 0;
+      }
+
       server_crypto_local.alpn_protocols = vec![b"h2".to_vec(), b"http/1.1".to_vec()];
       server_crypto_map.insert(server_name_bytes.clone(), Arc::new(server_crypto_local));
     }
@@ -144,6 +172,14 @@ impl ServerCryptoBase {
       .with_safe_default_protocol_versions()?
       .with_no_client_auth()
       .with_cert_resolver(Arc::new(resolver_global));
+
+    if self.tls_0rtt {
+      // Limit up to 1000 bytes for early data
+      server_crypto_global.max_early_data_size = 1000;
+    } else {
+      // TLS 0-RTT is disabled by setting this to zero
+      server_crypto_global.max_early_data_size = 0;
+    }
 
     #[cfg(feature = "http3")]
     {
@@ -205,5 +241,7 @@ mod tests {
         vec![b"h2".to_vec(), b"http/1.1".to_vec()]
       );
     }
+
+    assert_eq!(server_crypto.aggregated_config_no_client_auth.max_early_data_size, 1000);
   }
 }

--- a/rpxy-lib/src/globals.rs
+++ b/rpxy-lib/src/globals.rs
@@ -73,6 +73,9 @@ pub struct ProxyConfig {
   /// timeout to handle a connection, total time of receive request, serve, and send response. this might limits the max length of response.
   pub connection_handling_timeout: Option<Duration>,
 
+  /// TLS 0-RTT
+  pub tls_0rtt: bool,
+
   #[cfg(feature = "cache")]
   pub cache_enabled: bool,
   #[cfg(feature = "cache")]
@@ -121,6 +124,8 @@ impl Default for ProxyConfig {
       sni_consistency: true,
       trusted_forwarded_proxies: Vec::new(),
       connection_handling_timeout: None,
+
+      tls_0rtt: true,
 
       #[cfg(feature = "proxy-protocol")]
       tcp_recv_proxy_protocol: None,

--- a/rpxy-lib/src/proxy/proxy_quic_quinn.rs
+++ b/rpxy-lib/src/proxy/proxy_quic_quinn.rs
@@ -21,11 +21,16 @@ where
     // first set as null config server
     // AWS LC provider by default
     let provider = rustls::crypto::CryptoProvider::get_default().ok_or(RpxyError::NoDefaultCryptoProvider)?;
-    let rustls_server_config = ServerConfig::builder_with_provider(provider.clone())
+    let mut rustls_server_config = ServerConfig::builder_with_provider(provider.clone())
       .with_protocol_versions(&[&rustls::version::TLS13])
       .map_err(|e| RpxyError::FailedToBuildServerConfig(format!("TLS 1.3 server config failed: {e}")))?
       .with_no_client_auth()
       .with_cert_resolver(Arc::new(rustls::server::ResolvesServerCertUsingSni::new()));
+    rustls_server_config.max_early_data_size = if self.globals.proxy_config.tls_0rtt {
+        1000 // Limit up to 1000 bytes fo early data
+    } else {
+        0 // TLS 0-RTT is disabled by setting this to zero
+    };
     let quinn_server_config_crypto = QuicServerConfig::try_from(Arc::new(rustls_server_config)).unwrap();
 
     let mut transport_config_quic = TransportConfig::default();


### PR DESCRIPTION
* Enabled by default
* Add `tls_0rtt` config option
* Enabled for HTTP/1, HTTP/2 and HTTP/3 with quinn
* s2n-quic appears not to support TLS 0-RTT
* Update Tests
* Update config-example.toml
* Update CHANGELOG.md

Fixes #547 

Enabling 0-RTT by default is a breaking change, let me know if it's better to leave it disabled instead.

I was able to confirm this worked using python `sslyze` and with the rustls `simple_0rtt_client` example code.

With 0-RTT disabled
```
➜  examples git:(main) python -m sslyze --early_data localhost:8443

 CHECKING CONNECTIVITY TO SERVER(S)
 ----------------------------------

   localhost:8443            => 127.0.0.1 


 SCAN RESULTS FOR LOCALHOST:8443 - 127.0.0.1
 -------------------------------------------

 * TLS 1.3 Early Data:
                                          Not Supported

 SCANS COMPLETED IN 0.232835 S
 -----------------------------

 COMPLIANCE AGAINST TLS CONFIGURATION
 ------------------------------------

    Disabled; use --mozilla_config={old, intermediate, modern} or --custom_tls_config=path/to/profile.json.

➜  examples git:(main) cargo run --bin simple_0rtt_client localhost 8443 ../../rust-rpxy/example-certs/server.crt
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.11s
     Running `/home/cam/git/rustls/target/debug/simple_0rtt_client localhost 8443 ../../rust-rpxy/example-certs/server.crt`
* Sending first request:
  * Normal request sent
  * Server response: "HTTP/1.1 200 OK\r\n"
* Sending second request:
  * Normal request sent
  * Server response: "HTTP/1.1 429 Too Many Requests\r\n"
```

With 0-RTT enabled
```
➜  examples git:(main) python -m sslyze --early_data localhost:8443

 CHECKING CONNECTIVITY TO SERVER(S)
 ----------------------------------

   localhost:8443            => 127.0.0.1 


 SCAN RESULTS FOR LOCALHOST:8443 - 127.0.0.1
 -------------------------------------------

 * TLS 1.3 Early Data:
                                          Suppported - Server accepted early data

 SCANS COMPLETED IN 1.34862 S
 ----------------------------

 COMPLIANCE AGAINST TLS CONFIGURATION
 ------------------------------------

    Disabled; use --mozilla_config={old, intermediate, modern} or --custom_tls_config=path/to/profile.json.

➜  examples git:(main) cargo run --bin simple_0rtt_client localhost 8443 ../../rust-rpxy/example-certs/server.crt
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.07s
     Running `/home/cam/git/rustls/target/debug/simple_0rtt_client localhost 8443 ../../rust-rpxy/example-certs/server.crt`
* Sending first request:
  * Normal request sent
  * Server response: "HTTP/1.1 200 OK\r\n"
* Sending second request:
  * 0-RTT request sent
  * 0-RTT data accepted
```