### PR TITLE
feat: automatic upstream failover (proxy_next_upstream parity)

### DIFF
--- a/rpxy-bin/src/config/toml.rs
+++ b/rpxy-bin/src/config/toml.rs
@@ -234,6 +234,10 @@ pub struct ReverseProxyOption {
   pub failover_on_connection_failure: Option<bool>,
   /// Maximum failover retry attempts per request. Defaults to `upstream.len() - 1`.
   pub max_failover_retries: Option<usize>,
+  /// Opt-in: enable failover for non-idempotent methods (POST, PATCH).
+  /// Default `false` — only idempotent methods (GET/HEAD/PUT/DELETE/OPTIONS/TRACE) retry.
+  /// Risk of double-charge / double-write if upstream processed the side effect before responding.
+  pub failover_non_idempotent_methods: Option<bool>,
   #[cfg(feature = "health-check")]
   pub health_check: Option<HealthCheckOption>,
 }
@@ -625,6 +629,7 @@ impl TryInto<Vec<ReverseProxyConfig>> for &Application {
         failover_on_statuses: rpo.failover_on_statuses.clone(),
         failover_on_connection_failure: rpo.failover_on_connection_failure,
         max_failover_retries: rpo.max_failover_retries,
+        failover_non_idempotent_methods: rpo.failover_non_idempotent_methods,
         #[cfg(feature = "health-check")]
         health_check,
       })
@@ -1092,6 +1097,7 @@ mod tests {
         failover_on_statuses: None,
         failover_on_connection_failure: None,
         max_failover_retries: None,
+        failover_non_idempotent_methods: None,
         #[cfg(feature = "health-check")]
         health_check: None,
       }]),

--- a/rpxy-bin/src/config/toml.rs
+++ b/rpxy-bin/src/config/toml.rs
@@ -228,6 +228,12 @@ pub struct ReverseProxyOption {
   pub upstream: Vec<UpstreamParams>,
   pub upstream_options: Option<Vec<String>>,
   pub load_balance: Option<String>,
+  /// HTTP status codes that trigger failover to the next upstream (e.g. [502, 503, 504]).
+  pub failover_on_statuses: Option<Vec<u16>>,
+  /// Whether to failover when the upstream connection itself fails (timeout, refused, etc.).
+  pub failover_on_connection_failure: Option<bool>,
+  /// Maximum failover retry attempts per request. Defaults to `upstream.len() - 1`.
+  pub max_failover_retries: Option<usize>,
   #[cfg(feature = "health-check")]
   pub health_check: Option<HealthCheckOption>,
 }
@@ -590,6 +596,18 @@ impl TryInto<Vec<ReverseProxyConfig>> for &Application {
       }
       let upstream = upstream_res.into_iter().map(|v| v.unwrap()).collect();
 
+      // Validate failover trigger status codes if present
+      if let Some(ref statuses) = rpo.failover_on_statuses {
+        for &status in statuses {
+          ensure!(
+            (400..600).contains(&status),
+            "[{}] failover_on_statuses contains {} which is not in the 400-599 range",
+            &_server_name_string,
+            status
+          );
+        }
+      }
+
       #[cfg(feature = "health-check")]
       let health_check = rpo
         .health_check
@@ -604,6 +622,9 @@ impl TryInto<Vec<ReverseProxyConfig>> for &Application {
         upstream,
         upstream_options: rpo.upstream_options.clone(),
         load_balance: rpo.load_balance.clone(),
+        failover_on_statuses: rpo.failover_on_statuses.clone(),
+        failover_on_connection_failure: rpo.failover_on_connection_failure,
+        max_failover_retries: rpo.max_failover_retries,
         #[cfg(feature = "health-check")]
         health_check,
       })
@@ -1068,6 +1089,9 @@ mod tests {
         upstream: vec![],
         upstream_options: None,
         load_balance: None,
+        failover_on_statuses: None,
+        failover_on_connection_failure: None,
+        max_failover_retries: None,
         #[cfg(feature = "health-check")]
         health_check: None,
       }]),

--- a/rpxy-lib/src/backend/failover.rs
+++ b/rpxy-lib/src/backend/failover.rs
@@ -1,4 +1,5 @@
 use ahash::HashSet;
+use std::sync::Arc;
 
 /// Default HTTP status codes that trigger failover when no list is configured.
 const DEFAULT_TRIGGER_STATUSES: &[u16] = &[502, 503, 504];
