### PR TITLE
feat: redact sensitive debug headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,6 @@
 
 ### Important Changes
 
-- **Redact sensitive headers in DEBUG request logs.** The `debug!` line that logs the request to be forwarded now masks the values of `Authorization`, `Cookie`, and `Proxy-Authorization` with a `<redacted>` placeholder (header names stay visible). For troubleshooting, redaction can be disabled by setting the environment variable `RPXY_UNSAFE_DEBUG_HEADERS` to `1`, `true`, or `yes`; the variable is read once at startup and emits a `warn!` when enabled. Do not leave it enabled in production. The unredacted values still only appear when `RUST_LOG=debug`.
-
 ## 0.12.0 (To be released shortly)
 
 **Security-focused release with the following improvements and bugfixes.**
@@ -24,6 +22,7 @@
 - **Dependency note:** the sticky-cookie AEAD implementation currently pins `aes-gcm = 0.11.0-rc.3` intentionally for the 0.11 AEAD nonce-generation API. This pre-release dependency must be re-evaluated, replaced with a final 0.11.x release, or explicitly re-approved before the release dependency freeze.
 - Rebuild `X-Forwarded-Host` as part of the general forwarding-header policy. rpxy no longer forwards a client-supplied `X-Forwarded-Host` value as-is; instead it rebuilds `X-Forwarded-Host` from the original client-visible host, alongside the other authoritative `X-Forwarded-*` headers. As with `Forwarded: host=`, this value is observational only and must not be used for security decisions.
 - Harden TLS private key file permissions on Unix-like systems. Newly-created ACME cache files are now created with mode `0600`, newly-created ACME cache directories with mode `0700`, and existing cache artifacts keep their current modes. Manually provisioned TLS private key files are also checked at load time; rpxy emits a `warn!` log when any group or other permission bit is set, while still loading the key for backward compatibility.
+- **Redact sensitive headers in DEBUG request logs.** The `debug!` line that logs the request to be forwarded now masks the values of `Authorization`, `Cookie`, and `Proxy-Authorization` with a `<redacted>` placeholder (header names stay visible). For troubleshooting, redaction can be disabled by setting the environment variable `RPXY_UNSAFE_DEBUG_HEADERS` to `1`, `true`, or `yes`; the variable is read once at startup and emits a `warn!` when enabled. Do not leave it enabled in production. The unredacted values still only appear when `RUST_LOG=debug`.
 
 ### Improvement
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.12.1 or 0.13.0 (Unreleased)
 
+### Important Changes
+
+- **Redact sensitive headers in DEBUG request logs.** The `debug!` line that logs the request to be forwarded now masks the values of `Authorization`, `Cookie`, and `Proxy-Authorization` with a `<redacted>` placeholder (header names stay visible). For troubleshooting, redaction can be disabled by setting the environment variable `RPXY_UNSAFE_DEBUG_HEADERS` to `1`, `true`, or `yes`; the variable is read once at startup and emits a `warn!` when enabled. Do not leave it enabled in production. The unredacted values still only appear when `RUST_LOG=debug`.
+
 ## 0.12.0 (To be released shortly)
 
 **Security-focused release with the following improvements and bugfixes.**

--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ If you set `--log-dir=<log_dir>`, the log files are created in the specified dir
 <!-- - `${log_dir}/error.log` for error log -->
 - `${log_dir}/rpxy.log` for system and error log
 
+The log verbosity is controlled by the `RUST_LOG` environment variable (e.g., `RUST_LOG=debug`). At `debug` level, the request-forwarding log redacts the values of sensitive headers (`Authorization`, `Cookie`, `Proxy-Authorization`) as `<redacted>`. For troubleshooting only, you can disable this redaction by setting `RPXY_UNSAFE_DEBUG_HEADERS` to `1`, `true`, or `yes`; rpxy then prints these header values verbatim and emits a warning at startup. This is read once at startup and must not be left enabled in production.
+
 That's all!
 
 ## Basic Configuration

