### PR TITLE
feat: per-ip connection limit for avoiding connection exhausting attack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ## 0.12.1 or 0.13.0 (Unreleased)
 
-### Important Changes
-
 ## 0.12.0 (To be released shortly)
 
 **Security-focused release with the following improvements and bugfixes.**
@@ -25,9 +23,11 @@
 - **Redact sensitive headers in DEBUG request logs.** The `debug!` line that logs the request to be forwarded now masks the values of `Authorization`, `Cookie`, and `Proxy-Authorization` with a `<redacted>` placeholder (header names stay visible). For troubleshooting, redaction can be disabled by setting the environment variable `RPXY_UNSAFE_DEBUG_HEADERS` to `1`, `true`, or `yes`; the variable is read once at startup and emits a `warn!` when enabled. Do not leave it enabled in production. The unredacted values still only appear when `RUST_LOG=debug`.
 - **Fix: preserve the case of the sticky cookie `path` attribute.** The sticky-session `Set-Cookie` previously lowercased its `path`, which could mis-scope the cookie and silently break stickiness on case-sensitive route paths. The `path` is now emitted verbatim (the cookie `domain` is still lowercased). Because the path is bound into the sealed token, sticky cookies issued for a mixed-case path before the upgrade are ignored once and reissued; all-lowercase paths are unaffected.
 - **Validate `server_name` as a hostname.** Each app's `server_name` is now validated at startup and must be a syntactically valid hostname: dot-separated labels of 1-63 characters, each starting and ending with an alphanumeric and otherwise containing only alphanumerics and `-`, with a total length up to 253 ASCII characters. This is defense-in-depth, in particular for the ACME on-disk paths derived from `server_name`. Valid hostnames are unaffected, but a `server_name` that is not a valid hostname (containing path separators, `..`, wildcards `*`, underscores `_`, IPv6 literals, or non-ASCII characters) is now rejected at startup where it was previously accepted (IPv4 literals are still accepted).