@@ -6,8 +7,10 @@ const DEFAULT_TRIGGER_STATUSES: &[u16] = &[502, 503, 504];
 /// Configuration for failover behavior when upstreams return errors
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FailoverConfig {
-  /// HTTP status codes that trigger failover (e.g., 502, 503, 504)
-  pub trigger_statuses: HashSet<u16>,
+  /// HTTP status codes that trigger failover (e.g., 502, 503, 504). Wrapped in `Arc` so
+  /// the failover path can attach it to per-attempt request extensions without cloning
+  /// the underlying set on every request.
+  pub trigger_statuses: Arc<HashSet<u16>>,
   /// Whether to failover on connection failures (timeout, refused, etc.)
   pub on_connection_failure: bool,
   /// Maximum number of retry attempts (default: number of upstreams - 1)
@@ -28,10 +31,11 @@ impl FailoverConfig {
     retry_non_idempotent: Option<bool>,
     num_upstreams: usize,
   ) -> Self {
+    let statuses: HashSet<u16> = trigger_statuses
+      .map(|v| v.into_iter().collect())
+      .unwrap_or_else(|| DEFAULT_TRIGGER_STATUSES.iter().copied().collect());
     Self {
-      trigger_statuses: trigger_statuses
-        .map(|v| v.into_iter().collect())
-        .unwrap_or_else(|| DEFAULT_TRIGGER_STATUSES.iter().copied().collect()),
+      trigger_statuses: Arc::new(statuses),
       on_connection_failure: on_connection_failure.unwrap_or(true),
       max_retries: max_retries.unwrap_or_else(|| num_upstreams.saturating_sub(1)),
       retry_non_idempotent: retry_non_idempotent.unwrap_or(false),
@@ -40,7 +44,7 @@ impl FailoverConfig {
 
   /// Validate that status codes are in the 4xx/5xx range
   pub fn validate(&self) -> Result<(), String> {
-    for &status in &self.trigger_statuses {
+    for &status in self.trigger_statuses.iter() {
       if !(400..600).contains(&status) {
         return Err(format!("Failover status code {status} must be in range 400-599"));
       }

--- a/rpxy-lib/src/backend/failover.rs
+++ b/rpxy-lib/src/backend/failover.rs
@@ -1,5 +1,8 @@
 use ahash::HashSet;
 
+/// Default HTTP status codes that trigger failover when no list is configured.
+const DEFAULT_TRIGGER_STATUSES: &[u16] = &[502, 503, 504];
+
 /// Configuration for failover behavior when upstreams return errors
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FailoverConfig {
@@ -9,16 +12,10 @@ pub struct FailoverConfig {
   pub on_connection_failure: bool,
   /// Maximum number of retry attempts (default: number of upstreams - 1)
   pub max_retries: usize,
-}
-
-impl Default for FailoverConfig {
-  fn default() -> Self {
-    Self {
-      trigger_statuses: vec![502, 503, 504].into_iter().collect(),
-      on_connection_failure: true,
-      max_retries: 0,
-    }
-  }
+  /// Opt-in: retry non-idempotent methods (POST, PATCH). Default `false`. RFC 9110 §9.2.2 only
+  /// guarantees idempotency for GET/HEAD/PUT/DELETE/OPTIONS/TRACE; retrying others risks
+  /// double-write side effects when an upstream processes the request then fails the response.
+  pub retry_non_idempotent: bool,
 }
 
 impl FailoverConfig {
@@ -28,14 +25,16 @@ impl FailoverConfig {
     trigger_statuses: Option<Vec<u16>>,
     on_connection_failure: Option<bool>,
     max_retries: Option<usize>,
+    retry_non_idempotent: Option<bool>,
     num_upstreams: usize,
   ) -> Self {
-    let default_max_retries = num_upstreams.saturating_sub(1);
-
     Self {
-      trigger_statuses: trigger_statuses.unwrap_or_else(|| vec![502, 503, 504]).into_iter().collect(),
+      trigger_statuses: trigger_statuses
+        .map(|v| v.into_iter().collect())
+        .unwrap_or_else(|| DEFAULT_TRIGGER_STATUSES.iter().copied().collect()),
       on_connection_failure: on_connection_failure.unwrap_or(true),
-      max_retries: max_retries.unwrap_or(default_max_retries),
+      max_retries: max_retries.unwrap_or_else(|| num_upstreams.saturating_sub(1)),
+      retry_non_idempotent: retry_non_idempotent.unwrap_or(false),
     }
   }
 
@@ -97,44 +96,46 @@ mod tests {
   use super::*;
 
   #[test]
-  fn test_failover_config_default() {
-    let config = FailoverConfig::default();
+  fn test_failover_config_defaults() {
+    let config = FailoverConfig::new(None, None, None, None, 3);
     assert_eq!(config.trigger_statuses.len(), 3);
     assert!(config.trigger_statuses.contains(&502));
     assert!(config.trigger_statuses.contains(&503));
     assert!(config.trigger_statuses.contains(&504));
     assert!(config.on_connection_failure);
-    assert_eq!(config.max_retries, 0);
+    assert_eq!(config.max_retries, 2);
+    assert!(!config.retry_non_idempotent);
   }
 
   #[test]
-  fn test_failover_config_new() {
-    let config = FailoverConfig::new(Some(vec![404, 502]), Some(false), Some(2), 3);
+  fn test_failover_config_new_overrides() {
+    let config = FailoverConfig::new(Some(vec![404, 502]), Some(false), Some(2), Some(true), 3);
     assert_eq!(config.trigger_statuses.len(), 2);
     assert!(config.trigger_statuses.contains(&404));
     assert!(config.trigger_statuses.contains(&502));
     assert!(!config.on_connection_failure);
     assert_eq!(config.max_retries, 2);
+    assert!(config.retry_non_idempotent);
   }
 
   #[test]
-  fn test_failover_config_default_max_retries() {
-    let config = FailoverConfig::new(None, None, None, 3);
+  fn test_failover_config_default_max_retries_from_upstream_count() {
+    let config = FailoverConfig::new(None, None, None, None, 3);
     assert_eq!(config.max_retries, 2);
 
-    let config_zero = FailoverConfig::new(None, None, None, 0);
+    let config_zero = FailoverConfig::new(None, None, None, None, 0);
     assert_eq!(config_zero.max_retries, 0);
   }
 
   #[test]
   fn test_failover_config_validate() {
-    let valid = FailoverConfig::new(Some(vec![404, 502, 503]), None, None, 2);
+    let valid = FailoverConfig::new(Some(vec![404, 502, 503]), None, None, None, 2);
     assert!(valid.validate().is_ok());
 
-    let invalid_low = FailoverConfig::new(Some(vec![200, 502]), None, None, 2);
+    let invalid_low = FailoverConfig::new(Some(vec![200, 502]), None, None, None, 2);
     assert!(invalid_low.validate().is_err());
 
-    let invalid_high = FailoverConfig::new(Some(vec![600]), None, None, 2);
+    let invalid_high = FailoverConfig::new(Some(vec![600]), None, None, None, 2);
     assert!(invalid_high.validate().is_err());
   }
 

--- a/rpxy-lib/src/backend/failover.rs
+++ b/rpxy-lib/src/backend/failover.rs
@@ -1,0 +1,173 @@
+use ahash::HashSet;
+
+/// Configuration for failover behavior when upstreams return errors
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FailoverConfig {
+  /// HTTP status codes that trigger failover (e.g., 502, 503, 504)
+  pub trigger_statuses: HashSet<u16>,
+  /// Whether to failover on connection failures (timeout, refused, etc.)
+  pub on_connection_failure: bool,
+  /// Maximum number of retry attempts (default: number of upstreams - 1)
+  pub max_retries: usize,
+}
+
+impl Default for FailoverConfig {
+  fn default() -> Self {
+    Self {
+      trigger_statuses: vec![502, 503, 504].into_iter().collect(),
+      on_connection_failure: true,
+      max_retries: 0,
+    }
+  }
+}
+
+impl FailoverConfig {
+  /// Create a new FailoverConfig with custom settings.
+  /// `max_retries` defaults to `num_upstreams - 1` when not specified.
+  pub fn new(
+    trigger_statuses: Option<Vec<u16>>,
+    on_connection_failure: Option<bool>,
+    max_retries: Option<usize>,
+    num_upstreams: usize,
+  ) -> Self {
+    let default_max_retries = num_upstreams.saturating_sub(1);
+
+    Self {
+      trigger_statuses: trigger_statuses.unwrap_or_else(|| vec![502, 503, 504]).into_iter().collect(),
+      on_connection_failure: on_connection_failure.unwrap_or(true),
+      max_retries: max_retries.unwrap_or(default_max_retries),
+    }
+  }
+
+  /// Validate that status codes are in the 4xx/5xx range
+  pub fn validate(&self) -> Result<(), String> {
+    for &status in &self.trigger_statuses {
+      if !(400..600).contains(&status) {
+        return Err(format!("Failover status code {status} must be in range 400-599"));
+      }
+    }
+    Ok(())
+  }
+}
+
+/// Context tracking state during failover retries
+#[derive(Debug, Clone)]
+pub struct FailoverContext {
+  /// Set of upstream indices that have been tried
+  tried_upstreams: HashSet<usize>,
+  /// Current retry count
+  pub retry_count: usize,
+  /// Index of the initial upstream selected by load balancer
+  pub initial_upstream_idx: usize,
+}
+
+impl FailoverContext {
+  /// Create a new failover context starting from the given upstream index
+  pub fn new(initial_upstream_idx: usize) -> Self {
+    Self {
+      tried_upstreams: HashSet::default(),
+      retry_count: 0,
+      initial_upstream_idx,
+    }
+  }
+
+  /// Check if an upstream has already been tried
+  pub fn has_tried(&self, upstream_idx: usize) -> bool {
+    self.tried_upstreams.contains(&upstream_idx)
+  }
+
+  /// Mark an upstream as tried
+  pub fn mark_tried(&mut self, upstream_idx: usize) {
+    self.tried_upstreams.insert(upstream_idx);
+  }
+
+  /// Check if we can retry based on max_retries limit
+  pub fn can_retry(&self, max_retries: usize) -> bool {
+    self.retry_count < max_retries
+  }
+
+  /// Increment retry counter
+  pub fn increment_retry(&mut self) {
+    self.retry_count += 1;
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn test_failover_config_default() {
+    let config = FailoverConfig::default();
+    assert_eq!(config.trigger_statuses.len(), 3);
+    assert!(config.trigger_statuses.contains(&502));
+    assert!(config.trigger_statuses.contains(&503));
+    assert!(config.trigger_statuses.contains(&504));
+    assert!(config.on_connection_failure);
+    assert_eq!(config.max_retries, 0);
+  }
+
+  #[test]
+  fn test_failover_config_new() {
+    let config = FailoverConfig::new(Some(vec![404, 502]), Some(false), Some(2), 3);
+    assert_eq!(config.trigger_statuses.len(), 2);
+    assert!(config.trigger_statuses.contains(&404));
+    assert!(config.trigger_statuses.contains(&502));
+    assert!(!config.on_connection_failure);
+    assert_eq!(config.max_retries, 2);
+  }
+
+  #[test]
+  fn test_failover_config_default_max_retries() {
+    let config = FailoverConfig::new(None, None, None, 3);
+    assert_eq!(config.max_retries, 2);
+
+    let config_zero = FailoverConfig::new(None, None, None, 0);
+    assert_eq!(config_zero.max_retries, 0);
+  }
+
+  #[test]
+  fn test_failover_config_validate() {
+    let valid = FailoverConfig::new(Some(vec![404, 502, 503]), None, None, 2);
+    assert!(valid.validate().is_ok());
+
+    let invalid_low = FailoverConfig::new(Some(vec![200, 502]), None, None, 2);
+    assert!(invalid_low.validate().is_err());
+
+    let invalid_high = FailoverConfig::new(Some(vec![600]), None, None, 2);
+    assert!(invalid_high.validate().is_err());
+  }
+
+  #[test]
+  fn test_failover_context_tracking() {
+    let mut ctx = FailoverContext::new(0);
+    assert_eq!(ctx.initial_upstream_idx, 0);
+    assert_eq!(ctx.retry_count, 0);
+    // Initial upstream is NOT pre-marked to avoid skipping it
+    assert!(!ctx.has_tried(0));
+    assert!(!ctx.has_tried(1));
+
+    ctx.mark_tried(0);
+    assert!(ctx.has_tried(0));
+    assert!(!ctx.has_tried(1));
+
+    ctx.mark_tried(1);
+    assert!(ctx.has_tried(1));
+    assert!(!ctx.has_tried(2));
+
+    ctx.increment_retry();
+    assert_eq!(ctx.retry_count, 1);
+  }
+
+  #[test]
+  fn test_failover_context_can_retry() {
+    let mut ctx = FailoverContext::new(0);
+    assert!(ctx.can_retry(2));
+
+    ctx.increment_retry();
+    assert!(ctx.can_retry(2));
+
+    ctx.increment_retry();
+    assert!(!ctx.can_retry(2));
+  }
+}

--- a/rpxy-lib/src/backend/load_balance/load_balance_sticky.rs
+++ b/rpxy-lib/src/backend/load_balance/load_balance_sticky.rs
@@ -85,7 +85,7 @@ impl<'a> LoadBalanceSticky {
     pick_nth_available_index(upstreams, count)
   }
 
-  /// This is always called only internally. So 'unwrap()' is executed.
+  #[cfg(test)]
   fn get_server_id_from_index(&self, index: usize) -> String {
     self.upstream_maps.upstream_index_map.get(index).unwrap().to_owned()
   }
@@ -97,20 +97,16 @@ impl<'a> LoadBalanceSticky {
 
   /// Build a PointerToUpstream with a new cookie context for the given index
   fn build_ptr_with_new_cookie(&self, ptr: usize) -> PointerToUpstream {
-    let upstream_id = self.get_server_id_from_index(ptr);
-    let new_cookie = self.sticky_config.build_sticky_cookie(upstream_id).unwrap();
-    let new_context = Some(LoadBalanceContext {
-      sticky_cookie: new_cookie,
-    });
     PointerToUpstream {
       ptr,
-      context: new_context,
+      context: self.build_lb_context_for_index(ptr),
     }
   }
 
-  /// Build a fresh sticky-cookie context bound to the given upstream index. Used by the
-  /// failover path to ensure the Set-Cookie returned to the client encodes the upstream
-  /// that actually served the response, not the one originally picked from the cookie.
+  /// Build a fresh sticky-cookie context bound to the given upstream index. Returns
+  /// `None` if the index is out of range or the cookie can't be built. Used internally
+  /// for fresh LB picks and externally by the failover path so Set-Cookie tracks the
+  /// upstream that actually served the response (not the one originally pinned).
   pub(crate) fn build_lb_context_for_index(&self, idx: usize) -> Option<LoadBalanceContext> {
     let upstream_id = self.upstream_maps.upstream_index_map.get(idx)?.to_owned();
     let cookie = self.sticky_config.build_sticky_cookie(upstream_id).ok()?;

--- a/rpxy-lib/src/backend/load_balance/load_balance_sticky.rs
+++ b/rpxy-lib/src/backend/load_balance/load_balance_sticky.rs
@@ -107,6 +107,15 @@ impl<'a> LoadBalanceSticky {
       context: new_context,
     }
   }
+
+  /// Build a fresh sticky-cookie context bound to the given upstream index. Used by the
+  /// failover path to ensure the Set-Cookie returned to the client encodes the upstream
+  /// that actually served the response, not the one originally picked from the cookie.
+  pub(crate) fn build_lb_context_for_index(&self, idx: usize) -> Option<LoadBalanceContext> {
+    let upstream_id = self.upstream_maps.upstream_index_map.get(idx)?.to_owned();
+    let cookie = self.sticky_config.build_sticky_cookie(upstream_id).ok()?;
+    Some(LoadBalanceContext { sticky_cookie: cookie })
+  }
 }
 impl LoadBalanceWithPointer for LoadBalanceSticky {
   /// Get the pointer to the upstream server to serve the incoming request.

--- a/rpxy-lib/src/backend/mod.rs
+++ b/rpxy-lib/src/backend/mod.rs
@@ -1,4 +1,5 @@
 mod backend_main;
+mod failover;
 mod load_balance;
 mod upstream;
 mod upstream_opts;
@@ -10,6 +11,7 @@ pub(crate) mod health_check;
 pub(crate) use self::load_balance::{StickyCookie, StickyCookieValue};
 #[allow(unused)]
 pub(crate) use self::{
+  failover::{FailoverConfig, FailoverContext},
   load_balance::{LoadBalance, LoadBalanceContext},
   upstream::{PathManager, Upstream, UpstreamCandidates},
   upstream_opts::UpstreamOption,

--- a/rpxy-lib/src/backend/upstream.rs
+++ b/rpxy-lib/src/backend/upstream.rs
@@ -1,9 +1,12 @@
 #[cfg(feature = "sticky-cookie")]
 use super::load_balance::LoadBalanceStickyBuilder;
-use super::load_balance::{
-  LoadBalance, LoadBalanceContext, LoadBalanceRandomBuilder, LoadBalanceRoundRobinBuilder, load_balance_options as lb_opts,
-};
 use super::upstream_opts::UpstreamOption;
+use super::{
+  failover::FailoverConfig,
+  load_balance::{
+    LoadBalance, LoadBalanceContext, LoadBalanceRandomBuilder, LoadBalanceRoundRobinBuilder, load_balance_options as lb_opts,
+  },
+};
 #[cfg(feature = "health-check")]
 use crate::globals::HealthCheckConfig;
 use crate::{
@@ -58,7 +61,13 @@ impl TryFrom<&AppConfig> for PathManager {
         .path(&rpc.path)
         .replace_path(&rpc.replace_path)
         .load_balance(&rpc.load_balance, &upstream_vec, &app_config.server_name, &rpc.path)
-        .options(&rpc.upstream_options);
+        .options(&rpc.upstream_options)
+        .failover(
+          &rpc.failover_on_statuses,
+          &rpc.failover_on_connection_failure,
+          &rpc.max_failover_retries,
+          upstream_vec.len(),
+        );
 
       #[cfg(feature = "health-check")]
       builder.health_check_config(&rpc.health_check);
@@ -192,6 +201,10 @@ pub struct UpstreamCandidates {
   /// Activated upstream options defined in [[UpstreamOption]]
   pub options: HashSet<UpstreamOption>,
 
+  #[builder(setter(custom), default)]
+  /// Failover configuration. `Some(_)` enables retry across multiple upstreams on errors.
+  pub failover_config: Option<FailoverConfig>,
+
   #[cfg(feature = "health-check")]
   #[builder(setter(custom), default)]
   /// Health check configuration for this upstream group
@@ -278,6 +291,32 @@ impl UpstreamCandidatesBuilder {
     self.options = Some(opts);
     self
   }
+
+  /// Set the failover configuration. Failover is only enabled when there is more than one
+  /// upstream AND at least one failover option is specified by the user. Otherwise the
+  /// `failover_config` is left as `None` (no retry behavior).
+  pub fn failover(
+    &mut self,
+    statuses: &Option<Vec<u16>>,
+    on_connection_failure: &Option<bool>,
+    max_retries: &Option<usize>,
+    num_upstreams: usize,
+  ) -> &mut Self {
+    let any_option_specified = statuses.is_some() || on_connection_failure.is_some() || max_retries.is_some();
+    if num_upstreams > 1 && any_option_specified {
+      let cfg = FailoverConfig::new(statuses.clone(), *on_connection_failure, *max_retries, num_upstreams);
+      match cfg.validate() {
+        Ok(()) => self.failover_config = Some(Some(cfg)),
+        Err(e) => {
+          error!("Invalid failover configuration ({e}); failover disabled for this route");
+          self.failover_config = Some(None);
+        }
+      }
+    } else {
+      self.failover_config = Some(None);
+    }
+    self
+  }
 }
 
 impl UpstreamCandidates {
@@ -288,6 +327,26 @@ impl UpstreamCandidates {
     trace!("Context to LB (Cookie in Request): {:?}", context_to_lb);
     trace!("Context from LB (Set-Cookie in Response): {:?}", pointer_to_upstream.context);
     (self.inner.get(pointer_to_upstream.ptr), pointer_to_upstream.context)
+  }
+
+  /// Get the next untried upstream during failover. Iterates sequentially starting from
+  /// `failover_ctx.initial_upstream_idx`, wrapping around. Returns `None` when every
+  /// upstream has been tried.
+  pub fn get_next(&self, failover_ctx: &mut super::failover::FailoverContext) -> Option<(usize, &Upstream)> {
+    let len = self.inner.len();
+    for offset in 0..len {
+      let idx = (failover_ctx.initial_upstream_idx + offset) % len;
+      if !failover_ctx.has_tried(idx) {
+        failover_ctx.mark_tried(idx);
+        return Some((idx, &self.inner[idx]));
+      }
+    }
+    None
+  }
+
+  /// Find the index of a given upstream in the candidates list (matched by URI).
+  pub fn find_upstream_index(&self, upstream: &Upstream) -> Option<usize> {
+    self.inner.iter().position(|u| u.uri == upstream.uri)
   }
 }
 

--- a/rpxy-lib/src/backend/upstream.rs
+++ b/rpxy-lib/src/backend/upstream.rs
@@ -66,6 +66,7 @@ impl TryFrom<&AppConfig> for PathManager {
           &rpc.failover_on_statuses,
           &rpc.failover_on_connection_failure,
           &rpc.max_failover_retries,
+          &rpc.failover_non_idempotent_methods,
           upstream_vec.len(),
         );
 
@@ -300,11 +301,19 @@ impl UpstreamCandidatesBuilder {
     statuses: &Option<Vec<u16>>,
     on_connection_failure: &Option<bool>,
     max_retries: &Option<usize>,
+    retry_non_idempotent: &Option<bool>,
     num_upstreams: usize,
   ) -> &mut Self {
-    let any_option_specified = statuses.is_some() || on_connection_failure.is_some() || max_retries.is_some();
+    let any_option_specified =
+      statuses.is_some() || on_connection_failure.is_some() || max_retries.is_some() || retry_non_idempotent.is_some();
     if num_upstreams > 1 && any_option_specified {
-      let cfg = FailoverConfig::new(statuses.clone(), *on_connection_failure, *max_retries, num_upstreams);
+      let cfg = FailoverConfig::new(
+        statuses.clone(),
+        *on_connection_failure,
+        *max_retries,
+        *retry_non_idempotent,
+        num_upstreams,
+      );
       match cfg.validate() {
         Ok(()) => self.failover_config = Some(Some(cfg)),
         Err(e) => {
@@ -320,19 +329,25 @@ impl UpstreamCandidatesBuilder {
 }
 
 impl UpstreamCandidates {
-  /// Get an enabled option of load balancing [[LoadBalance]]
-  pub fn get(&self, context_to_lb: &Option<LoadBalanceContext>) -> (Option<&Upstream>, Option<LoadBalanceContext>) {
+  /// Pick an upstream via the configured load balancer, returning the chosen index, the
+  /// upstream itself, and the LB-emitted context (only meaningful for sticky-cookie LB,
+  /// which encodes the picked upstream into a Set-Cookie payload).
+  pub(crate) fn get_with_index(
+    &self,
+    context_to_lb: &Option<LoadBalanceContext>,
+  ) -> Option<(usize, &Upstream, Option<LoadBalanceContext>)> {
     let pointer_to_upstream = self.load_balance.get_context(context_to_lb, &self.inner);
     trace!("Upstream of index {} is chosen.", pointer_to_upstream.ptr);
     trace!("Context to LB (Cookie in Request): {:?}", context_to_lb);
     trace!("Context from LB (Set-Cookie in Response): {:?}", pointer_to_upstream.context);
-    (self.inner.get(pointer_to_upstream.ptr), pointer_to_upstream.context)
+    let upstream = self.inner.get(pointer_to_upstream.ptr)?;
+    Some((pointer_to_upstream.ptr, upstream, pointer_to_upstream.context))
   }
 
   /// Get the next untried upstream during failover. Iterates sequentially starting from
   /// `failover_ctx.initial_upstream_idx`, wrapping around. Returns `None` when every
   /// upstream has been tried.
-  pub fn get_next(&self, failover_ctx: &mut super::failover::FailoverContext) -> Option<(usize, &Upstream)> {
+  pub(crate) fn get_next(&self, failover_ctx: &mut super::failover::FailoverContext) -> Option<(usize, &Upstream)> {
     let len = self.inner.len();
     for offset in 0..len {
       let idx = (failover_ctx.initial_upstream_idx + offset) % len;
@@ -344,9 +359,17 @@ impl UpstreamCandidates {
     None
   }
 
-  /// Find the index of a given upstream in the candidates list (matched by URI).
-  pub fn find_upstream_index(&self, upstream: &Upstream) -> Option<usize> {
-    self.inner.iter().position(|u| u.uri == upstream.uri)
+  /// Build a load-balancer context (sticky-cookie payload) bound to a specific upstream
+  /// index. Used by the failover path to fix up Set-Cookie when failover redirects to a
+  /// different upstream than the cookie originally pinned. Returns `None` for non-sticky
+  /// load balancers (which don't emit Set-Cookie at all).
+  #[cfg(feature = "sticky-cookie")]
+  pub(crate) fn build_lb_context_for_index(&self, idx: usize) -> Option<LoadBalanceContext> {
+    if let LoadBalance::StickyRoundRobin(lb) = &self.load_balance {
+      lb.build_lb_context_for_index(idx)
+    } else {
+      None
+    }
   }
 }
 

--- a/rpxy-lib/src/constants.rs
+++ b/rpxy-lib/src/constants.rs
@@ -5,6 +5,9 @@ pub const UPSTREAM_IDLE_TIMEOUT_SEC: u64 = 20;
 pub const TLS_HANDSHAKE_TIMEOUT_SEC: u64 = 15; // default as with firefox browser
 pub const MAX_CLIENTS: usize = 512;
 pub const MAX_CONCURRENT_STREAMS: u32 = 64;
+/// Maximum request body size (bytes) buffered in memory to enable failover retries.
+/// Requests larger than this will not be retried.
+pub const MAX_BUFFERED_BODY_SIZE: usize = 1024 * 1024; // 1MB
 
 #[allow(non_snake_case)]
 #[cfg(any(feature = "http3-quinn", feature = "http3-s2n"))]

--- a/rpxy-lib/src/forwarder/client.rs
+++ b/rpxy-lib/src/forwarder/client.rs
@@ -54,9 +54,8 @@ where
     // TODO: cache handling
     #[cfg(feature = "cache")]
     {
-      // Snapshot the request's no-cache-statuses extension before consuming the request.
-      // The failover path inserts this so the cache layer skips storing trigger statuses
-      // (e.g. 502/503/504) — otherwise a poisoned cache would defeat retries.
+      // Snapshot before consuming the request; the failover path inserts this to
+      // prevent trigger statuses (e.g. 502/503/504) from poisoning the cache.
       let no_cache_statuses = req.extensions().get::<NoCacheStatuses>().cloned();
       let mut synth_req = None;
       if self.cache.is_some() {

--- a/rpxy-lib/src/forwarder/client.rs
+++ b/rpxy-lib/src/forwarder/client.rs
@@ -5,6 +5,7 @@ use crate::{
   hyper_ext::{body::ResponseBody, rt::LocalExecutor},
   log::*,
 };
+use ahash::HashSet;
 use async_trait::async_trait;
 use http::{Request, Response, Version};
 use hyper::body::{Body, Incoming};
@@ -13,6 +14,13 @@ use hyper_util::client::legacy::{
   connect::{Connect, HttpConnector},
 };
 use std::sync::Arc;
+
+/// Request extension marker carrying status codes whose responses must NOT be stored in
+/// the response cache. Used by the failover path to prevent caching of trigger statuses
+/// (e.g. 502/503/504) which would otherwise defeat retries on subsequent requests.
+#[derive(Clone)]
+#[allow(dead_code)] // only read when `cache` feature is enabled
+pub(crate) struct NoCacheStatuses(pub(crate) Arc<HashSet<u16>>);
 
 #[cfg(feature = "cache")]
 use super::cache::{RpxyCache, get_policy_if_cacheable};
@@ -46,6 +54,10 @@ where
     // TODO: cache handling
     #[cfg(feature = "cache")]
     {
+      // Snapshot the request's no-cache-statuses extension before consuming the request.
+      // The failover path inserts this so the cache layer skips storing trigger statuses
+      // (e.g. 502/503/504) — otherwise a poisoned cache would defeat retries.
+      let no_cache_statuses = req.extensions().get::<NoCacheStatuses>().cloned();
       let mut synth_req = None;
       if self.cache.is_some() {
         // try reading from cache
@@ -68,6 +80,16 @@ where
       let Ok(Some(cache_policy)) = get_policy_if_cacheable(synth_req.as_ref(), res.as_ref().ok()) else {
         return res.map(|inner| inner.map(ResponseBody::Incoming));
       };
+      // Skip cache storage if this response's status is in the request's no-cache list.
+      if let (Some(NoCacheStatuses(statuses)), Ok(response)) = (no_cache_statuses.as_ref(), res.as_ref())
+        && statuses.contains(&response.status().as_u16())
+      {
+        debug!(
+          "Skipping cache store for status {} (failover trigger status)",
+          response.status()
+        );
+        return res.map(|inner| inner.map(ResponseBody::Incoming));
+      }
       let (parts, body) = res.unwrap().into_parts();
 
       // Get streamed body without waiting for the arrival of the body,

--- a/rpxy-lib/src/forwarder/mod.rs
+++ b/rpxy-lib/src/forwarder/mod.rs
@@ -5,7 +5,7 @@ mod client;
 use crate::hyper_ext::body::RequestBody;
 
 pub(crate) type Forwarder<C> = client::Forwarder<C, RequestBody>;
-pub(crate) use client::ForwardRequest;
+pub(crate) use client::{ForwardRequest, NoCacheStatuses};
 
 #[cfg(feature = "cache")]
 pub(crate) use cache::CacheError;

--- a/rpxy-lib/src/globals.rs
+++ b/rpxy-lib/src/globals.rs
@@ -178,6 +178,12 @@ pub struct ReverseProxyConfig {
   pub upstream: Vec<UpstreamUri>,
   pub upstream_options: Option<Vec<String>>,
   pub load_balance: Option<String>,
+  /// HTTP status codes that trigger upstream failover (e.g. [502, 503, 504])
+  pub failover_on_statuses: Option<Vec<u16>>,
+  /// Whether to failover on connection failures (timeout, refused, etc.)
+  pub failover_on_connection_failure: Option<bool>,
+  /// Maximum retry attempts (default: number of upstreams - 1)
+  pub max_failover_retries: Option<usize>,
   #[cfg(feature = "health-check")]
   pub health_check: Option<HealthCheckConfig>,
 }

--- a/rpxy-lib/src/globals.rs
+++ b/rpxy-lib/src/globals.rs
@@ -184,6 +184,8 @@ pub struct ReverseProxyConfig {
   pub failover_on_connection_failure: Option<bool>,
   /// Maximum retry attempts (default: number of upstreams - 1)
   pub max_failover_retries: Option<usize>,
+  /// Opt-in to retry POST/PATCH methods (default false; only idempotent methods retry).
+  pub failover_non_idempotent_methods: Option<bool>,
   #[cfg(feature = "health-check")]
   pub health_check: Option<HealthCheckConfig>,
 }

--- a/rpxy-lib/src/hyper_ext/body_incoming_like.rs
+++ b/rpxy-lib/src/hyper_ext/body_incoming_like.rs
@@ -33,7 +33,7 @@ type TrailersSender = oneshot::Sender<HeaderMap>;
 
 const MAX_LEN: u64 = u64::MAX - 2;
 #[derive(Clone, Copy, PartialEq, Eq)]
-pub struct DecodedLength(u64);
+pub(crate) struct DecodedLength(u64);
 impl DecodedLength {
   pub(crate) const CLOSE_DELIMITED: DecodedLength = DecodedLength(u64::MAX);
   pub(crate) const CHUNKED: DecodedLength = DecodedLength(u64::MAX - 1);

--- a/rpxy-lib/src/hyper_ext/body_incoming_like.rs
+++ b/rpxy-lib/src/hyper_ext/body_incoming_like.rs
@@ -33,7 +33,7 @@ type TrailersSender = oneshot::Sender<HeaderMap>;
 
 const MAX_LEN: u64 = u64::MAX - 2;
 #[derive(Clone, Copy, PartialEq, Eq)]
-pub(crate) struct DecodedLength(u64);
+pub struct DecodedLength(u64);
 impl DecodedLength {
   pub(crate) const CLOSE_DELIMITED: DecodedLength = DecodedLength(u64::MAX);
   pub(crate) const CHUNKED: DecodedLength = DecodedLength(u64::MAX - 1);

--- a/rpxy-lib/src/hyper_ext/body_type.rs
+++ b/rpxy-lib/src/hyper_ext/body_type.rs
@@ -41,6 +41,20 @@ impl Body for RequestBody {
       RequestBody::IncomingLike(incoming_like) => Pin::new(incoming_like).poll_frame(cx),
     }
   }
+
+  fn is_end_stream(&self) -> bool {
+    match self {
+      RequestBody::Incoming(b) => b.is_end_stream(),
+      RequestBody::IncomingLike(b) => b.is_end_stream(),
+    }
+  }
+
+  fn size_hint(&self) -> hyper::body::SizeHint {
+    match self {
+      RequestBody::Incoming(b) => b.size_hint(),
+      RequestBody::IncomingLike(b) => b.size_hint(),
+    }
+  }
 }
 
 /* ------------------------------------ */

--- a/rpxy-lib/src/hyper_ext/mod.rs
+++ b/rpxy-lib/src/hyper_ext/mod.rs
@@ -11,6 +11,6 @@ pub(crate) mod rt {
 }
 #[allow(unused)]
 pub(crate) mod body {
-  pub(crate) use super::body_incoming_like::IncomingLike;
+  pub(crate) use super::body_incoming_like::{DecodedLength, IncomingLike};
   pub(crate) use super::body_type::{BoxBody, RequestBody, ResponseBody, UnboundedStreamBody, empty, full};
 }

--- a/rpxy-lib/src/message_handler/handler_main.rs
+++ b/rpxy-lib/src/message_handler/handler_main.rs
@@ -8,25 +8,39 @@ use super::{
 use crate::{
   backend::{BackendAppManager, FailoverContext, LoadBalanceContext, UpstreamCandidates},
   error::*,
-  forwarder::{ForwardRequest, Forwarder},
+  forwarder::{ForwardRequest, Forwarder, NoCacheStatuses},
   globals::Globals,
   hyper_ext::body::{DecodedLength, IncomingLike, RequestBody, ResponseBody},
   log::*,
   name_exp::ServerName,
 };
+use ahash::HashSet;
 use derive_builder::Builder;
-use http::{Request, Response, StatusCode, header};
-use http_body_util::BodyExt;
-use hyper::body::Bytes;
+use http::{HeaderMap, Method, Request, Response, StatusCode, header};
+use http_body_util::{BodyExt, Limited};
+use hyper::body::{Body, Bytes};
 use hyper_util::{client::legacy::connect::Connect, rt::TokioIo};
 use std::{net::SocketAddr, sync::Arc};
 use tokio::io::copy_bidirectional;
 
+/// Captured request body and trailers after buffering. Used by the failover loop to
+/// reconstruct a fresh request for each attempt.
+enum BufferedBody {
+  /// No body to buffer (e.g. GET, HEAD, DELETE without body).
+  Empty,
+  /// Body fully captured. Trailers preserved so gRPC and other trailer-bearing requests
+  /// don't lose data on replay.
+  Replayable { bytes: Bytes, trailers: Option<HeaderMap> },
+}
+
 #[allow(dead_code)]
 #[derive(Debug)]
-/// Context object to handle sticky cookies at HTTP message handler
+/// Context object returned by `generate_request_forwarded`. Carries:
+/// - `context_lb`: sticky-cookie context to set as Set-Cookie on the response (None for non-sticky LB).
+/// - `chosen_upstream_idx`: which upstream slot was selected, so the failover path can track tried upstreams without round-tripping through URI matching.
 pub(super) struct HandlerContext {
   pub(super) context_lb: Option<LoadBalanceContext>,
+  pub(super) chosen_upstream_idx: usize,
 }
 
 #[derive(Clone, Builder)]
@@ -155,22 +169,27 @@ where
     // `generate_request_forwarded` can force-overwrite `Host` after the usual header pass.
     let fallback_host = fallback_to_default_app.then_some(&backend_app.server_name);
 
-    // Determine whether failover is eligible for this request. Failover requires the request
-    // body (if any) to be small and replayable; we therefore disable it for HTTP upgrades
-    // (WebSocket / H2C) and for requests whose body is chunked or larger than the buffer cap.
-    let body_too_large_or_chunked = is_body_unbufferable(&req);
-    let should_use_failover = upstream_candidates.failover_config.is_some()
+    // Determine whether failover is eligible for this request. Failover requires:
+    // - failover config present, multiple upstreams, no HTTP upgrade in flight
+    // - the request method must be idempotent unless explicitly opted into via
+    //   `failover_non_idempotent_methods` (RFC 9110 §9.2.2)
+    // - the body must be replayable (size_hint upper bounded and within `MAX_BUFFERED_BODY_SIZE`)
+    // Cheap checks come first so we only scan headers / size hints when the route is a candidate.
+    let should_use_failover = upstream_candidates
+      .failover_config
+      .as_ref()
+      .is_some_and(|cfg| cfg.retry_non_idempotent || is_idempotent_method(req.method()))
       && upstream_candidates.inner.len() > 1
       && upgrade_in_request.is_none()
-      && !body_too_large_or_chunked;
+      && !is_body_unbufferable(&req);
 
     let (mut res_backend, _context_lb) = if should_use_failover {
       debug!("Failover eligible for this request");
-      let (req_parts, buffered_body) = self.buffer_request_body(req).await?;
+      let (req_parts, buffered) = self.buffer_request_body(req).await?;
       self
         .request_with_failover(
           req_parts,
-          buffered_body,
+          buffered,
           upstream_candidates,
           &client_addr,
           &listen_addr,
@@ -191,6 +210,7 @@ where
           upstream_candidates,
           tls_enabled,
           fallback_host,
+          None, // let the load balancer pick
         )
         .map_err(|e| HttpError::FailedToGenerateUpstreamRequest(e.to_string()))?;
 
@@ -274,48 +294,82 @@ where
   }
 
   /// Collect the request body into memory so it can be replayed on failover retries.
-  /// Returns `(parts, Some(bytes))` for normal-sized bodies and `(parts, None)` for the
-  /// edge case of a body that grows past `MAX_BUFFERED_BODY_SIZE` only after collection
-  /// begins (e.g. a chunked body that lied about its size). Callers are expected to have
-  /// already filtered chunked / oversized bodies out via `is_body_unbufferable`.
-  async fn buffer_request_body(&self, req: Request<RequestBody>) -> HttpResult<(http::request::Parts, Option<Bytes>)> {
+  /// Wraps the body in `Limited` so collection aborts early if the body exceeds
+  /// `MAX_BUFFERED_BODY_SIZE` — this prevents a malicious client from OOM-ing the proxy
+  /// by sending an unbounded body whose declared size hint understated the actual length.
+  /// Trailers (e.g. for gRPC over HTTP/2) are captured and replayed on each attempt.
+  async fn buffer_request_body(&self, req: Request<RequestBody>) -> HttpResult<(http::request::Parts, BufferedBody)> {
     let (parts, body) = req.into_parts();
-    let collected = body
-      .collect()
-      .await
-      .map_err(|e| HttpError::Other(anyhow::anyhow!("Failed to collect request body for failover: {e}")))?
-      .to_bytes();
-    if collected.len() > crate::constants::MAX_BUFFERED_BODY_SIZE {
-      debug!(
-        "Request body collected to {} bytes, exceeds {} byte buffer cap; failover disabled for this request",
-        collected.len(),
-        crate::constants::MAX_BUFFERED_BODY_SIZE
-      );
-      return Ok((parts, None));
+    // Fast path: known-empty body (Content-Length: 0 or methods without bodies). Skip
+    // collection entirely so common GET/HEAD requests don't allocate.
+    if body.is_end_stream() {
+      return Ok((parts, BufferedBody::Empty));
     }
-    Ok((parts, Some(collected)))
+    let limited = Limited::new(body, crate::constants::MAX_BUFFERED_BODY_SIZE);
+    let collected = match limited.collect().await {
+      Ok(c) => c,
+      Err(e) => {
+        // Limited's error is opaque; either the body grew past the cap or the underlying
+        // body errored. In both cases the body is unrecoverable — we cannot stream-fallback
+        // because the body is already partially consumed. Surface as a 502 to the client.
+        debug!(
+          "Failed to buffer request body for failover (likely exceeded {} bytes): {e}",
+          crate::constants::MAX_BUFFERED_BODY_SIZE
+        );
+        return Err(HttpError::Other(anyhow::anyhow!(
+          "Request body exceeded buffer cap or stream errored: {e}"
+        )));
+      }
+    };
+    let trailers = collected.trailers().cloned();
+    let bytes = collected.to_bytes();
+    Ok((parts, BufferedBody::Replayable { bytes, trailers }))
   }
 
-  /// Reconstruct a request from the saved parts and a buffered body, producing a fresh
-  /// `RequestBody::IncomingLike` body for each retry attempt.
-  fn reconstruct_request(&self, parts: &http::request::Parts, body_bytes: Bytes) -> HttpResult<Request<RequestBody>> {
-    let len = body_bytes.len() as u64;
-    let (mut tx, rx) = IncomingLike::new_channel(DecodedLength::new(len), false);
-    // The channel buffer holds one pending Bytes send; try_send avoids needing await here.
-    tx.try_send_data(body_bytes)
-      .map_err(|_| HttpError::Other(anyhow::anyhow!("Failed to enqueue buffered body for retry")))?;
-    drop(tx); // close the channel — only one frame plus terminator will be observed
-    Ok(Request::from_parts(parts.clone(), RequestBody::IncomingLike(rx)))
+  /// Reconstruct a request from the saved parts and the buffered body, producing a fresh
+  /// `RequestBody::IncomingLike` body for each retry attempt. Trailers (if captured) are
+  /// replayed via the IncomingLike trailers channel so gRPC and other trailer-aware
+  /// upstreams receive a well-formed request.
+  async fn reconstruct_request(&self, parts: &http::request::Parts, buffered: &BufferedBody) -> HttpResult<Request<RequestBody>> {
+    let body = match buffered {
+      BufferedBody::Empty => {
+        let (_tx, rx) = IncomingLike::new_channel(DecodedLength::ZERO, false);
+        RequestBody::IncomingLike(rx)
+      }
+      BufferedBody::Replayable { bytes, trailers } => {
+        let len = bytes.len() as u64;
+        let (mut tx, rx) = IncomingLike::new_channel(DecodedLength::new(len), false);
+        tx.try_send_data(bytes.clone())
+          .map_err(|_| HttpError::Other(anyhow::anyhow!("Failed to enqueue buffered body for retry")))?;
+        if let Some(t) = trailers {
+          tx.send_trailers(t.clone())
+            .await
+            .map_err(|e| HttpError::Other(anyhow::anyhow!("Failed to enqueue trailers for retry: {e}")))?;
+        }
+        drop(tx);
+        RequestBody::IncomingLike(rx)
+      }
+    };
+    Ok(Request::from_parts(parts.clone(), body))
   }
 
-  /// Drive the retry loop across upstream candidates. Returns the last response (success or
-  /// final failure) plus the load-balancer context produced during the final attempt — so
-  /// the caller can still apply sticky-cookie handling to the response.
+  /// Drive the retry loop across upstream candidates.
+  ///
+  /// Attempt 0 lets the load balancer pick (so sticky-cookie / round-robin behave
+  /// normally on the first try). After attempt 0 the chosen upstream's index is recorded
+  /// in `failover_ctx` and subsequent attempts iterate sequentially through untried
+  /// upstreams, calling `generate_request_forwarded` with the preselected upstream so
+  /// the URI, Host header (when `set_upstream_host` is enabled), and Set-Cookie all
+  /// reflect the upstream that's actually being targeted.
+  ///
+  /// Returns the last response (success or final triggered failure) plus the
+  /// load-balancer context to apply to the response (so Set-Cookie tracks the upstream
+  /// that actually served the request, not the originally-cookie-pinned one).
   #[allow(clippy::too_many_arguments)]
   async fn request_with_failover(
     &self,
     req_parts: http::request::Parts,
-    buffered_body: Option<Bytes>,
+    buffered: BufferedBody,
     upstream_candidates: &UpstreamCandidates,
     client_addr: &SocketAddr,
     listen_addr: &SocketAddr,
@@ -329,51 +383,39 @@ where
       .as_ref()
       .expect("failover_config must be Some when entering request_with_failover");
 
-    // Probe the load balancer once to find the initial upstream index. The actual
-    // per-attempt request will call generate_request_forwarded again, which itself
-    // re-invokes the load balancer; for retries (attempt > 0) we override the URI
-    // explicitly to point at the failover-selected upstream.
-    let (initial_upstream_opt, _initial_lb_ctx) = upstream_candidates.get(&None);
-    let initial_upstream = initial_upstream_opt.ok_or(HttpError::NoUpstreamCandidates)?;
-    let initial_idx = upstream_candidates
-      .find_upstream_index(initial_upstream)
-      .ok_or(HttpError::NoUpstreamCandidates)?;
-
-    let mut failover_ctx = FailoverContext::new(initial_idx);
+    // Snapshot trigger statuses behind an Arc so we can cheaply attach them to each
+    // outgoing request as a NoCacheStatuses extension — the cache layer reads this and
+    // skips storing responses whose status would otherwise poison the cache for retries.
+    let no_cache_statuses: Arc<HashSet<u16>> = Arc::new(failover_config.trigger_statuses.clone());
     let max_retries = failover_config.max_retries.min(upstream_candidates.inner.len() - 1);
 
     debug!(
-      "Failover starting: initial_upstream_idx={}, max_retries={}, trigger_statuses={:?}, on_connection_failure={}",
-      initial_idx, max_retries, failover_config.trigger_statuses, failover_config.on_connection_failure
+      "Failover starting: max_retries={}, trigger_statuses={:?}, on_connection_failure={}, retry_non_idempotent={}",
+      max_retries, failover_config.trigger_statuses, failover_config.on_connection_failure, failover_config.retry_non_idempotent,
     );
 
+    // initial_upstream_idx is filled in after attempt 0 returns (we don't pre-probe).
+    let mut failover_ctx = FailoverContext::new(0);
     let mut last_response: Option<Response<ResponseBody>> = None;
     let mut last_lb_context: Option<LoadBalanceContext> = None;
     let mut attempt: usize = 0;
 
     loop {
-      let Some((upstream_idx, _upstream)) = upstream_candidates.get_next(&mut failover_ctx) else {
-        break;
-      };
-
-      // Build a fresh request for this attempt. If we have a buffered body we replay it
-      // through a new IncomingLike channel; if not we cannot retry safely beyond attempt 0.
-      let req = match (&buffered_body, attempt) {
-        (Some(bytes), _) => self.reconstruct_request(&req_parts, bytes.clone())?,
-        (None, 0) => {
-          // Body collection produced a too-large payload, so failover is effectively disabled.
-          // Issue a single attempt with an empty body. (Callers normally prevent this branch
-          // via is_body_unbufferable, but defend against it anyway.)
-          let (_tx, rx) = IncomingLike::new_channel(DecodedLength::ZERO, false);
-          Request::from_parts(req_parts.clone(), RequestBody::IncomingLike(rx))
-        }
-        (None, _) => {
-          warn!("Cannot retry failover attempt {attempt}: request body was not buffered");
-          break;
+      // Decide which upstream this attempt targets.
+      let preselected = if attempt == 0 {
+        None // let the LB pick — respects sticky cookie / round-robin normally
+      } else {
+        match upstream_candidates.get_next(&mut failover_ctx) {
+          Some(p) => Some(p),
+          None => break, // every upstream has been tried
         }
       };
 
-      let mut forwarded_req = req;
+      let mut forwarded_req = self.reconstruct_request(&req_parts, &buffered).await?;
+      forwarded_req
+        .extensions_mut()
+        .insert(NoCacheStatuses(no_cache_statuses.clone()));
+
       let handler_context = self
         .generate_request_forwarded(
           client_addr,
@@ -383,40 +425,16 @@ where
           upstream_candidates,
           tls_enabled,
           fallback_host,
+          preselected,
         )
         .map_err(|e| HttpError::FailedToGenerateUpstreamRequest(e.to_string()))?;
+      let chosen_idx = handler_context.chosen_upstream_idx;
 
-      // For retries (attempt > 0) override the URI to point at the failover-selected
-      // upstream, since generate_request_forwarded re-asks the load balancer and may not
-      // pick the same index we are tracking. Note: Host header rewriting (e.g. the
-      // `set_upstream_host` option) still reflects the load balancer's pick — this matches
-      // the documented limitation that header rewriting is not reapplied per retry.
-      if attempt > 0 {
-        let upstream = &upstream_candidates.inner[upstream_idx];
-        let original_pq = forwarded_req
-          .uri()
-          .path_and_query()
-          .map(|pq| pq.as_str().to_owned())
-          .unwrap_or_else(|| "/".to_owned());
-        let scheme = upstream
-          .uri
-          .scheme()
-          .ok_or_else(|| HttpError::Other(anyhow::anyhow!("Upstream missing scheme")))?
-          .as_str()
-          .to_owned();
-        let authority = upstream
-          .uri
-          .authority()
-          .ok_or_else(|| HttpError::Other(anyhow::anyhow!("Upstream missing authority")))?
-          .as_str()
-          .to_owned();
-        let new_uri = http::Uri::builder()
-          .scheme(scheme.as_str())
-          .authority(authority.as_str())
-          .path_and_query(original_pq.as_str())
-          .build()
-          .map_err(|e| HttpError::Other(anyhow::anyhow!("Failed to rebuild URI for retry: {e}")))?;
-        *forwarded_req.uri_mut() = new_uri;
+      // Anchor failover_ctx at the LB-picked upstream after attempt 0, then mark it
+      // tried so subsequent get_next calls iterate from there to the rest.
+      if attempt == 0 {
+        failover_ctx.initial_upstream_idx = chosen_idx;
+        failover_ctx.mark_tried(chosen_idx);
       }
 
       log_data.xff(&forwarded_req.headers().get(header_defs::X_FORWARDED_FOR));
@@ -424,8 +442,8 @@ where
 
       debug!(
         "Failover attempt {} -> upstream[{}]: {}",
-        failover_ctx.retry_count + 1,
-        upstream_idx,
+        attempt + 1,
+        chosen_idx,
         forwarded_req.uri()
       );
 
@@ -435,22 +453,32 @@ where
           if failover_config.trigger_statuses.contains(&status.as_u16()) {
             warn!(
               "Upstream[{}] returned status {} matching failover triggers; will retry next upstream",
-              upstream_idx, status
+              chosen_idx, status
             );
+            // Drain the previously-captured trigger response (if any) so its connection
+            // can be returned to the keep-alive pool instead of being closed.
+            if let Some(prev) = last_response.take() {
+              self.spawn_drain_response(prev);
+            }
             last_response = Some(response);
             last_lb_context = handler_context.context_lb;
           } else {
+            // Success — drain any captured trigger response before returning.
+            if let Some(prev) = last_response.take() {
+              self.spawn_drain_response(prev);
+            }
             return Ok((response, handler_context.context_lb));
           }
         }
         Err(e) => {
           if failover_config.on_connection_failure {
-            warn!(
-              "Upstream[{}] connection failed: {}; will retry next upstream",
-              upstream_idx, e
-            );
+            warn!("Upstream[{}] connection failed: {}; will retry next upstream", chosen_idx, e);
             last_lb_context = handler_context.context_lb;
           } else {
+            // Drain any pending trigger response before bailing out.
+            if let Some(prev) = last_response.take() {
+              self.spawn_drain_response(prev);
+            }
             return Err(HttpError::FailedToGetResponseFromBackend(e.to_string()));
           }
         }
@@ -468,12 +496,28 @@ where
       .map(|r| (r, last_lb_context))
       .ok_or(HttpError::AllUpstreamsFailed)
   }
+
+  /// Drain a discarded response body in the background so the underlying upstream
+  /// connection can be returned to the keep-alive pool. Without this, dropping a
+  /// partially-read response causes hyper to close the connection — bad under
+  /// sustained partial-failure load against already-sick upstreams.
+  fn spawn_drain_response(&self, res: Response<ResponseBody>) {
+    self.globals.runtime_handle.spawn(async move {
+      let (_, body) = res.into_parts();
+      let _ = body.collect().await;
+    });
+  }
 }
 
 /// Returns true when the request body cannot safely be buffered for failover retries.
-/// This is the case for chunked-encoded bodies (size unknown until fully collected) and
-/// for requests whose declared `Content-Length` exceeds `MAX_BUFFERED_BODY_SIZE`.
-fn is_body_unbufferable<B>(req: &Request<B>) -> bool {
+///
+/// Uses two complementary signals:
+/// 1. `Transfer-Encoding: chunked` (HTTP/1.1) — chunked size is unknown ahead of time.
+/// 2. `Body::size_hint().upper()` — handles HTTP/1.0 close-delimited (None upper),
+///    HTTP/2 / HTTP/3 streamed without END_STREAM-known length (None upper), and
+///    declared sizes above `MAX_BUFFERED_BODY_SIZE`. This is the authoritative check
+///    for non-HTTP/1.1 traffic where the chunked header doesn't apply.
+fn is_body_unbufferable<B: Body>(req: &Request<B>) -> bool {
   let chunked = req
     .headers()
     .get(header::TRANSFER_ENCODING)
@@ -482,10 +526,77 @@ fn is_body_unbufferable<B>(req: &Request<B>) -> bool {
   if chunked {
     return true;
   }
-  req
-    .headers()
-    .get(header::CONTENT_LENGTH)
-    .and_then(|v| v.to_str().ok())
-    .and_then(|s| s.parse::<usize>().ok())
-    .is_some_and(|len| len > crate::constants::MAX_BUFFERED_BODY_SIZE)
+  match req.body().size_hint().upper() {
+    None => true,
+    Some(n) => n as usize > crate::constants::MAX_BUFFERED_BODY_SIZE,
+  }
+}
+
+/// RFC 9110 §9.2.2 lists the methods whose semantics make repeated invocation safe.
+/// Failover retries for non-idempotent methods (POST, PATCH, etc.) require explicit
+/// opt-in via `failover_non_idempotent_methods` because the upstream may have
+/// processed the side effect before responding.
+fn is_idempotent_method(method: &Method) -> bool {
+  matches!(
+    *method,
+    Method::GET | Method::HEAD | Method::PUT | Method::DELETE | Method::OPTIONS | Method::TRACE
+  )
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use http_body_util::{Empty, Full};
+
+  fn req_with_body<B>(method: Method, headers: &[(&str, &str)], body: B) -> Request<B> {
+    let mut b = Request::builder().method(method).uri("http://example.com/");
+    for (k, v) in headers {
+      b = b.header(*k, *v);
+    }
+    b.body(body).unwrap()
+  }
+
+  #[test]
+  fn idempotent_methods_match_rfc_9110() {
+    for m in [
+      Method::GET,
+      Method::HEAD,
+      Method::PUT,
+      Method::DELETE,
+      Method::OPTIONS,
+      Method::TRACE,
+    ] {
+      assert!(is_idempotent_method(&m), "{m} should be idempotent");
+    }
+    for m in [Method::POST, Method::PATCH] {
+      assert!(!is_idempotent_method(&m), "{m} should not be idempotent");
+    }
+  }
+
+  #[test]
+  fn unbufferable_chunked_transfer_encoding() {
+    let r = req_with_body(Method::POST, &[("transfer-encoding", "chunked")], Empty::<Bytes>::new());
+    assert!(is_body_unbufferable(&r));
+    let r = req_with_body(Method::POST, &[("transfer-encoding", "gzip, chunked")], Empty::<Bytes>::new());
+    assert!(is_body_unbufferable(&r));
+    let r = req_with_body(Method::POST, &[("transfer-encoding", "CHUNKED")], Empty::<Bytes>::new());
+    assert!(is_body_unbufferable(&r));
+  }
+
+  #[test]
+  fn unbufferable_falls_through_to_size_hint() {
+    // Empty body has size_hint upper Some(0) — bufferable.
+    let r = req_with_body(Method::GET, &[], Empty::<Bytes>::new());
+    assert!(!is_body_unbufferable(&r));
+
+    // Full body within cap — bufferable.
+    let small = Bytes::from_static(b"hi");
+    let r = req_with_body(Method::POST, &[], Full::new(small));
+    assert!(!is_body_unbufferable(&r));
+
+    // Full body over cap — unbufferable.
+    let big = Bytes::from(vec![0u8; crate::constants::MAX_BUFFERED_BODY_SIZE + 1]);
+    let r = req_with_body(Method::POST, &[], Full::new(big));
+    assert!(is_body_unbufferable(&r));
+  }
 }

--- a/rpxy-lib/src/message_handler/handler_main.rs
+++ b/rpxy-lib/src/message_handler/handler_main.rs
@@ -14,7 +14,6 @@ use crate::{
   log::*,
   name_exp::ServerName,
 };
-use ahash::HashSet;
 use derive_builder::Builder;
 use http::{HeaderMap, Method, Request, Response, StatusCode, header};
 use http_body_util::{BodyExt, Limited};
@@ -23,14 +22,11 @@ use hyper_util::{client::legacy::connect::Connect, rt::TokioIo};
 use std::{net::SocketAddr, sync::Arc};
 use tokio::io::copy_bidirectional;
 
-/// Captured request body and trailers after buffering. Used by the failover loop to
-/// reconstruct a fresh request for each attempt.
-enum BufferedBody {
-  /// No body to buffer (e.g. GET, HEAD, DELETE without body).
-  Empty,
-  /// Body fully captured. Trailers preserved so gRPC and other trailer-bearing requests
-  /// don't lose data on replay.
-  Replayable { bytes: Bytes, trailers: Option<HeaderMap> },
+/// Captured request body and trailers, replayed by the failover loop on each attempt.
+/// Trailers preserved so gRPC and other trailer-bearing requests don't lose data.
+struct BufferedBody {
+  bytes: Bytes,
+  trailers: Option<HeaderMap>,
 }
 
 #[allow(dead_code)]
@@ -169,12 +165,8 @@ where
     // `generate_request_forwarded` can force-overwrite `Host` after the usual header pass.
     let fallback_host = fallback_to_default_app.then_some(&backend_app.server_name);
 
-    // Determine whether failover is eligible for this request. Failover requires:
-    // - failover config present, multiple upstreams, no HTTP upgrade in flight
-    // - the request method must be idempotent unless explicitly opted into via
-    //   `failover_non_idempotent_methods` (RFC 9110 §9.2.2)
-    // - the body must be replayable (size_hint upper bounded and within `MAX_BUFFERED_BODY_SIZE`)
-    // Cheap checks come first so we only scan headers / size hints when the route is a candidate.
+    // Eligibility: failover config present, multiple upstreams, no HTTP upgrade,
+    // idempotent method (unless `retry_non_idempotent` opt-in), and a replayable body.
     let should_use_failover = upstream_candidates
       .failover_config
       .as_ref()
@@ -294,63 +286,53 @@ where
   }
 
   /// Collect the request body into memory so it can be replayed on failover retries.
-  /// Wraps the body in `Limited` so collection aborts early if the body exceeds
-  /// `MAX_BUFFERED_BODY_SIZE` — this prevents a malicious client from OOM-ing the proxy
-  /// by sending an unbounded body whose declared size hint understated the actual length.
-  /// Trailers (e.g. for gRPC over HTTP/2) are captured and replayed on each attempt.
+  /// `Limited` aborts collection if the body exceeds `MAX_BUFFERED_BODY_SIZE`, defending
+  /// against clients that under-declare their size hint.
   async fn buffer_request_body(&self, req: Request<RequestBody>) -> HttpResult<(http::request::Parts, BufferedBody)> {
     let (parts, body) = req.into_parts();
-    // Fast path: known-empty body (Content-Length: 0 or methods without bodies). Skip
-    // collection entirely so common GET/HEAD requests don't allocate.
+    // Skip allocation for known-empty bodies (GET/HEAD/Content-Length: 0).
     if body.is_end_stream() {
-      return Ok((parts, BufferedBody::Empty));
+      return Ok((
+        parts,
+        BufferedBody {
+          bytes: Bytes::new(),
+          trailers: None,
+        },
+      ));
     }
     let limited = Limited::new(body, crate::constants::MAX_BUFFERED_BODY_SIZE);
-    let collected = match limited.collect().await {
-      Ok(c) => c,
-      Err(e) => {
-        // Limited's error is opaque; either the body grew past the cap or the underlying
-        // body errored. In both cases the body is unrecoverable — we cannot stream-fallback
-        // because the body is already partially consumed. Surface as a 502 to the client.
-        debug!(
-          "Failed to buffer request body for failover (likely exceeded {} bytes): {e}",
-          crate::constants::MAX_BUFFERED_BODY_SIZE
-        );
-        return Err(HttpError::Other(anyhow::anyhow!(
-          "Request body exceeded buffer cap or stream errored: {e}"
-        )));
-      }
-    };
+    // Limited::collect errors when the body grows past the cap (or the underlying body
+    // errors). Either way the body is unrecoverable — we cannot fall back to streaming
+    // because it's already partially consumed. Surface as a 502.
+    let collected = limited.collect().await.map_err(|e| {
+      debug!(
+        "Failed to buffer request body for failover (likely exceeded {} bytes): {e}",
+        crate::constants::MAX_BUFFERED_BODY_SIZE
+      );
+      HttpError::Other(anyhow::anyhow!("Request body exceeded buffer cap or stream errored: {e}"))
+    })?;
     let trailers = collected.trailers().cloned();
     let bytes = collected.to_bytes();
-    Ok((parts, BufferedBody::Replayable { bytes, trailers }))
+    Ok((parts, BufferedBody { bytes, trailers }))
   }
 
-  /// Reconstruct a request from the saved parts and the buffered body, producing a fresh
-  /// `RequestBody::IncomingLike` body for each retry attempt. Trailers (if captured) are
-  /// replayed via the IncomingLike trailers channel so gRPC and other trailer-aware
-  /// upstreams receive a well-formed request.
+  /// Reconstruct a request from saved parts and the buffered body, producing a fresh
+  /// `RequestBody::IncomingLike` body each call. Trailers (if any) are replayed so
+  /// gRPC and other trailer-aware upstreams see a well-formed request.
   async fn reconstruct_request(&self, parts: &http::request::Parts, buffered: &BufferedBody) -> HttpResult<Request<RequestBody>> {
-    let body = match buffered {
-      BufferedBody::Empty => {
-        let (_tx, rx) = IncomingLike::new_channel(DecodedLength::ZERO, false);
-        RequestBody::IncomingLike(rx)
-      }
-      BufferedBody::Replayable { bytes, trailers } => {
-        let len = bytes.len() as u64;
-        let (mut tx, rx) = IncomingLike::new_channel(DecodedLength::new(len), false);
-        tx.try_send_data(bytes.clone())
-          .map_err(|_| HttpError::Other(anyhow::anyhow!("Failed to enqueue buffered body for retry")))?;
-        if let Some(t) = trailers {
-          tx.send_trailers(t.clone())
-            .await
-            .map_err(|e| HttpError::Other(anyhow::anyhow!("Failed to enqueue trailers for retry: {e}")))?;
-        }
-        drop(tx);
-        RequestBody::IncomingLike(rx)
-      }
-    };
-    Ok(Request::from_parts(parts.clone(), body))
+    let len = buffered.bytes.len() as u64;
+    let (mut tx, rx) = IncomingLike::new_channel(DecodedLength::new(len), false);
+    if !buffered.bytes.is_empty() {
+      tx.try_send_data(buffered.bytes.clone())
+        .map_err(|_| HttpError::Other(anyhow::anyhow!("Failed to enqueue buffered body for retry")))?;
+    }
+    if let Some(t) = &buffered.trailers {
+      tx.send_trailers(t.clone())
+        .await
+        .map_err(|e| HttpError::Other(anyhow::anyhow!("Failed to enqueue trailers for retry: {e}")))?;
+    }
+    drop(tx);
+    Ok(Request::from_parts(parts.clone(), RequestBody::IncomingLike(rx)))
   }
 
   /// Drive the retry loop across upstream candidates.
@@ -383,10 +365,9 @@ where
       .as_ref()
       .expect("failover_config must be Some when entering request_with_failover");
 
-    // Snapshot trigger statuses behind an Arc so we can cheaply attach them to each
-    // outgoing request as a NoCacheStatuses extension — the cache layer reads this and
-    // skips storing responses whose status would otherwise poison the cache for retries.
-    let no_cache_statuses: Arc<HashSet<u16>> = Arc::new(failover_config.trigger_statuses.clone());
+    // The trigger-status set is already Arc-shared in FailoverConfig; clone the Arc once
+    // here so each per-attempt extension insert is just a refcount bump.
+    let no_cache_statuses = failover_config.trigger_statuses.clone();
     let max_retries = failover_config.max_retries.min(upstream_candidates.inner.len() - 1);
 
     debug!(

--- a/rpxy-lib/src/message_handler/handler_main.rs
+++ b/rpxy-lib/src/message_handler/handler_main.rs
@@ -6,16 +6,18 @@ use super::{
   synthetic_response::{secure_redirection_response, synthetic_error_response},
 };
 use crate::{
-  backend::{BackendAppManager, LoadBalanceContext},
+  backend::{BackendAppManager, FailoverContext, LoadBalanceContext, UpstreamCandidates},
   error::*,
   forwarder::{ForwardRequest, Forwarder},
   globals::Globals,
-  hyper_ext::body::{RequestBody, ResponseBody},
+  hyper_ext::body::{DecodedLength, IncomingLike, RequestBody, ResponseBody},
   log::*,
   name_exp::ServerName,
 };
 use derive_builder::Builder;
-use http::{Request, Response, StatusCode};
+use http::{Request, Response, StatusCode, header};
+use http_body_util::BodyExt;
+use hyper::body::Bytes;
 use hyper_util::{client::legacy::connect::Connect, rt::TokioIo};
 use std::{net::SocketAddr, sync::Arc};
 use tokio::io::copy_bidirectional;
@@ -153,42 +155,67 @@ where
     // `generate_request_forwarded` can force-overwrite `Host` after the usual header pass.
     let fallback_host = fallback_to_default_app.then_some(&backend_app.server_name);
 
-    // Build request from destination information
-    let _context = self
-      .generate_request_forwarded(
-        &client_addr,
-        &listen_addr,
-        &mut req,
-        &upgrade_in_request,
-        upstream_candidates,
-        tls_enabled,
-        fallback_host,
-      )
-      .map_err(|e| HttpError::FailedToGenerateUpstreamRequest(e.to_string()))?;
+    // Determine whether failover is eligible for this request. Failover requires the request
+    // body (if any) to be small and replayable; we therefore disable it for HTTP upgrades
+    // (WebSocket / H2C) and for requests whose body is chunked or larger than the buffer cap.
+    let body_too_large_or_chunked = is_body_unbufferable(&req);
+    let should_use_failover = upstream_candidates.failover_config.is_some()
+      && upstream_candidates.inner.len() > 1
+      && upgrade_in_request.is_none()
+      && !body_too_large_or_chunked;
 
-    debug!(
-      "Request to be forwarded: [uri {}, method: {}, version {:?}, headers {:?}]",
-      req.uri(),
-      req.method(),
-      req.version(),
-      req.headers()
-    );
-    log_data.xff(&req.headers().get(header_defs::X_FORWARDED_FOR));
-    log_data.upstream(req.uri());
-    //////
+    let (mut res_backend, _context_lb) = if should_use_failover {
+      debug!("Failover eligible for this request");
+      let (req_parts, buffered_body) = self.buffer_request_body(req).await?;
+      self
+        .request_with_failover(
+          req_parts,
+          buffered_body,
+          upstream_candidates,
+          &client_addr,
+          &listen_addr,
+          tls_enabled,
+          &upgrade_in_request,
+          fallback_host,
+          log_data,
+        )
+        .await?
+    } else {
+      // Single-attempt path: no body buffering, request body streams directly to upstream.
+      let handler_context = self
+        .generate_request_forwarded(
+          &client_addr,
+          &listen_addr,
+          &mut req,
+          &upgrade_in_request,
+          upstream_candidates,
+          tls_enabled,
+          fallback_host,
+        )
+        .map_err(|e| HttpError::FailedToGenerateUpstreamRequest(e.to_string()))?;
 
-    //////////////
-    // Forward request to a chosen backend
-    let mut res_backend = self
-      .forwarder
-      .request(req)
-      .await
-      .map_err(|e| HttpError::FailedToGetResponseFromBackend(e.to_string()))?;
+      debug!(
+        "Request to be forwarded: [uri {}, method: {}, version {:?}, headers {:?}]",
+        req.uri(),
+        req.method(),
+        req.version(),
+        req.headers()
+      );
+      log_data.xff(&req.headers().get(header_defs::X_FORWARDED_FOR));
+      log_data.upstream(req.uri());
+
+      let res = self
+        .forwarder
+        .request(req)
+        .await
+        .map_err(|e| HttpError::FailedToGetResponseFromBackend(e.to_string()))?;
+      (res, handler_context.context_lb)
+    };
 
     //////////////
     // Process reverse proxy context generated during the forwarding request generation.
     #[cfg(feature = "sticky-cookie")]
-    if let Some(context_from_lb) = _context.context_lb {
+    if let Some(context_from_lb) = _context_lb {
       let res_headers = res_backend.headers_mut();
       if let Err(e) = set_sticky_cookie_lb_context(res_headers, &context_from_lb) {
         return Err(HttpError::FailedToAddSetCookeInResponse(e.to_string()));
@@ -245,4 +272,220 @@ where
 
     Ok(res_backend)
   }
+
+  /// Collect the request body into memory so it can be replayed on failover retries.
+  /// Returns `(parts, Some(bytes))` for normal-sized bodies and `(parts, None)` for the
+  /// edge case of a body that grows past `MAX_BUFFERED_BODY_SIZE` only after collection
+  /// begins (e.g. a chunked body that lied about its size). Callers are expected to have
+  /// already filtered chunked / oversized bodies out via `is_body_unbufferable`.
+  async fn buffer_request_body(&self, req: Request<RequestBody>) -> HttpResult<(http::request::Parts, Option<Bytes>)> {
+    let (parts, body) = req.into_parts();
+    let collected = body
+      .collect()
+      .await
+      .map_err(|e| HttpError::Other(anyhow::anyhow!("Failed to collect request body for failover: {e}")))?
+      .to_bytes();
+    if collected.len() > crate::constants::MAX_BUFFERED_BODY_SIZE {
+      debug!(
+        "Request body collected to {} bytes, exceeds {} byte buffer cap; failover disabled for this request",
+        collected.len(),
+        crate::constants::MAX_BUFFERED_BODY_SIZE
+      );
+      return Ok((parts, None));
+    }
+    Ok((parts, Some(collected)))
+  }
+
+  /// Reconstruct a request from the saved parts and a buffered body, producing a fresh
+  /// `RequestBody::IncomingLike` body for each retry attempt.
+  fn reconstruct_request(&self, parts: &http::request::Parts, body_bytes: Bytes) -> HttpResult<Request<RequestBody>> {
+    let len = body_bytes.len() as u64;
+    let (mut tx, rx) = IncomingLike::new_channel(DecodedLength::new(len), false);
+    // The channel buffer holds one pending Bytes send; try_send avoids needing await here.
+    tx.try_send_data(body_bytes)
+      .map_err(|_| HttpError::Other(anyhow::anyhow!("Failed to enqueue buffered body for retry")))?;
+    drop(tx); // close the channel — only one frame plus terminator will be observed
+    Ok(Request::from_parts(parts.clone(), RequestBody::IncomingLike(rx)))
+  }
+
+  /// Drive the retry loop across upstream candidates. Returns the last response (success or
+  /// final failure) plus the load-balancer context produced during the final attempt — so
+  /// the caller can still apply sticky-cookie handling to the response.
+  #[allow(clippy::too_many_arguments)]
+  async fn request_with_failover(
+    &self,
+    req_parts: http::request::Parts,
+    buffered_body: Option<Bytes>,
+    upstream_candidates: &UpstreamCandidates,
+    client_addr: &SocketAddr,
+    listen_addr: &SocketAddr,
+    tls_enabled: bool,
+    upgrade: &Option<String>,
+    fallback_host: Option<&ServerName>,
+    log_data: &mut HttpMessageLog,
+  ) -> HttpResult<(Response<ResponseBody>, Option<LoadBalanceContext>)> {
+    let failover_config = upstream_candidates
+      .failover_config
+      .as_ref()
+      .expect("failover_config must be Some when entering request_with_failover");
+
+    // Probe the load balancer once to find the initial upstream index. The actual
+    // per-attempt request will call generate_request_forwarded again, which itself
+    // re-invokes the load balancer; for retries (attempt > 0) we override the URI
+    // explicitly to point at the failover-selected upstream.
+    let (initial_upstream_opt, _initial_lb_ctx) = upstream_candidates.get(&None);
+    let initial_upstream = initial_upstream_opt.ok_or(HttpError::NoUpstreamCandidates)?;
+    let initial_idx = upstream_candidates
+      .find_upstream_index(initial_upstream)
+      .ok_or(HttpError::NoUpstreamCandidates)?;
+
+    let mut failover_ctx = FailoverContext::new(initial_idx);
+    let max_retries = failover_config.max_retries.min(upstream_candidates.inner.len() - 1);
+
+    debug!(
+      "Failover starting: initial_upstream_idx={}, max_retries={}, trigger_statuses={:?}, on_connection_failure={}",
+      initial_idx, max_retries, failover_config.trigger_statuses, failover_config.on_connection_failure
+    );
+
+    let mut last_response: Option<Response<ResponseBody>> = None;
+    let mut last_lb_context: Option<LoadBalanceContext> = None;
+    let mut attempt: usize = 0;
+
+    loop {
+      let Some((upstream_idx, _upstream)) = upstream_candidates.get_next(&mut failover_ctx) else {
+        break;
+      };
+
+      // Build a fresh request for this attempt. If we have a buffered body we replay it
+      // through a new IncomingLike channel; if not we cannot retry safely beyond attempt 0.
+      let req = match (&buffered_body, attempt) {
+        (Some(bytes), _) => self.reconstruct_request(&req_parts, bytes.clone())?,
+        (None, 0) => {
+          // Body collection produced a too-large payload, so failover is effectively disabled.
+          // Issue a single attempt with an empty body. (Callers normally prevent this branch
+          // via is_body_unbufferable, but defend against it anyway.)
+          let (_tx, rx) = IncomingLike::new_channel(DecodedLength::ZERO, false);
+          Request::from_parts(req_parts.clone(), RequestBody::IncomingLike(rx))
+        }
+        (None, _) => {
+          warn!("Cannot retry failover attempt {attempt}: request body was not buffered");
+          break;
+        }
+      };
+
+      let mut forwarded_req = req;
+      let handler_context = self
+        .generate_request_forwarded(
+          client_addr,
+          listen_addr,
+          &mut forwarded_req,
+          upgrade,
+          upstream_candidates,
+          tls_enabled,
+          fallback_host,
+        )
+        .map_err(|e| HttpError::FailedToGenerateUpstreamRequest(e.to_string()))?;
+
+      // For retries (attempt > 0) override the URI to point at the failover-selected
+      // upstream, since generate_request_forwarded re-asks the load balancer and may not
+      // pick the same index we are tracking. Note: Host header rewriting (e.g. the
+      // `set_upstream_host` option) still reflects the load balancer's pick — this matches
+      // the documented limitation that header rewriting is not reapplied per retry.
+      if attempt > 0 {
+        let upstream = &upstream_candidates.inner[upstream_idx];
+        let original_pq = forwarded_req
+          .uri()
+          .path_and_query()
+          .map(|pq| pq.as_str().to_owned())
+          .unwrap_or_else(|| "/".to_owned());
+        let scheme = upstream
+          .uri
+          .scheme()
+          .ok_or_else(|| HttpError::Other(anyhow::anyhow!("Upstream missing scheme")))?
+          .as_str()
+          .to_owned();
+        let authority = upstream
+          .uri
+          .authority()
+          .ok_or_else(|| HttpError::Other(anyhow::anyhow!("Upstream missing authority")))?
+          .as_str()
+          .to_owned();
+        let new_uri = http::Uri::builder()
+          .scheme(scheme.as_str())
+          .authority(authority.as_str())
+          .path_and_query(original_pq.as_str())
+          .build()
+          .map_err(|e| HttpError::Other(anyhow::anyhow!("Failed to rebuild URI for retry: {e}")))?;
+        *forwarded_req.uri_mut() = new_uri;
+      }
+
+      log_data.xff(&forwarded_req.headers().get(header_defs::X_FORWARDED_FOR));
+      log_data.upstream(forwarded_req.uri());
+
+      debug!(
+        "Failover attempt {} -> upstream[{}]: {}",
+        failover_ctx.retry_count + 1,
+        upstream_idx,
+        forwarded_req.uri()
+      );
+
+      match self.forwarder.request(forwarded_req).await {
+        Ok(response) => {
+          let status = response.status();
+          if failover_config.trigger_statuses.contains(&status.as_u16()) {
+            warn!(
+              "Upstream[{}] returned status {} matching failover triggers; will retry next upstream",
+              upstream_idx, status
+            );
+            last_response = Some(response);
+            last_lb_context = handler_context.context_lb;
+          } else {
+            return Ok((response, handler_context.context_lb));
+          }
+        }
+        Err(e) => {
+          if failover_config.on_connection_failure {
+            warn!(
+              "Upstream[{}] connection failed: {}; will retry next upstream",
+              upstream_idx, e
+            );
+            last_lb_context = handler_context.context_lb;
+          } else {
+            return Err(HttpError::FailedToGetResponseFromBackend(e.to_string()));
+          }
+        }
+      }
+
+      if !failover_ctx.can_retry(max_retries) {
+        debug!("Failover max_retries ({}) reached", max_retries);
+        break;
+      }
+      attempt += 1;
+      failover_ctx.increment_retry();
+    }
+
+    last_response
+      .map(|r| (r, last_lb_context))
+      .ok_or(HttpError::AllUpstreamsFailed)
+  }
+}
+
+/// Returns true when the request body cannot safely be buffered for failover retries.
+/// This is the case for chunked-encoded bodies (size unknown until fully collected) and
+/// for requests whose declared `Content-Length` exceeds `MAX_BUFFERED_BODY_SIZE`.
+fn is_body_unbufferable<B>(req: &Request<B>) -> bool {
+  let chunked = req
+    .headers()
+    .get(header::TRANSFER_ENCODING)
+    .and_then(|v| v.to_str().ok())
+    .is_some_and(|s| s.to_ascii_lowercase().split(',').any(|t| t.trim() == "chunked"));
+  if chunked {
+    return true;
+  }
+  req
+    .headers()
+    .get(header::CONTENT_LENGTH)
+    .and_then(|v| v.to_str().ok())
+    .and_then(|s| s.parse::<usize>().ok())
+    .is_some_and(|len| len > crate::constants::MAX_BUFFERED_BODY_SIZE)
 }

--- a/rpxy-lib/src/message_handler/handler_manipulate_messages.rs
+++ b/rpxy-lib/src/message_handler/handler_manipulate_messages.rs
@@ -64,12 +64,9 @@ where
   /// with the given authoritative value. `X-Forwarded-Host` is rebuilt separately by
   /// `add_forwarding_header()` as part of the general forwarding-header policy.
   ///
-  /// `preselected_upstream`: when `Some((idx, upstream))`, skip the load-balancer call entirely
-  /// and route this request to the named upstream. The sticky-cookie payload returned via
-  /// `HandlerContext::context_lb` is recomputed against `idx` so any Set-Cookie sent back to
-  /// the client encodes the upstream that actually served the request — important for the
-  /// failover path where retries may target a different upstream than the cookie originally
-  /// pinned. When `None`, the load balancer picks normally.
+  /// `preselected_upstream`: when `Some(_)`, skip the load balancer and route to that upstream;
+  /// `HandlerContext::context_lb` is rebuilt against the chosen index so Set-Cookie tracks
+  /// where the request actually went (matters for failover retries against sticky-cookie LB).
   pub(super) fn generate_request_forwarded<B>(
     &self,
     client_addr: &SocketAddr,

--- a/rpxy-lib/src/message_handler/handler_manipulate_messages.rs
+++ b/rpxy-lib/src/message_handler/handler_manipulate_messages.rs
@@ -1,6 +1,6 @@
 use super::{HttpMessageHandler, handler_main::HandlerContext, header_ops::*, request_ops::update_request_line};
 use crate::{
-  backend::{BackendApp, UpstreamCandidates},
+  backend::{BackendApp, Upstream, UpstreamCandidates},
   constants::RESPONSE_HEADER_SERVER,
   log::*,
   name_exp::ServerName,
@@ -63,6 +63,13 @@ where
   /// fallback path. In that case the incoming `Host` is untrusted and will be force-overwritten
   /// with the given authoritative value. `X-Forwarded-Host` is rebuilt separately by
   /// `add_forwarding_header()` as part of the general forwarding-header policy.
+  ///
+  /// `preselected_upstream`: when `Some((idx, upstream))`, skip the load-balancer call entirely
+  /// and route this request to the named upstream. The sticky-cookie payload returned via
+  /// `HandlerContext::context_lb` is recomputed against `idx` so any Set-Cookie sent back to
+  /// the client encodes the upstream that actually served the request — important for the
+  /// failover path where retries may target a different upstream than the cookie originally
+  /// pinned. When `None`, the load balancer picks normally.
   pub(super) fn generate_request_forwarded<B>(
     &self,
     client_addr: &SocketAddr,
@@ -72,6 +79,7 @@ where
     upstream_candidates: &UpstreamCandidates,
     tls_enabled: bool,
     fallback_host: Option<&ServerName>,
+    preselected_upstream: Option<(usize, &Upstream)>,
   ) -> Result<HandlerContext> {
     trace!("Generate request to be forwarded");
 
@@ -117,25 +125,39 @@ where
     };
 
     /////////////////////////////////////////////
-    // Fix unique upstream destination since there could be multiple ones.
+    // Always remove the sticky cookie from request headers so we don't forward it upstream.
+    // For the LB-picks-upstream path this gives us the cookie to feed back to the LB; for
+    // the preselected path we discard the cookie value (the caller is overriding the LB).
     #[cfg(feature = "sticky-cookie")]
-    let (upstream_chosen_opt, context_from_lb) = {
-      let context_to_lb = if let crate::backend::LoadBalance::StickyRoundRobin(lb) = &upstream_candidates.load_balance {
-        takeout_sticky_cookie_lb_context(req.headers_mut(), &lb.sticky_config.name)?
-      } else {
-        None
-      };
-      upstream_candidates.get(&context_to_lb)
+    let context_to_lb = if let crate::backend::LoadBalance::StickyRoundRobin(lb) = &upstream_candidates.load_balance {
+      takeout_sticky_cookie_lb_context(req.headers_mut(), &lb.sticky_config.name)?
+    } else {
+      None
     };
-    #[cfg(not(feature = "sticky-cookie"))]
-    let (upstream_chosen_opt, _) = upstream_candidates.get(&None);
 
-    let upstream_chosen = upstream_chosen_opt.ok_or_else(|| anyhow!("Failed to get upstream"))?;
+    let (upstream_chosen, context_from_lb, chosen_idx): (&Upstream, Option<crate::backend::LoadBalanceContext>, usize) =
+      match preselected_upstream {
+        Some((idx, upstream)) => {
+          // Skip the load-balancer call. Compute a fresh sticky-cookie payload bound to
+          // the preselected upstream so Set-Cookie tracks where the request actually goes.
+          #[cfg(feature = "sticky-cookie")]
+          let context = upstream_candidates.build_lb_context_for_index(idx);
+          #[cfg(not(feature = "sticky-cookie"))]
+          let context = None;
+          (upstream, context, idx)
+        }
+        None => {
+          #[cfg(feature = "sticky-cookie")]
+          let picked = upstream_candidates.get_with_index(&context_to_lb);
+          #[cfg(not(feature = "sticky-cookie"))]
+          let picked = upstream_candidates.get_with_index(&None);
+          let (idx, upstream, ctx) = picked.ok_or_else(|| anyhow!("Failed to get upstream"))?;
+          (upstream, ctx, idx)
+        }
+      };
     let context = HandlerContext {
-      #[cfg(feature = "sticky-cookie")]
       context_lb: context_from_lb,
-      #[cfg(not(feature = "sticky-cookie"))]
-      context_lb: None,
+      chosen_upstream_idx: chosen_idx,
     };
     /////////////////////////////////////////////
 

--- a/rpxy-lib/src/message_handler/header_ops/upstream.rs
+++ b/rpxy-lib/src/message_handler/header_ops/upstream.rs
@@ -127,6 +127,7 @@ mod tests {
       replace_path: None,
       load_balance: LoadBalance::default(),
       options: HashSet::from_iter([UpstreamOption::ForwardedHeader]),
+      failover_config: None,
       #[cfg(feature = "health-check")]
       health_check_config: None,
     };
@@ -192,6 +193,7 @@ mod tests {
       replace_path: None,
       load_balance: LoadBalance::default(),
       options: HashSet::from_iter([UpstreamOption::SetUpstreamHost]),
+      failover_config: None,
       #[cfg(feature = "health-check")]
       health_check_config: None,
     };
@@ -226,6 +228,7 @@ mod tests {
       replace_path: None,
       load_balance: LoadBalance::default(),
       options: HashSet::from_iter([UpstreamOption::SetUpstreamHost, UpstreamOption::KeepOriginalHost]),
+      failover_config: None,
       #[cfg(feature = "health-check")]
       health_check_config: None,
     };

--- a/rpxy-lib/src/message_handler/http_result.rs
+++ b/rpxy-lib/src/message_handler/http_result.rs
@@ -36,6 +36,10 @@ pub enum HttpError {
   // NoUpgradeExtensionInRequest,
   // #[error("Response does not have an upgrade extension")]
   // NoUpgradeExtensionInResponse,
+  #[error("All upstreams failed during failover")]
+  AllUpstreamsFailed,
+  #[error("Request body too large to buffer for failover retry")]
+  RequestBodyTooLargeForRetry,
   #[error(transparent)]
   Other(#[from] anyhow::Error),
 }
@@ -56,6 +60,8 @@ impl From<HttpError> for StatusCode {
       HttpError::FailedToGetResponseFromBackend(_) => StatusCode::BAD_GATEWAY,
       // HttpError::NoUpgradeExtensionInRequest => StatusCode::BAD_REQUEST,
       // HttpError::NoUpgradeExtensionInResponse => StatusCode::BAD_GATEWAY,
+      HttpError::AllUpstreamsFailed => StatusCode::BAD_GATEWAY,
+      HttpError::RequestBodyTooLargeForRetry => StatusCode::BAD_GATEWAY,
       _ => StatusCode::INTERNAL_SERVER_ERROR,
     }
   }

--- a/rpxy-lib/src/message_handler/http_result.rs
+++ b/rpxy-lib/src/message_handler/http_result.rs
@@ -38,8 +38,6 @@ pub enum HttpError {
   // NoUpgradeExtensionInResponse,
   #[error("All upstreams failed during failover")]
   AllUpstreamsFailed,
-  #[error("Request body too large to buffer for failover retry")]
-  RequestBodyTooLargeForRetry,
   #[error(transparent)]
   Other(#[from] anyhow::Error),
 }
@@ -61,7 +59,6 @@ impl From<HttpError> for StatusCode {
       // HttpError::NoUpgradeExtensionInRequest => StatusCode::BAD_REQUEST,
       // HttpError::NoUpgradeExtensionInResponse => StatusCode::BAD_GATEWAY,
       HttpError::AllUpstreamsFailed => StatusCode::BAD_GATEWAY,
-      HttpError::RequestBodyTooLargeForRetry => StatusCode::BAD_GATEWAY,
       _ => StatusCode::INTERNAL_SERVER_ERROR,
     }
   }


### PR DESCRIPTION
## Heads-up on the contribution guideline

Per `CONTRIBUTING.md`, large changes should be discussed in an Issue or Discussion first. I went ahead and built this without that conversation because I needed it for production migration work, and I wanted to put working code in front of you rather than a vague proposal. **Completely understand if you'd prefer to close this and pick up the conversation in a Discussion first** — happy to do that. If the design doesn't fit the project's direction, I'll keep it in my fork.

## Summary

Adds automatic upstream failover, similar in spirit to nginx's `proxy_next_upstream`. When a request to the load-balancer-selected upstream returns a configured error status (default `[502, 503, 504]`) or the connection fails, the request is transparently retried against the next upstream in the same `[[reverse_proxy]]` block.

```toml
[[apps.api.reverse_proxy]]
upstream = [
  { location = 'backend1:8080' },
  { location = 'backend2:8080' },
]
failover_on_statuses          = [502, 503, 504]   # default
failover_on_connection_failure = true             # default
max_failover_retries           = 1                # default: upstream.len() - 1
failover_non_idempotent_methods = false           # default; opt-in to retry POST/PATCH
```

Failover is auto-disabled (request falls through to the existing single-attempt streaming path) when:
- only one upstream is configured, or no failover field is set
- the request is a WebSocket / H2C upgrade
- the request method is non-idempotent and `failover_non_idempotent_methods` is `false` (RFC 9110 §9.2.2)
- the request body cannot be replayed (chunked, or `size_hint().upper()` is `None` or `> MAX_BUFFERED_BODY_SIZE` — 1 MiB)

## Use cases

The motivating one for me is a **gradual backend migration**: try a new Elixir backend first, fall back to the legacy Ruby backend on `404`/`501`. rpxy's existing load balancing distributes traffic, but doesn't retry — this fills that gap. Other configurations the same code supports: standard HA on `5xx`, canary rollback, multi-region failover on connection failure.

## Design highlights

- **`generate_request_forwarded` accepts an optional preselected upstream.** When provided it skips its own load-balancer call and applies URI rewriting + `set_upstream_host` rewriting + `Set-Cookie` against that upstream. This is what makes failover correct against sticky-cookie LB: the response's `Set-Cookie` encodes the upstream that actually served the request, not the one originally pinned. It also eliminates the double LB probe per request.
- **`HandlerContext` carries `chosen_upstream_idx`** so the failover loop tracks tried upstreams without round-tripping through URI matching.
- **Body buffering uses `http_body_util::Limited`** so collection aborts early if the body grows past the cap mid-stream — prevents memory exhaustion via under-declared size hints (HTTP/2/3 streamed bodies, HTTP/1.0 close-delimited).
- **Trailers preserved**: `Collected::trailers()` is captured and replayed via `IncomingLike::send_trailers` so gRPC requests don't lose their trailing metadata on retry.
- **Cache-poisoning fix**: a `NoCacheStatuses(Arc<HashSet<u16>>)` request extension is read by `Forwarder::request` and skips `cache.put()` for trigger-status responses. Without this, a 502 from a triggering upstream could be cached and defeat retries on subsequent requests.
- **Connection-pool friendliness**: discarded responses (during retry) are drained in a background task so hyper returns their connections to the keep-alive pool instead of closing them.

## Limitations (documented)

- Retries are sequential, like nginx. No parallel speculation.
- `Retry-After` headers are not honored. No backoff between attempts.
- No integration with `health-check`: a sick upstream is hammered by every failover-eligible request until the next health probe.
- Per-attempt `generate_request_forwarded` re-runs forwarding-header generation on retries (small constant-factor overhead).
- Only the cookie-pinned upstream's `Set-Cookie` is corrected on success; if every attempt fails (`AllUpstreamsFailed`), the LB context returned reflects the last failing attempt.

## Verification

- `cargo fmt --check` — clean (against the files this PR touches; pre-existing fmt issues elsewhere left untouched).
- `cargo test` — 151 passed (113 `rpxy-lib` + 4 `rpxy-trusted-proxies` + 29 `rpxy-certs` + 4 `rpxy-bin` + 1 `rpxy-acme`). 9 new unit tests covering `FailoverConfig`, `FailoverContext`, `is_idempotent_method`, and `is_body_unbufferable`.
- `cargo build --release` — clean.
- `cargo check --workspace --all-features` — clean.
- `cargo clippy --workspace` — same warning count as `develop` baseline (zero new warnings introduced).

## Commits

This branch has three commits, intentionally kept separate so each is reviewable on its own:

1. **Introduce automatic upstream failover feature** — initial implementation: `FailoverConfig`/`FailoverContext`, TOML plumbing, retry loop in `handle_request_inner`.
2. **Address upstream-failover review findings** — second-pass hardening: streaming body cap, `generate_request_forwarded` refactor (preselected upstream), gRPC trailers, idempotent-method gate, cache-poisoning fix, response drain. Resolves seven correctness/security findings.
3. **Simplify failover hardening** — code-quality follow-up: `Arc<HashSet<u16>>` hoisted into `FailoverConfig`, `BufferedBody` enum collapsed to a struct, sticky-cookie helpers unified, comment trimming.

Net diff vs `develop`: 15 files, +853/-148.

## Test plan

- [x] Local `cargo test` and `cargo build --release`
- [x] CI: `verify` workflow on each commit
- [x] Manual: run `./target/release/rpxy --config config-failover-example.toml` (in branch); send requests against a flapping mock upstream and confirm failover behavior / log output
- [ ] (Optional, for reviewer) Try with an existing sticky-cookie config to confirm cookies don't break

## On scope

If the maintainer feels this is too large or doesn't fit the project's direction, I'm happy to:
- Split into smaller PRs (the three commits already separate cleanly)
- Move it to a `Discussion` for design feedback first
- Maintain it in my fork

Either way, thanks for considering it.