--- a/rpxy-bin/src/config/toml.rs
+++ b/rpxy-bin/src/config/toml.rs
@@ -13,7 +13,6 @@ use serde::Deserialize;
 use std::{
   fs,
   net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
-  sync::Arc,
 };
 use tokio::time::Duration;
 
@@ -22,6 +21,9 @@ use rpxy_lib::TcpRecvProxyProtocolConfig;
 
 #[cfg(feature = "health-check")]
 use rpxy_lib::{HealthCheckConfig, HealthCheckType, LOAD_BALANCE_PRIMARY_BACKUP};
+
+#[cfg(feature = "sticky-cookie")]
+use std::sync::Arc;
 
 #[cfg(feature = "sticky-cookie")]
 use rpxy_lib::{LOAD_BALANCE_STICKY_ROUND_ROBIN, StickyCookieSecret, validate_sticky_cookie_aad_component};

--- a/rpxy-bin/src/log.rs
+++ b/rpxy-bin/src/log.rs
@@ -6,6 +6,34 @@ use tracing_subscriber::{filter::filter_fn, fmt, prelude::*};
 #[allow(unused)]
 pub use tracing::{debug, error, info, warn};
 
+/// Environment variable that disables credential-header redaction in DEBUG
+/// request logs. Troubleshooting-only; see `unsafe_debug_headers_enabled`.
+const UNSAFE_DEBUG_HEADERS_ENV: &str = "RPXY_UNSAFE_DEBUG_HEADERS";
+
+/// Strict parse of the `RPXY_UNSAFE_DEBUG_HEADERS` opt-out value. Only `1`,
+/// `true`, or `yes` (case-insensitive, trimmed) enable it; every other value -
+/// including typos and `0` / `false` - is treated as disabled, so the fail-safe
+/// posture is always toward redaction.
+fn parse_unsafe_debug_headers(value: Option<&str>) -> bool {
+  value
+    .map(|v| matches!(v.trim().to_ascii_lowercase().as_str(), "1" | "true" | "yes"))
+    .unwrap_or(false)
+}
+
+/// Read the `RPXY_UNSAFE_DEBUG_HEADERS` opt-out once at startup. When enabled,
+/// emit a single `warn!` so that even at `RUST_LOG=info` an operator sees that
+/// credential redaction is disabled (the header dump itself still only appears
+/// at `RUST_LOG=debug`). Not hot-reloaded: read once and threaded into rpxy-lib.
+pub fn unsafe_debug_headers_enabled() -> bool {
+  let enabled = parse_unsafe_debug_headers(std::env::var(UNSAFE_DEBUG_HEADERS_ENV).ok().as_deref());
+  if enabled {
+    warn!(
+      "unsafe debug header logging enabled via {UNSAFE_DEBUG_HEADERS_ENV}: Authorization / Cookie / Proxy-Authorization values will be printed verbatim at RUST_LOG=debug. Do not leave this enabled in production."
+    );
+  }
+  enabled
+}
+
 /// Initialize the logger with the RUST_LOG environment variable.
 pub fn init_logger(log_dir_path: Option<&str>) {
   let level = std::env::var("RUST_LOG")
@@ -123,4 +151,28 @@ where
 fn is_cargo_pkg(metadata: &tracing::Metadata<'_>) -> bool {
   let pkg_name = env!("CARGO_PKG_NAME").replace('-', "_");
   metadata.target().starts_with(&pkg_name)
+}
+
+#[cfg(test)]
+mod tests {
+  use super::parse_unsafe_debug_headers;
+
+  #[test]
+  fn enabled_values() {
+    for v in ["1", "true", "yes", "TRUE", "Yes", " yes ", "True"] {
+      assert!(parse_unsafe_debug_headers(Some(v)), "{v:?} should enable");
+    }
+  }
+
+  #[test]
+  fn disabled_values() {
+    for v in ["0", "false", "no", "enabled", "", " ", "2", "on"] {
+      assert!(!parse_unsafe_debug_headers(Some(v)), "{v:?} should not enable");
+    }
+  }
+
+  #[test]
+  fn unset_is_disabled() {
+    assert!(!parse_unsafe_debug_headers(None));
+  }
 }

--- a/rpxy-bin/src/main.rs
+++ b/rpxy-bin/src/main.rs
@@ -38,6 +38,10 @@ fn main() {
 
     init_logger(parsed_opts.log_dir_path.as_deref());
 
+    // Read the unsafe debug-header logging opt-out once at startup.
+    // Not hot-reloaded; threaded into rpxy-lib via RpxyOptions.
+    let unsafe_debug_headers = unsafe_debug_headers_enabled();
+
     let reloader_config = ReloaderConfig::hybrid(CONFIG_WATCH_DELAY_SECS);
 
     let (config_service, config_rx) =
@@ -52,7 +56,7 @@ fn main() {
           std::process::exit(1);
         }
       }
-      rpxy_res = rpxy_service(config_rx, runtime.handle().clone()) => {
+      rpxy_res = rpxy_service(config_rx, runtime.handle().clone(), unsafe_debug_headers) => {
         if let Err(e) = rpxy_res {
           error!("rpxy service exited: {e}");
           std::process::exit(1);
@@ -70,6 +74,9 @@ struct RpxyService {
   app_conf: rpxy_lib::AppConfigList,
   cert_service: Option<Arc<ReloaderService<rpxy_certs::CryptoReloader, rpxy_certs::ServerCryptoBase>>>,
   cert_rx: Option<ReloaderReceiver<rpxy_certs::ServerCryptoBase>>,
+  /// Operator opt-out for credential-header redaction in DEBUG logs,
+  /// read once at startup from `RPXY_UNSAFE_DEBUG_HEADERS`.
+  unsafe_debug_headers: bool,
   #[cfg(feature = "sticky-cookie")]
   sticky_cookie_secret: Option<Arc<StickyCookieSecret>>,
   #[cfg(feature = "acme")]
@@ -78,7 +85,11 @@ struct RpxyService {
 
 impl RpxyService {
   /// Create a new RpxyService from config and runtime handle.
-  async fn new(config_toml: &ConfigToml, runtime_handle: tokio::runtime::Handle) -> Result<Self, anyhow::Error> {
+  async fn new(
+    config_toml: &ConfigToml,
+    runtime_handle: tokio::runtime::Handle,
+    unsafe_debug_headers: bool,
+  ) -> Result<Self, anyhow::Error> {
     let (proxy_conf, app_conf) = build_settings(config_toml).map_err(|e| anyhow!("Invalid configuration: {e}"))?;
     #[cfg(feature = "sticky-cookie")]
     let sticky_cookie_secret =
@@ -96,6 +107,7 @@ impl RpxyService {
       app_conf,
       cert_service,
       cert_rx,
+      unsafe_debug_headers,
       #[cfg(feature = "sticky-cookie")]
       sticky_cookie_secret,
       #[cfg(feature = "acme")]
@@ -110,6 +122,7 @@ impl RpxyService {
       app_conf,
       cert_service: _,
       cert_rx,
+      unsafe_debug_headers,
       #[cfg(feature = "sticky-cookie")]
       sticky_cookie_secret,
       #[cfg(feature = "acme")]
@@ -128,6 +141,7 @@ impl RpxyService {
         .app_config_list(app_conf.clone())
         .cert_rx(cert_rx.clone())
         .runtime_handle(runtime_handle.clone())
+        .unsafe_debug_headers(*unsafe_debug_headers)
         .server_configs_acme_challenge(Arc::new(server_config_acme_challenge));
       #[cfg(feature = "sticky-cookie")]
       builder.sticky_cookie_secret(sticky_cookie_secret.clone());
@@ -145,7 +159,8 @@ impl RpxyService {
         .proxy_config(proxy_conf.clone())
         .app_config_list(app_conf.clone())
         .cert_rx(cert_rx.clone())
-        .runtime_handle(runtime_handle.clone());
+        .runtime_handle(runtime_handle.clone())
+        .unsafe_debug_headers(*unsafe_debug_headers);
       #[cfg(feature = "sticky-cookie")]
       builder.sticky_cookie_secret(sticky_cookie_secret.clone());
       let rpxy_opts = builder.build()?;
@@ -248,6 +263,7 @@ impl RpxyService {
 async fn rpxy_service(
   mut config_rx: ReloaderReceiver<ConfigToml, String>,
   runtime_handle: tokio::runtime::Handle,
+  unsafe_debug_headers: bool,
 ) -> Result<(), anyhow::Error> {
   info!("Start rpxy service with dynamic config reloader");
   // Initial loading
@@ -256,7 +272,7 @@ async fn rpxy_service(
     .borrow()
     .clone()
     .ok_or(anyhow!("Something wrong in config reloader receiver"))?;
-  let mut service = RpxyService::new(&config_toml, runtime_handle.clone()).await?;
+  let mut service = RpxyService::new(&config_toml, runtime_handle.clone(), unsafe_debug_headers).await?;
 
   // Continuous monitoring
   loop {
@@ -279,7 +295,7 @@ async fn rpxy_service(
           error!("Something wrong in config reloader receiver");
           return Err(anyhow!("Something wrong in config reloader receiver"));
         };
-        match RpxyService::new(&new_config_toml, runtime_handle.clone()).await {
+        match RpxyService::new(&new_config_toml, runtime_handle.clone(), unsafe_debug_headers).await {
           Ok(new_service) => {
             info!("Configuration updated.");
             service = new_service;

--- a/rpxy-lib/src/globals.rs
+++ b/rpxy-lib/src/globals.rs
@@ -29,6 +29,9 @@ pub struct Globals {
   pub runtime_handle: tokio::runtime::Handle,
   /// Shared context - Certificate reloader service receiver // TODO: newer one
   pub cert_reloader_rx: Option<ReloaderReceiver<ServerCryptoBase>>,
+  /// Operator opt-out (env `RPXY_UNSAFE_DEBUG_HEADERS`) that disables
+  /// credential-header redaction in DEBUG request logs. Default false.
+  pub(crate) unsafe_debug_headers: bool,
   #[cfg(feature = "sticky-cookie")]
   pub(crate) sticky_cookie_cipher: Option<std::sync::Arc<Aes256Gcm>>,
 

--- a/rpxy-lib/src/lib.rs
+++ b/rpxy-lib/src/lib.rs
@@ -65,6 +65,10 @@ pub struct RpxyOptions {
   pub cert_rx: Option<ReloaderReceiver<ServerCryptoBase>>, // TODO:
   /// Async task runtime handler
   pub runtime_handle: tokio::runtime::Handle,
+  /// Operator opt-out (env `RPXY_UNSAFE_DEBUG_HEADERS`) that disables
+  /// credential-header redaction in DEBUG request logs. Default false.
+  #[builder(default)]
+  pub unsafe_debug_headers: bool,
   #[cfg(feature = "sticky-cookie")]
   #[builder(default)]
   pub sticky_cookie_secret: Option<Arc<StickyCookieSecret>>,
@@ -81,6 +85,7 @@ pub async fn entrypoint(
     app_config_list,
     cert_rx, // TODO:
     runtime_handle,
+    unsafe_debug_headers,
     #[cfg(feature = "sticky-cookie")]
     sticky_cookie_secret,
     #[cfg(feature = "acme")]
@@ -174,6 +179,7 @@ pub async fn entrypoint(
     request_count: Default::default(),
     runtime_handle: runtime_handle.clone(),
     cert_reloader_rx: cert_rx.clone(),
+    unsafe_debug_headers: *unsafe_debug_headers,
     #[cfg(feature = "sticky-cookie")]
     sticky_cookie_cipher,
 

--- a/rpxy-lib/src/message_handler/handler_main.rs
+++ b/rpxy-lib/src/message_handler/handler_main.rs
@@ -181,7 +181,7 @@ where
       req.uri(),
       req.method(),
       req.version(),
-      req.headers()
+      DebugHeaders::new(req.headers(), self.globals.unsafe_debug_headers)
     );
     log_data.xff(&req.headers().get(header_defs::X_FORWARDED_FOR));
     log_data.upstream(req.uri());

--- a/rpxy-lib/src/message_handler/header_ops/forwarding.rs
+++ b/rpxy-lib/src/message_handler/header_ops/forwarding.rs
@@ -671,7 +671,7 @@ fn format_forwarded_node(node: &ForwardedNode) -> Result<String> {
 ///
 /// 1. If the rpxy listener is TLS-terminating, return true.
 /// 2. Otherwise, only honor forwarding-derived scheme when the immediate peer is in
-///    `trusted_forwarded_proxies` (same trust boundary as H-1).
+///    `trusted_forwarded_proxies` (same trust boundary as the forwarding-header policy).
 /// 3. Header priority: `X-Forwarded-Proto` first comma-element wins; fall back to the
 ///    `proto=` parameter of the first `Forwarded` entry.
 /// 4. Any parse failure fails closed to false (debug-logged, not warn-logged) and does

--- a/rpxy-lib/src/message_handler/header_ops/mod.rs
+++ b/rpxy-lib/src/message_handler/header_ops/mod.rs
@@ -1,6 +1,7 @@
 mod common;
 mod forwarding;
 mod hop;
+mod redact;
 #[cfg(feature = "sticky-cookie")]
 mod sticky_cookie;
 mod upstream;
@@ -10,6 +11,7 @@ pub(super) use forwarding::add_forwarding_header;
 #[cfg(feature = "sticky-cookie")]
 pub(super) use forwarding::client_visible_secure;
 pub(super) use hop::{extract_upgrade, remove_connection_header, remove_hop_header};
+pub(crate) use redact::DebugHeaders;
 #[cfg(feature = "sticky-cookie")]
 pub(super) use sticky_cookie::{set_sticky_cookie_lb_context, takeout_sticky_cookie_lb_context};
 pub(super) use upstream::{apply_default_app_host_rewrite, apply_upstream_options_to_header};

--- a/rpxy-lib/src/message_handler/header_ops/redact.rs
+++ b/rpxy-lib/src/message_handler/header_ops/redact.rs
@@ -1,0 +1,103 @@
+use http::{HeaderMap, HeaderName, header};
+
+/// Request headers whose values are masked in DEBUG logs.
+/// These are the IANA standard credential-bearing headers; they are provided as
+/// `http::header` constants, so the denylist stays closed and typo-free.
+const SENSITIVE_HEADERS: [HeaderName; 3] = [header::AUTHORIZATION, header::PROXY_AUTHORIZATION, header::COOKIE];
+
+/// Wraps a `&HeaderMap` for DEBUG logging of requests to be forwarded.
+///
+/// When `redact` is true (the default), the values of credential-bearing
+/// headers (`Authorization` / `Cookie` / `Proxy-Authorization`) are replaced
+/// with a `<redacted>` placeholder while the header names stay visible for
+/// diagnostics. When `redact` is false (operator opted in via the env var
+/// `RPXY_UNSAFE_DEBUG_HEADERS`), all values are printed verbatim.
+pub(crate) struct DebugHeaders<'a> {
+  headers: &'a HeaderMap,
+  redact: bool,
+}
+
+impl<'a> DebugHeaders<'a> {
+  /// Build a debug view of `headers`. `unsafe_debug_headers` is the
+  /// operator-facing opt-out (env `RPXY_UNSAFE_DEBUG_HEADERS`); when it is
+  /// `false` (the default) credential headers are redacted. The inversion is
+  /// localized here so the call site reads as "log these headers, honoring the
+  /// unsafe-debug flag" without a bare `!` at the use point.
+  pub(crate) fn new(headers: &'a HeaderMap, unsafe_debug_headers: bool) -> Self {
+    Self {
+      headers,
+      redact: !unsafe_debug_headers,
+    }
+  }
+}
+
+impl std::fmt::Debug for DebugHeaders<'_> {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    let mut m = f.debug_map();
+    for (name, value) in self.headers.iter() {
+      // `HeaderMap::iter()` repeats the name for multi-value headers, so each
+      // value of a repeated sensitive header is masked individually.
+      if self.redact && SENSITIVE_HEADERS.contains(name) {
+        m.entry(&name.as_str(), &"<redacted>");
+      } else {
+        m.entry(&name.as_str(), &value);
+      }
+    }
+    m.finish()
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use http::HeaderValue;
+
+  fn build_headers() -> HeaderMap {
+    let mut h = HeaderMap::new();
+    h.insert(header::AUTHORIZATION, HeaderValue::from_static("Bearer supersecret"));
+    h.insert(header::PROXY_AUTHORIZATION, HeaderValue::from_static("Basic dXNlcjpwdw=="));
+    h.append(header::COOKIE, HeaderValue::from_static("sid=abc"));
+    h.append(header::COOKIE, HeaderValue::from_static("pref=dark"));
+    h.insert("x-forwarded-for", HeaderValue::from_static("203.0.113.1"));
+    h
+  }
+
+  #[test]
+  fn redacts_sensitive_values_and_keeps_benign() {
+    let headers = build_headers();
+    let rendered = format!("{:?}", DebugHeaders::new(&headers, false));
+
+    // sensitive values are masked
+    assert!(!rendered.contains("supersecret"), "authorization value leaked: {rendered}");
+    assert!(!rendered.contains("dXNlcjpwdw=="), "proxy-authorization value leaked: {rendered}");
+    assert!(!rendered.contains("sid=abc"), "cookie value leaked: {rendered}");
+    assert!(!rendered.contains("pref=dark"), "second cookie value leaked: {rendered}");
+    assert!(rendered.contains("<redacted>"), "expected redaction placeholder: {rendered}");
+
+    // header names remain visible for diagnostics
+    assert!(rendered.contains("authorization"), "authorization name missing: {rendered}");
+    assert!(rendered.contains("cookie"), "cookie name missing: {rendered}");
+
+    // benign header is untouched
+    assert!(rendered.contains("203.0.113.1"), "benign header was masked: {rendered}");
+  }
+
+  #[test]
+  fn multi_value_cookie_masks_every_entry() {
+    let headers = build_headers();
+    let rendered = format!("{:?}", DebugHeaders::new(&headers, false));
+    // both cookie entries replaced; placeholder appears at least twice for cookie
+    let redacted_count = rendered.matches("<redacted>").count();
+    // authorization + proxy-authorization + 2 cookie entries = 4 masked values
+    assert_eq!(redacted_count, 4, "expected 4 masked values: {rendered}");
+  }
+
+  #[test]
+  fn unsafe_opt_out_prints_values_verbatim() {
+    let headers = build_headers();
+    let rendered = format!("{:?}", DebugHeaders::new(&headers, true));
+    assert!(rendered.contains("supersecret"), "opt-out must print authorization: {rendered}");
+    assert!(rendered.contains("sid=abc"), "opt-out must print cookie: {rendered}");
+    assert!(!rendered.contains("<redacted>"), "opt-out must not redact: {rendered}");
+  }
+}


### PR DESCRIPTION
Redact sensitive headers in DEBUG request logs. The `debug!` line that logs the request to be forwarded now masks the values of `Authorization`, `Cookie`, and `Proxy-Authorization` with a `<redacted>` placeholder (header names stay visible). For troubleshooting, redaction can be disabled by setting the environment variable `RPXY_UNSAFE_DEBUG_HEADERS` to `1`, `true`, or `yes`; the variable is read once at startup and emits a `warn!` when enabled. Do not leave it enabled in production. The unredacted values still only appear when `RUST_LOG=debug`.