+- **Add optional per-IP connection limit.** A new global `max_clients_per_ip` option caps the number of concurrent connections from a single source IP, in addition to the existing global `max_clients`, so one source cannot exhaust the connection pool. It defaults to `0` (disabled), preserving existing behavior. The source IP is the immediate TCP/QUIC peer, or the real client address recovered from an inbound PROXY protocol header; it is not derived from `X-Forwarded-For` / `Forwarded`, so the limit is only meaningful when rpxy is the edge or inbound PROXY protocol is enabled (behind a bare L7 load balancer every connection collapses to the balancer's IP). For HTTP/1.1 and HTTP/2 the slot is reserved before the TLS handshake so handshake floods are bounded too; for HTTP/3 it caps QUIC connections per source IP, and a single IP's concurrent HTTP/3 request streams are then bounded by `max_clients_per_ip` times `[experimental.h3] max_concurrent_bidistream`.
 
 ### Improvement
 
+- Document that `connection_handling_timeout = 0` (the default) means no forced timeout, and recommend a non-zero value in production unless long-lived connections (e.g. WebSocket) are required.
 - deps and refactor
 
 ## 0.11.3

--- a/config-example.toml
+++ b/config-example.toml
@@ -46,6 +46,17 @@ max_concurrent_streams = 100
 # Optional. Counted in total for http1.1, 2, 3
 max_clients = 512
 
+# Optional. Max concurrent connections per source IP, in addition to max_clients. 0 disables it (default).
+# This caps how many connections a single client IP may hold so one source cannot exhaust max_clients.
+# The source IP is the immediate TCP/QUIC peer, or the real client address recovered from an inbound
+# PROXY protocol header (see [experimental.tcp_recv_proxy_protocol]). It does NOT use X-Forwarded-For /
+# Forwarded, so it is only meaningful when rpxy is the edge or inbound PROXY protocol is enabled; behind
+# a bare L7 load balancer every connection collapses to the LB's IP. Hence it is disabled by default.
+# For HTTP/3, this caps QUIC connections per IP; a single IP's concurrent H3 request streams are then
+# bounded by max_clients_per_ip * [experimental.h3] max_concurrent_bidistream, so size them together
+# relative to max_clients.
+# max_clients_per_ip = 0
+
 # Optional. Trusted proxies whose incoming X-Forwarded-* / Forwarded headers are
 # recursively trusted. If omitted or empty, forwarding headers from preceding peers
 # are ignored and rebuilt from the immediate peer address.
@@ -172,6 +183,7 @@ ignore_sni_consistency = false
 # Force connection handling timeout regardless of the connection status, i.e., idle or not.
 # 0 represents an infinite timeout. [default: 0]
 # Note that idel and header read timeouts are always specified independently of this.
+# A non-zero value is recommended in production unless long-lived connections (e.g. WebSocket) are required.
 connection_handling_timeout = 0 # sec
 
 # If this specified, h3 is enabled

--- a/config-example.toml
+++ b/config-example.toml
@@ -182,7 +182,7 @@ ignore_sni_consistency = false
 
 # Force connection handling timeout regardless of the connection status, i.e., idle or not.
 # 0 represents an infinite timeout. [default: 0]
-# Note that idel and header read timeouts are always specified independently of this.
+# Note that idle and header read timeouts are always specified independently of this.
 # A non-zero value is recommended in production unless long-lived connections (e.g. WebSocket) are required.
 connection_handling_timeout = 0 # sec
 

--- a/rpxy-bin/src/config/toml.rs
+++ b/rpxy-bin/src/config/toml.rs
@@ -65,6 +65,7 @@ impl OneOrMany {
 /// - `tcp_listen_backlog`: Optional TCP backlog size.
 /// - `max_concurrent_streams`: Optional max concurrent streams.
 /// - `max_clients`: Optional max client connections.
+/// - `max_clients_per_ip`: Optional max concurrent connections per source IP (0 disables it).
 /// - `trusted_forwarded_proxies`: Optional CIDR(s) or built-in alias names whose incoming forwarding headers are trusted.
 /// - `apps`: Optional application definitions.
 /// - `default_app`: Optional default application name.
@@ -79,6 +80,7 @@ pub struct ConfigToml {
   pub tcp_listen_backlog: Option<u32>,
   pub max_concurrent_streams: Option<u32>,
   pub max_clients: Option<u32>,
+  pub max_clients_per_ip: Option<u32>,
   #[cfg(feature = "sticky-cookie")]
   pub sticky_cookie_secret: Option<String>,
   pub trusted_forwarded_proxies: Option<OneOrMany>,
@@ -356,6 +358,9 @@ impl TryInto<ProxyConfig> for &ConfigToml {
     // max values
     if let Some(c) = self.max_clients {
       proxy_config.max_clients = c as usize;
+    }
+    if let Some(c) = self.max_clients_per_ip {
+      proxy_config.max_clients_per_ip = c as usize;
     }
     if let Some(c) = self.max_concurrent_streams {
       proxy_config.max_concurrent_streams = c;
@@ -1005,6 +1010,27 @@ mod tests {
     let config: ConfigToml = toml::from_str(toml_str).unwrap();
     let proxy_config: ProxyConfig = (&config).try_into().unwrap();
     assert!(proxy_config.trusted_forwarded_proxies.is_empty());
+  }
+
+  #[test]
+  fn max_clients_per_ip_defaults_to_zero() {
+    let toml_str = r#"
+      listen_port = 8080
+    "#;
+    let config: ConfigToml = toml::from_str(toml_str).unwrap();
+    let proxy_config: ProxyConfig = (&config).try_into().unwrap();
+    assert_eq!(proxy_config.max_clients_per_ip, 0);
+  }
+
+  #[test]
+  fn max_clients_per_ip_is_applied() {
+    let toml_str = r#"
+      listen_port = 8080
+      max_clients_per_ip = 16
+    "#;
+    let config: ConfigToml = toml::from_str(toml_str).unwrap();
+    let proxy_config: ProxyConfig = (&config).try_into().unwrap();
+    assert_eq!(proxy_config.max_clients_per_ip, 16);
   }
 
   #[test]

--- a/rpxy-lib/src/constants.rs
+++ b/rpxy-lib/src/constants.rs
@@ -4,6 +4,7 @@ pub const PROXY_IDLE_TIMEOUT_SEC: u64 = 20;
 pub const UPSTREAM_IDLE_TIMEOUT_SEC: u64 = 20;
 pub const TLS_HANDSHAKE_TIMEOUT_SEC: u64 = 15; // default as with firefox browser
 pub const MAX_CLIENTS: usize = 512;
+pub const MAX_CLIENTS_PER_IP: usize = 0; // 0 disables the per-IP connection limit
 pub const MAX_CONCURRENT_STREAMS: u32 = 64;
 
 #[allow(non_snake_case)]

--- a/rpxy-lib/src/count.rs
+++ b/rpxy-lib/src/count.rs
@@ -1,6 +1,10 @@
-use std::sync::{
-  Arc,
-  atomic::{AtomicUsize, Ordering},
+use std::{
+  collections::HashMap,
+  net::IpAddr,
+  sync::{
+    Arc, Mutex,
+    atomic::{AtomicUsize, Ordering},
+  },
 };
 
 #[derive(Debug, Clone, Default)]
@@ -27,5 +31,146 @@ impl RequestCount {
           != Ok(count)
     } {}
     count
+  }
+}
+
+type IpConnectionMap = HashMap<IpAddr, usize, ahash::RandomState>;
+
+#[derive(Debug, Clone)]
+/// Per-source-IP concurrent connection counter, in addition to the global RequestCount.
+/// `max_per_ip == 0` disables the limit, in which case the map is never touched.
+pub struct PerIpConnectionCount {
+  inner: Arc<Mutex<IpConnectionMap>>,
+  max_per_ip: usize,
+}
+
+impl PerIpConnectionCount {
+  pub fn new(max_per_ip: usize) -> Self {
+    Self {
+      inner: Arc::new(Mutex::new(IpConnectionMap::default())),
+      max_per_ip,
+    }
+  }
+
+  /// Reserves one connection slot for the given IP, returning a guard that releases the slot on drop.
+  /// Returns None when the IP already holds max_per_ip slots. When the limit is disabled
+  /// (max_per_ip == 0), always returns a no-op guard without touching the map.
+  pub fn try_acquire(&self, ip: IpAddr) -> Option<PerIpConnectionGuard> {
+    if self.max_per_ip == 0 {
+      return Some(PerIpConnectionGuard { state: None });
+    }
+    let mut map = self.inner.lock().unwrap();
+    let count = map.entry(ip).or_insert(0);
+    // A freshly inserted entry is 0, which is below max_per_ip (>= 1 here), so the rejection
+    // branch is only reached for an already-positive count and never leaves a stale zero entry.
+    if *count >= self.max_per_ip {
+      return None;
+    }
+    *count += 1;
+    Some(PerIpConnectionGuard {
+      state: Some((self.inner.clone(), ip)),
+    })
+  }
+}
+
+/// RAII guard releasing one per-IP connection slot on drop, removing the entry when it reaches zero.
+pub struct PerIpConnectionGuard {
+  state: Option<(Arc<Mutex<IpConnectionMap>>, IpAddr)>,
+}
+
+impl Drop for PerIpConnectionGuard {
+  fn drop(&mut self) {
+    let Some((map, ip)) = &self.state else {
+      return;
+    };
+    let mut map = map.lock().unwrap();
+    if let Some(count) = map.get_mut(ip) {
+      *count -= 1;
+      if *count == 0 {
+        map.remove(ip);
+      }
+    }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use std::net::Ipv4Addr;
+
+  fn ip(last: u8) -> IpAddr {
+    IpAddr::V4(Ipv4Addr::new(192, 0, 2, last))
+  }
+
+  impl PerIpConnectionCount {
+    fn tracked_ips(&self) -> usize {
+      self.inner.lock().unwrap().len()
+    }
+    fn current(&self, ip: IpAddr) -> usize {
+      self.inner.lock().unwrap().get(&ip).copied().unwrap_or(0)
+    }
+  }
+
+  #[test]
+  fn disabled_never_touches_map() {
+    let counter = PerIpConnectionCount::new(0);
+    let g1 = counter.try_acquire(ip(1)).unwrap();
+    let g2 = counter.try_acquire(ip(1)).unwrap();
+    assert_eq!(counter.tracked_ips(), 0);
+    drop((g1, g2));
+    assert_eq!(counter.tracked_ips(), 0);
+  }
+
+  #[test]
+  fn enforces_cap_per_ip() {
+    let counter = PerIpConnectionCount::new(2);
+    let _g1 = counter.try_acquire(ip(1)).unwrap();
+    let _g2 = counter.try_acquire(ip(1)).unwrap();
+    assert!(counter.try_acquire(ip(1)).is_none());
+    assert_eq!(counter.current(ip(1)), 2);
+  }
+
+  #[test]
+  fn distinct_ips_are_independent() {
+    let counter = PerIpConnectionCount::new(1);
+    let _g1 = counter.try_acquire(ip(1)).unwrap();
+    assert!(counter.try_acquire(ip(1)).is_none());
+    let _g2 = counter.try_acquire(ip(2)).unwrap();
+    assert_eq!(counter.tracked_ips(), 2);
+  }
+
+  #[test]
+  fn drop_releases_slot_and_removes_entry_at_zero() {
+    let counter = PerIpConnectionCount::new(1);
+    let g1 = counter.try_acquire(ip(1)).unwrap();
+    assert!(counter.try_acquire(ip(1)).is_none());
+    drop(g1);
+    assert_eq!(counter.current(ip(1)), 0);
+    assert_eq!(counter.tracked_ips(), 0);
+    let _g2 = counter.try_acquire(ip(1)).unwrap();
+    assert_eq!(counter.current(ip(1)), 1);
+  }
+
+  #[test]
+  fn concurrent_acquire_release_never_exceeds_cap() {
+    let counter = PerIpConnectionCount::new(4);
+    let mut handles = Vec::new();
+    for _ in 0..16 {
+      let counter = counter.clone();
+      handles.push(std::thread::spawn(move || {
+        for _ in 0..1000 {
+          for last in 0..3u8 {
+            if let Some(guard) = counter.try_acquire(ip(last)) {
+              assert!(counter.current(ip(last)) <= 4);
+              drop(guard);
+            }
+          }
+        }
+      }));
+    }
+    for h in handles {
+      h.join().unwrap();
+    }
+    assert_eq!(counter.tracked_ips(), 0);
   }
 }

--- a/rpxy-lib/src/count.rs
+++ b/rpxy-lib/src/count.rs
@@ -36,6 +36,12 @@ impl RequestCount {
 
 type IpConnectionMap = HashMap<IpAddr, usize, ahash::RandomState>;
 
+/// Locks the map, recovering the guard if the mutex was poisoned. This counter is a best-effort
+/// availability guard, so a panic elsewhere must not cascade into rejecting every connection.
+fn lock_map(map: &Mutex<IpConnectionMap>) -> std::sync::MutexGuard<'_, IpConnectionMap> {
+  map.lock().unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
 #[derive(Debug, Clone)]
 /// Per-source-IP concurrent connection counter, in addition to the global RequestCount.
 /// `max_per_ip == 0` disables the limit, in which case the map is never touched.
@@ -59,7 +65,7 @@ impl PerIpConnectionCount {
     if self.max_per_ip == 0 {
       return Some(PerIpConnectionGuard { state: None });
     }
-    let mut map = self.inner.lock().unwrap();
+    let mut map = lock_map(&self.inner);
     let count = map.entry(ip).or_insert(0);
     // A freshly inserted entry is 0, which is below max_per_ip (>= 1 here), so the rejection
     // branch is only reached for an already-positive count and never leaves a stale zero entry.
@@ -83,9 +89,9 @@ impl Drop for PerIpConnectionGuard {
     let Some((map, ip)) = &self.state else {
       return;
     };
-    let mut map = map.lock().unwrap();
+    let mut map = lock_map(map);
     if let Some(count) = map.get_mut(ip) {
-      *count -= 1;
+      *count = count.saturating_sub(1);
       if *count == 0 {
         map.remove(ip);
       }

--- a/rpxy-lib/src/globals.rs
+++ b/rpxy-lib/src/globals.rs
@@ -1,4 +1,7 @@
-use crate::{constants::*, count::RequestCount};
+use crate::{
+  constants::*,
+  count::{PerIpConnectionCount, RequestCount},
+};
 use hot_reload::ReloaderReceiver;
 use ipnet::IpNet;
 use rpxy_certs::ServerCryptoBase;
@@ -19,12 +22,15 @@ pub struct TcpRecvProxyProtocolConfig {
 }
 
 /// Global object containing proxy configurations and shared object like counters.
-/// But note that in Globals, we do not have Mutex and RwLock. It is indeed, the context shared among async tasks.
+/// The only lock-bearing shared state is the per-IP connection counter, which is touched
+/// solely on connection open/close (a cold path), not on the per-request path.
 pub struct Globals {
   /// Configuration parameters for proxy transport and request handlers
   pub proxy_config: ProxyConfig,
   /// Shared context - Counter for serving requests
   pub request_count: RequestCount,
+  /// Shared context - Per-source-IP concurrent connection counter
+  pub per_ip_connection_count: PerIpConnectionCount,
   /// Shared context - Async task runtime handler
   pub runtime_handle: tokio::runtime::Handle,
   /// Shared context - Certificate reloader service receiver // TODO: newer one
@@ -62,6 +68,7 @@ pub struct ProxyConfig {
   pub upstream_idle_timeout: Duration,
 
   pub max_clients: usize,          // when serving requests
+  pub max_clients_per_ip: usize,   // per source IP; 0 disables the per-IP limit
   pub max_concurrent_streams: u32, // when instantiate server
   pub keepalive: bool,             // when instantiate server
 
@@ -123,6 +130,7 @@ impl Default for ProxyConfig {
       upstream_idle_timeout: Duration::from_secs(UPSTREAM_IDLE_TIMEOUT_SEC),
 
       max_clients: MAX_CLIENTS,
+      max_clients_per_ip: MAX_CLIENTS_PER_IP,
       max_concurrent_streams: MAX_CONCURRENT_STREAMS,
       keepalive: true,
 

--- a/rpxy-lib/src/lib.rs
+++ b/rpxy-lib/src/lib.rs
@@ -177,6 +177,7 @@ pub async fn entrypoint(
   let globals = Arc::new(Globals {
     proxy_config: proxy_config.clone(),
     request_count: Default::default(),
+    per_ip_connection_count: count::PerIpConnectionCount::new(proxy_config.max_clients_per_ip),
     runtime_handle: runtime_handle.clone(),
     cert_reloader_rx: cert_rx.clone(),
     unsafe_debug_headers: *unsafe_debug_headers,

--- a/rpxy-lib/src/proxy/proxy_h3.rs
+++ b/rpxy-lib/src/proxy/proxy_h3.rs
@@ -32,6 +32,12 @@ where
     <<C as OpenStreams<Bytes>>::BidiStream as BidiStream<Bytes>>::RecvStream: Send,
     <<C as OpenStreams<Bytes>>::BidiStream as BidiStream<Bytes>>::SendStream: Send,
   {
+    // Per-IP cap at the established-connection level; held for the whole QUIC connection lifetime.
+    let Some(_per_ip_guard) = self.globals.per_ip_connection_count.try_acquire(client_addr.ip()) else {
+      debug!("Per-IP connection limit reached for {client_addr}, dropping HTTP/3 connection");
+      return Ok(());
+    };
+
     let mut h3_conn = h3::server::Connection::<_, Bytes>::new(quic_connection).await?;
     debug!(
       "QUIC/HTTP3 connection established from {:?} {}",

--- a/rpxy-lib/src/proxy/proxy_main.rs
+++ b/rpxy-lib/src/proxy/proxy_main.rs
@@ -1,6 +1,7 @@
 use super::socket::bind_tcp_socket;
 use crate::{
   constants::TLS_HANDSHAKE_TIMEOUT_SEC,
+  count::PerIpConnectionGuard,
   error::*,
   globals::Globals,
   hyper_ext::{
@@ -244,9 +245,16 @@ impl<T> Proxy<T>
 where
   T: Send + Sync + Connect + Clone + 'static,
 {
-  /// Serves requests from clients
-  fn serve_connection<I>(&self, stream: I, peer_addr: SocketAddr, tls_server_name: Option<ServerName>)
-  where
+  /// Serves requests from clients.
+  /// The per-IP connection slot is reserved by the caller and passed in as a guard so that it
+  /// spans the same lifetime as the connection (including the preceding TLS handshake).
+  fn serve_connection<I>(
+    &self,
+    stream: I,
+    peer_addr: SocketAddr,
+    tls_server_name: Option<ServerName>,
+    per_ip_guard: PerIpConnectionGuard,
+  ) where
     I: Read + Write + Send + Unpin + 'static,
   {
     let request_count = self.globals.request_count.clone();
@@ -263,6 +271,8 @@ where
     let handling_timeout = self.globals.proxy_config.connection_handling_timeout;
 
     self.globals.runtime_handle.clone().spawn(async move {
+      // Hold the per-IP connection slot for the whole connection lifetime.
+      let _per_ip_guard = per_ip_guard;
       let fut = server_clone.serve_connection_with_upgrades(
         stream,
         service_fn(move |req: Request<Incoming>| {
@@ -297,7 +307,11 @@ where
       #[cfg(not(feature = "proxy-protocol"))]
       while let Ok((stream, client_addr)) = tcp_listener.accept().await {
         trace!("Accepted TCP connection from {client_addr}");
-        self.serve_connection(TokioIo::new(stream), client_addr, None);
+        let Some(per_ip_guard) = self.globals.per_ip_connection_count.try_acquire(client_addr.ip()) else {
+          debug!("Per-IP connection limit reached for {client_addr}, dropping connection");
+          continue;
+        };
+        self.serve_connection(TokioIo::new(stream), client_addr, None, per_ip_guard);
       }
       #[cfg(feature = "proxy-protocol")]
       {
@@ -326,12 +340,20 @@ where
                   return;
                 }
               };
-              self_inner.serve_connection(TokioIo::new(stream), real_addr, None);
+              let Some(per_ip_guard) = self_inner.globals.per_ip_connection_count.try_acquire(real_addr.ip()) else {
+                debug!("Per-IP connection limit reached for {real_addr}, dropping connection");
+                return;
+              };
+              self_inner.serve_connection(TokioIo::new(stream), real_addr, None, per_ip_guard);
             });
             continue;
           }
           // If inbound PROXY protocol is not enabled, serve connection directly with peer address from TCP accept
-          self.serve_connection(TokioIo::new(stream), client_addr, None);
+          let Some(per_ip_guard) = self.globals.per_ip_connection_count.try_acquire(client_addr.ip()) else {
+            debug!("Per-IP connection limit reached for {client_addr}, dropping connection");
+            continue;
+          };
+          self.serve_connection(TokioIo::new(stream), client_addr, None, per_ip_guard);
         }
       }
 
@@ -495,6 +517,12 @@ where
         }
       };
 
+      // Reserve the per-IP connection slot before the TLS handshake so handshake floods are bounded too.
+      let Some(per_ip_guard) = self_inner.globals.per_ip_connection_count.try_acquire(client_addr.ip()) else {
+        debug!("Per-IP connection limit reached for {client_addr}, dropping connection (TLS)");
+        return;
+      };
+
       #[cfg(feature = "acme")]
       let tls_handshake_fut = serve_tls_handshake(raw_stream, server_configs_acme_challenge, server_crypto_map);
       #[cfg(not(feature = "acme"))]
@@ -520,7 +548,7 @@ where
               stream.inner_mut().shutdown().await.ok();
               return;
             }
-            self_inner.serve_connection(stream, client_addr, Some(server_name));
+            self_inner.serve_connection(stream, client_addr, Some(server_name), per_ip_guard);
           }
           Err(e) => {
             error!("{}", e);
@@ -532,7 +560,7 @@ where
       {
         match tls_handshake_result {
           Ok(TlsHandshakeResult { stream, server_name }) => {
-            self_inner.serve_connection(stream, client_addr, Some(server_name));
+            self_inner.serve_connection(stream, client_addr, Some(server_name), per_ip_guard);
           }
           Err(e) => {
             error!("{}", e);


### PR DESCRIPTION
## Important changes

- **Add optional per-IP connection limit.** A new global `max_clients_per_ip` option caps the number of concurrent connections from a single source IP, in addition to the existing global `max_clients`, so one source cannot exhaust the connection pool. It defaults to `0` (disabled), preserving existing behavior. The source IP is the immediate TCP/QUIC peer, or the real client address recovered from an inbound PROXY protocol header; it is not derived from `X-Forwarded-For` / `Forwarded`, so the limit is only meaningful when rpxy is the edge or inbound PROXY protocol is enabled (behind a bare L7 load balancer every connection collapses to the balancer's IP). For HTTP/1.1 and HTTP/2 the slot is reserved before the TLS handshake so handshake floods are bounded too; for HTTP/3 it caps QUIC connections per source IP, and a single IP's concurrent HTTP/3 request streams are then bounded by `max_clients_per_ip` times `[experimental.h3] max_concurrent_bidistream`.

### Improvement

- Document that `connection_handling_timeout = 0` (the default) means no forced timeout, and recommend a non-zero value in production unless long-lived connections (e.g. WebSocket) are required.