### PR TITLE
perf(net): enable TCP_NODELAY on downstream and upstream connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - **Fix: the cache no longer truncates responses larger than `cache_max_each_size`.** With the `cache` feature enabled, a cacheable response whose body exceeded `cache_max_each_size` (default 65535 bytes) was truncated when delivered to the client, because the caching worker stopped forwarding the response body to the client as soon as the size limit was crossed. Depending on framing this surfaced either as a silently short body (chunked / unknown-length responses) or as a body/protocol error (when `Content-Length` was present). Such over-limit responses are now forwarded to the client in full and simply not cached; within-limit responses are cached as before. Relatedly, a response whose upstream body errors mid-stream now propagates that error to the client (failing as it did upstream) instead of the cache layer masking it as a clean, truncated end-of-stream.
 
+### Improvement
+
+- **Enable `TCP_NODELAY` on downstream and upstream connections.** rpxy now disables Nagle's algorithm on accepted client connections (both cleartext and TLS, set on the raw socket right after accept) and on the forwarder's upstream HTTP connector, matching common reverse-proxy practice. This avoids Nagle / delayed-ACK latency on the many small writes a proxy relays; the effect is most visible over connections with non-trivial round-trip time. Health-check probe connections and HTTP/3 (QUIC, UDP) are intentionally left unaffected.
+
 ## 0.12.0
 
 **Security-focused release with the following improvements and bugfixes.**

--- a/rpxy-lib/src/forwarder/client.rs
+++ b/rpxy-lib/src/forwarder/client.rs
@@ -136,6 +136,8 @@ Enable 'native-tls-backend' or 'rustls-backend' feature for TLS support.
     http.enforce_http(true);
     http.set_reuse_address(true);
     http.set_keepalive(Some(_globals.proxy_config.upstream_idle_timeout));
+    // Disable Nagle's algorithm: rpxy relays many small request/response writes upstream.
+    http.set_nodelay(true);
     let inner = Client::builder(executor).build::<_, B>(http);
     let inner_h2 = inner.clone();
 
@@ -172,6 +174,8 @@ where
           http.enforce_http(false);
           http.set_reuse_address(true);
           http.set_keepalive(Some(_globals.proxy_config.upstream_idle_timeout));
+          // Disable Nagle's algorithm: rpxy relays many small request/response writes upstream.
+          http.set_nodelay(true);
           hyper_tls::HttpsConnector::from((http, tls.into()))
         })
     };
@@ -222,6 +226,8 @@ where
     http.enforce_http(false);
     http.set_reuse_address(true);
     http.set_keepalive(Some(_globals.proxy_config.upstream_idle_timeout));
+    // Disable Nagle's algorithm: rpxy relays many small request/response writes upstream.
+    http.set_nodelay(true);
 
     let connector = builder.https_or_http().enable_all_versions().wrap_connector(http.clone());
     let connector_h2 = builder_h2.https_or_http().enable_http2().wrap_connector(http);

--- a/rpxy-lib/src/proxy/proxy_main.rs
+++ b/rpxy-lib/src/proxy/proxy_main.rs
@@ -31,6 +31,18 @@ use tokio_util::sync::CancellationToken;
 use crate::globals::TcpRecvProxyProtocolConfig;
 
 /* -------------------------------------------------------------------------------------------------------- */
+/// Disable Nagle's algorithm (`TCP_NODELAY`) on an accepted connection. rpxy relays many small
+/// request/response exchanges, so this avoids Nagle / delayed-ACK latency on small writes. It is
+/// applied to the raw `TcpStream` right after accept (before it is wrapped / handed to the TLS
+/// handshake), so it also covers the TLS handshake and the post-handshake data phase. Best-effort:
+/// a (rare) failure is logged at `debug!` and does not drop the connection.
+fn set_tcp_nodelay(stream: &TcpStream, peer: SocketAddr) {
+  if let Err(e) = stream.set_nodelay(true) {
+    debug!("Failed to set TCP_NODELAY for {peer}: {e}");
+  }
+}
+
+/* -------------------------------------------------------------------------------------------------------- */
 /// Wrapper function to handle request for HTTP/1.1 and HTTP/2
 /// HTTP/3 is handled in proxy_h3.rs which directly calls the message handler
 async fn serve_request<T>(
@@ -323,6 +335,7 @@ where
       #[cfg(not(feature = "proxy-protocol"))]
       while let Ok((stream, client_addr)) = tcp_listener.accept().await {
         trace!("Accepted TCP connection from {client_addr}");
+        set_tcp_nodelay(&stream, client_addr);
         let Some(per_ip_guard) = self.globals.per_ip_connection_count.try_acquire(client_addr.ip()) else {
           debug!("Per-IP connection limit reached for {client_addr}, dropping connection");
           continue;
@@ -335,6 +348,7 @@ where
         let pp_semaphore = Arc::new(tokio::sync::Semaphore::new(self.globals.proxy_config.max_clients));
         while let Ok((mut stream, client_addr)) = tcp_listener.accept().await {
           trace!("Accepted TCP connection from {client_addr}");
+          set_tcp_nodelay(&stream, client_addr);
           // [PROXY-PROTOCOL] Parse PROXY header before serving connection
           if self.globals.proxy_config.tcp_recv_proxy_protocol.is_some() {
             let permit = match pp_semaphore.clone().try_acquire_owned() {
@@ -487,6 +501,7 @@ where
     #[cfg(not(feature = "proxy-protocol"))]
     let (raw_stream, client_addr) = tcp_cnx.unwrap();
     trace!("Accepted TCP connection from {client_addr} at TLS listener");
+    set_tcp_nodelay(&raw_stream, client_addr);
 
     #[cfg(feature = "proxy-protocol")]
     let pp_config = self.globals.proxy_config.tcp_recv_proxy_protocol.clone();
@@ -609,5 +624,22 @@ where
     };
 
     proxy_service.await
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use tokio::net::TcpListener;
+
+  #[tokio::test]
+  async fn set_tcp_nodelay_enables_nodelay() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    // An accepted TcpStream defaults to nodelay = false; the helper must flip it on.
+    let _client = TcpStream::connect(addr).await.unwrap();
+    let (server, peer) = listener.accept().await.unwrap();
+    set_tcp_nodelay(&server, peer);
+    assert!(server.nodelay().unwrap(), "set_tcp_nodelay must enable TCP_NODELAY");
   }
 }


### PR DESCRIPTION
- **Enable `TCP_NODELAY` on downstream and upstream connections.** rpxy now disables Nagle's algorithm on accepted client connections (both cleartext and TLS, set on the raw socket right after accept) and on the forwarder's upstream HTTP connector, matching common reverse-proxy practice. This avoids Nagle / delayed-ACK latency on the many small writes a proxy relays; the effect is most visible over connections with non-trivial round-trip time. Health-check 