### PR TITLE
perf(log): defer access-log string construction to Display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Improvement
 
 - **Enable `TCP_NODELAY` on downstream and upstream connections.** rpxy now disables Nagle's algorithm on accepted client connections (both cleartext and TLS, set on the raw socket right after accept) and on the forwarder's upstream HTTP connector, matching common reverse-proxy practice. This avoids Nagle / delayed-ACK latency on the many small writes a proxy relays; the effect is most visible over connections with non-trivial round-trip time. Health-check probe connections and HTTP/3 (QUIC, UDP) are intentionally left unaffected.
+- **Build the access-log record lazily to cut per-request allocations.** The access-log record is now captured as cheap, reference-counted handles (request URI, method, headers) and formatted only when a log line is actually emitted, instead of eagerly building roughly eight owned strings on every request. This removes that per-request work when access logging is filtered out (for example, the stdout logger at `RUST_LOG=warn` or higher; a configured file logger always emits the access log). The emitted log line is byte-for-byte unchanged, and the query-redaction guarantee of `redact_query_in_access_log` is preserved: when redaction is enabled, query values are still masked at capture time so raw query strings are never retained in the record.
 
 ## 0.12.0
 

--- a/rpxy-lib/src/message_handler/http_log.rs
+++ b/rpxy-lib/src/message_handler/http_log.rs
@@ -42,132 +42,177 @@ fn redact_query_values(path_and_query: &str) -> Cow<'_, str> {
   Cow::Owned(out)
 }
 
-/// Struct to log HTTP messages
+/// Request URI captured for the access log.
+///
+/// `http::Uri` (and any `Scheme` / `Authority` / `PathAndQuery` extracted from it) shares the
+/// original `Bytes` buffer, so holding one keeps the raw query alive in memory. To honor the
+/// redaction guarantee, redaction-on captures only freshly-allocated query-free / redacted strings
+/// and never retains the `Uri`.
+#[derive(Debug, Clone)]
+enum LoggedUri {
+  /// Redaction disabled: keep the cheap `Uri` handle and render lazily in `Display`.
+  Verbatim(http::Uri),
+  /// Redaction enabled: query masked at capture time; no raw query bytes retained.
+  Redacted { host: String, p_and_q: String, target: String },
+}
+
+/// Upstream URI captured for the access log; same Verbatim/Redacted split as `LoggedUri`.
+#[derive(Debug, Clone)]
+enum LoggedUpstream {
+  Verbatim(http::Uri),
+  Redacted(String),
+}
+
+/// Render an upstream URI with query values masked. For the common absolute form, rebuild from the
+/// URI parts so the raw query is never copied verbatim; fall back to redacting the rendered URI for
+/// other forms. The returned `String` does not alias the source `Uri` buffer.
+fn redact_upstream(upstream: &http::Uri) -> String {
+  match (upstream.scheme_str(), upstream.authority()) {
+    (Some(scheme), Some(authority)) => {
+      let mut s = String::new();
+      s.push_str(scheme);
+      s.push_str("://");
+      s.push_str(authority.as_str());
+      if let Some(p_and_q) = upstream.path_and_query() {
+        s.push_str(&redact_query_values(p_and_q.as_str()));
+      }
+      s
+    }
+    _ => redact_query_values(&upstream.to_string()).into_owned(),
+  }
+}
+
+/// Struct to log HTTP messages.
+///
+/// Fields hold cheap-to-clone source types: `Uri` / `HeaderValue` are `Bytes`-backed (clone is a
+/// refcount bump), and `Method` is allocation-free for standard methods. String rendering is
+/// deferred to `Display`, so a request whose access-log line is never emitted pays no formatting
+/// cost. Query-bearing fields use `LoggedUri` / `LoggedUpstream` so that redaction-on never retains
+/// raw query bytes.
 #[derive(Debug, Clone)]
 pub struct HttpMessageLog {
-  // pub tls_server_name: String,
-  pub client_addr: String,
-  pub method: String,
-  pub host: String,
-  pub p_and_q: String,
-  pub version: http::Version,
-  pub scheme: String,
-  pub path: String,
-  pub ua: String,
-  pub xff: String,
-  pub forwarded: String,
-  pub status: String,
-  pub upstream: String,
-  /// When set, query-string values in `p_and_q` and `upstream` are stored already redacted.
+  client_addr: Option<SocketAddr>,
+  method: http::Method,
+  version: http::Version,
+  // `Host` header, used as a fallback when the URI carries no authority (Verbatim case only).
+  host_header: Option<header::HeaderValue>,
+  ua: Option<header::HeaderValue>,
+  xff: Option<header::HeaderValue>,
+  forwarded: Option<header::HeaderValue>,
+  status: Option<http::StatusCode>,
+  uri: LoggedUri,
+  upstream: Option<LoggedUpstream>,
+  /// Whether query-string values are masked. Set at construction; consulted by the `upstream`
+  /// setter (which runs after `new()`).
   redact_query: bool,
 }
 
 impl HttpMessageLog {
-  /// Build an access-log record from a request. When `redact_query` is set, query-string values
-  /// in `p_and_q` are masked at construction (and in `upstream` via its setter), so the struct
-  /// never retains raw query values once redaction is enabled.
+  /// Build an access-log record from a request. Source data is captured as cheap-clone handles;
+  /// formatting happens lazily in `Display`, when (and only when) the log line is emitted. With
+  /// redaction enabled, query values are masked here so no raw query bytes are retained.
   pub fn new<T>(req: &http::Request<T>, redact_query: bool) -> Self {
-    let header_mapper = |v: header::HeaderName| {
-      req
-        .headers()
-        .get(v)
-        .map_or_else(|| "", |s| s.to_str().unwrap_or(""))
-        .to_string()
-    };
-    let host = header_ops::host_from_uri_or_host_header(req.uri(), req.headers().get(header::HOST)).unwrap_or_default();
-    let p_and_q_raw = req.uri().path_and_query().map_or_else(|| "", |v| v.as_str());
-    let p_and_q = if redact_query {
-      redact_query_values(p_and_q_raw).into_owned()
+    let uri = if redact_query {
+      let host = header_ops::host_from_uri_or_host_header(req.uri(), req.headers().get(header::HOST)).unwrap_or_default();
+      let p_and_q_raw = req.uri().path_and_query().map_or("", |v| v.as_str());
+      let p_and_q = redact_query_values(p_and_q_raw).into_owned();
+      let scheme = req.uri().scheme_str().unwrap_or("");
+      let path = req.uri().path();
+      let target = if !scheme.is_empty() && !host.is_empty() {
+        format!("{scheme}://{host}{path}")
+      } else {
+        path.to_string()
+      };
+      LoggedUri::Redacted { host, p_and_q, target }
     } else {
-      p_and_q_raw.to_string()
+      LoggedUri::Verbatim(req.uri().clone())
     };
 
     Self {
-      // tls_server_name: "".to_string(),
-      client_addr: "".to_string(),
-      method: req.method().to_string(),
-      host,
-      p_and_q,
+      client_addr: None,
+      method: req.method().clone(),
       version: req.version(),
-      scheme: req.uri().scheme_str().unwrap_or("").to_string(),
-      path: req.uri().path().to_string(),
-      ua: header_mapper(header::USER_AGENT),
-      xff: header_mapper(header_ops::header_defs::X_FORWARDED_FOR),
-      forwarded: header_mapper(header::FORWARDED),
-      status: "".to_string(),
-      upstream: "".to_string(),
+      host_header: req.headers().get(header::HOST).cloned(),
+      ua: req.headers().get(header::USER_AGENT).cloned(),
+      xff: req.headers().get(header_ops::header_defs::X_FORWARDED_FOR).cloned(),
+      forwarded: req.headers().get(header::FORWARDED).cloned(),
+      status: None,
+      uri,
+      upstream: None,
       redact_query,
+    }
+  }
+
+  /// Derive `(host, path-and-query, target)` for the log line from the captured request URI.
+  /// For `Verbatim`, host falls back to the `Host` header and the values are computed on demand;
+  /// for `Redacted`, the precomputed (already-masked) strings are borrowed.
+  fn render_request_uri(&self) -> (Cow<'_, str>, Cow<'_, str>, Cow<'_, str>) {
+    match &self.uri {
+      LoggedUri::Verbatim(uri) => {
+        let host = header_ops::host_from_uri_or_host_header(uri, self.host_header.as_ref()).unwrap_or_default();
+        let p_and_q = uri.path_and_query().map_or("", |v| v.as_str());
+        let scheme = uri.scheme_str().unwrap_or("");
+        let path = uri.path();
+        let target = if !scheme.is_empty() && !host.is_empty() {
+          format!("{scheme}://{host}{path}")
+        } else {
+          path.to_string()
+        };
+        (Cow::Owned(host), Cow::Borrowed(p_and_q), Cow::Owned(target))
+      }
+      LoggedUri::Redacted { host, p_and_q, target } => (Cow::Borrowed(host), Cow::Borrowed(p_and_q), Cow::Borrowed(target)),
     }
   }
 }
 
 impl std::fmt::Display for HttpMessageLog {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-    let forwarded_part = if !self.forwarded.is_empty() {
-      format!(" \"{}\"", self.forwarded)
+    let (host, p_and_q, target) = self.render_request_uri();
+
+    let ua = self.ua.as_ref().and_then(|h| h.to_str().ok()).unwrap_or("");
+    let xff = self.xff.as_ref().and_then(|h| h.to_str().ok()).unwrap_or("");
+    let forwarded = self.forwarded.as_ref().and_then(|h| h.to_str().ok()).unwrap_or("");
+    let forwarded_part = if !forwarded.is_empty() {
+      format!(" \"{forwarded}\"")
     } else {
-      "".to_string()
+      String::new()
+    };
+
+    let client_addr = self.client_addr.map(|a| a.to_string()).unwrap_or_default();
+    let status = self.status.map(|s| s.to_string()).unwrap_or_default();
+    let upstream: Cow<'_, str> = match &self.upstream {
+      None => Cow::Borrowed(""),
+      Some(LoggedUpstream::Verbatim(u)) => Cow::Owned(u.to_string()),
+      Some(LoggedUpstream::Redacted(s)) => Cow::Borrowed(s),
     };
 
     write!(
       f,
       "{} <- {} -- {} {} {:?} -- {} -- {} \"{}\", \"{}\"{} \"{}\"",
-      self.host,
-      self.client_addr,
-      self.method,
-      self.p_and_q,
-      self.version,
-      self.status,
-      if !self.scheme.is_empty() && !self.host.is_empty() {
-        format!("{}://{}{}", self.scheme, self.host, self.path)
-      } else {
-        self.path.clone()
-      },
-      self.ua,
-      self.xff,
-      forwarded_part,
-      self.upstream
+      host, client_addr, self.method, p_and_q, self.version, status, target, ua, xff, forwarded_part, upstream
     )
   }
 }
 
 impl HttpMessageLog {
   pub fn client_addr(&mut self, client_addr: &SocketAddr) -> &mut Self {
-    self.client_addr = client_addr.to_canonical().to_string();
+    self.client_addr = Some(client_addr.to_canonical());
     self
   }
-  // pub fn tls_server_name(&mut self, tls_server_name: &str) -> &mut Self {
-  //   self.tls_server_name = tls_server_name.to_string();
-  //   self
-  // }
   pub fn status_code(&mut self, status_code: &http::StatusCode) -> &mut Self {
-    self.status = status_code.to_string();
+    self.status = Some(*status_code);
     self
   }
   pub fn xff(&mut self, xff: &Option<&header::HeaderValue>) -> &mut Self {
-    self.xff = xff.map_or_else(|| "", |v| v.to_str().unwrap_or("")).to_string();
+    self.xff = (*xff).cloned();
     self
   }
   pub fn upstream(&mut self, upstream: &http::Uri) -> &mut Self {
-    if !self.redact_query {
-      self.upstream = upstream.to_string();
-      return self;
-    }
-    // Redaction on. For the common absolute form, rebuild from the URI parts so the raw query is
-    // never copied into an owned string; fall back to redacting the rendered URI for other forms.
-    self.upstream = match (upstream.scheme_str(), upstream.authority()) {
-      (Some(scheme), Some(authority)) => {
-        let mut s = String::new();
-        s.push_str(scheme);
-        s.push_str("://");
-        s.push_str(authority.as_str());
-        if let Some(p_and_q) = upstream.path_and_query() {
-          s.push_str(&redact_query_values(p_and_q.as_str()));
-        }
-        s
-      }
-      _ => redact_query_values(&upstream.to_string()).into_owned(),
-    };
+    self.upstream = Some(if self.redact_query {
+      LoggedUpstream::Redacted(redact_upstream(upstream))
+    } else {
+      LoggedUpstream::Verbatim(upstream.clone())
+    });
     self
   }
 
@@ -182,54 +227,71 @@ impl HttpMessageLog {
 #[cfg(test)]
 mod tests {
   use super::*;
-  use http::{Method, Version};
+  use http::{HeaderValue, Method, StatusCode, Version};
+
+  // Build a log record with the same field values the two format tests share. `forwarded` and the
+  // trailing setters are left to the caller.
+  fn sample_log() -> HttpMessageLog {
+    HttpMessageLog {
+      client_addr: Some("192.168.1.1:8080".parse().unwrap()),
+      method: Method::GET,
+      version: Version::HTTP_11,
+      host_header: None,
+      ua: Some(HeaderValue::from_static("Mozilla/5.0")),
+      xff: Some(HeaderValue::from_static("10.0.0.1")),
+      forwarded: None,
+      status: Some(StatusCode::OK),
+      uri: LoggedUri::Verbatim("https://example.com/path?query=value".parse().unwrap()),
+      // Production upstreams always carry a path; the explicit path also avoids `Uri::to_string`
+      // normalizing an authority-only URI to a trailing "/".
+      upstream: Some(LoggedUpstream::Verbatim("https://backend.example.com/api".parse().unwrap())),
+      redact_query: false,
+    }
+  }
 
   #[test]
   fn test_log_format_without_forwarded() {
-    let log = HttpMessageLog {
-      client_addr: "192.168.1.1:8080".to_string(),
-      method: Method::GET.to_string(),
-      host: "example.com".to_string(),
-      p_and_q: "/path?query=value".to_string(),
-      version: Version::HTTP_11,
-      scheme: "https".to_string(),
-      path: "/path".to_string(),
-      ua: "Mozilla/5.0".to_string(),
-      xff: "10.0.0.1".to_string(),
-      forwarded: "".to_string(),
-      status: "200".to_string(),
-      upstream: "https://backend.example.com".to_string(),
-      redact_query: false,
-    };
+    let log = sample_log();
 
     let formatted = format!("{}", log);
     assert!(!formatted.contains(" \"\""));
-    assert!(formatted.contains("\"Mozilla/5.0\", \"10.0.0.1\" \"https://backend.example.com\""));
+    assert!(formatted.contains("\"Mozilla/5.0\", \"10.0.0.1\" \"https://backend.example.com/api\""));
   }
 
   #[test]
   fn test_log_format_with_forwarded() {
     let log = HttpMessageLog {
-      client_addr: "192.168.1.1:8080".to_string(),
-      method: Method::GET.to_string(),
-      host: "example.com".to_string(),
-      p_and_q: "/path?query=value".to_string(),
-      version: Version::HTTP_11,
-      scheme: "https".to_string(),
-      path: "/path".to_string(),
-      ua: "Mozilla/5.0".to_string(),
-      xff: "10.0.0.1".to_string(),
-      forwarded: "for=192.0.2.60;proto=http;by=203.0.113.43".to_string(),
-      status: "200".to_string(),
-      upstream: "https://backend.example.com".to_string(),
-      redact_query: false,
+      forwarded: Some(HeaderValue::from_static("for=192.0.2.60;proto=http;by=203.0.113.43")),
+      ..sample_log()
     };
 
     let formatted = format!("{}", log);
     assert!(formatted.contains(" \"for=192.0.2.60;proto=http;by=203.0.113.43\""));
-    assert!(
-      formatted
-        .contains("\"Mozilla/5.0\", \"10.0.0.1\" \"for=192.0.2.60;proto=http;by=203.0.113.43\" \"https://backend.example.com\"")
+    assert!(formatted.contains(
+      "\"Mozilla/5.0\", \"10.0.0.1\" \"for=192.0.2.60;proto=http;by=203.0.113.43\" \"https://backend.example.com/api\""
+    ));
+  }
+
+  // Pin the entire access-log line, built through the production path (`new()` + setters), so the
+  // byte-exact format - including the `status` segment, which renders via `StatusCode::Display`
+  // (e.g. "200 OK") - is guarded against future drift.
+  #[test]
+  fn full_line_equivalence_via_new_and_setters() {
+    let req = http::Request::builder()
+      .method(Method::GET)
+      .uri("https://example.com/path?query=value")
+      .header(http::header::USER_AGENT, "Mozilla/5.0")
+      .body(())
+      .unwrap();
+    let mut log = HttpMessageLog::new(&req, false);
+    log.client_addr(&"192.168.1.1:8080".parse().unwrap());
+    log.xff(&Some(&HeaderValue::from_static("10.0.0.1")));
+    log.upstream(&"https://backend.example.com/path?query=value".parse().unwrap());
+    log.status_code(&StatusCode::OK);
+
+    assert_eq!(
+      format!("{log}"),
+      "example.com <- 192.168.1.1:8080 -- GET /path?query=value HTTP/1.1 -- 200 OK -- https://example.com/path \"Mozilla/5.0\", \"10.0.0.1\" \"https://backend.example.com/path?query=value\""
     );
   }
 
@@ -279,8 +341,11 @@ mod tests {
       .body(())
       .unwrap();
     let log = HttpMessageLog::new(&req, true);
-    assert_eq!(log.p_and_q, "/reset?token=<redacted>&email=<redacted>");
     let formatted = format!("{log}");
+    assert!(
+      formatted.contains("/reset?token=<redacted>&email=<redacted>"),
+      "redacted path-and-query missing: {formatted}"
+    );
     assert!(!formatted.contains("abc123"), "token value leaked: {formatted}");
     assert!(!formatted.contains("a@b.com"), "email value leaked: {formatted}");
   }
@@ -292,7 +357,7 @@ mod tests {
       .body(())
       .unwrap();
     let log = HttpMessageLog::new(&req, false);
-    assert_eq!(log.p_and_q, "/reset?token=abc123");
+    assert!(format!("{log}").contains("/reset?token=abc123"));
   }
 
   #[test]
@@ -300,7 +365,12 @@ mod tests {
     let req = http::Request::builder().uri("https://example.com/p").body(()).unwrap();
     let mut log = HttpMessageLog::new(&req, true);
     log.upstream(&"https://backend.local/api?key=s3cret".parse::<http::Uri>().unwrap());
-    assert_eq!(log.upstream, "https://backend.local/api?key=<redacted>");
+    let formatted = format!("{log}");
+    assert!(
+      formatted.contains("https://backend.local/api?key=<redacted>"),
+      "redacted upstream missing: {formatted}"
+    );
+    assert!(!formatted.contains("s3cret"), "upstream query value leaked: {formatted}");
   }
 
   #[test]
@@ -308,7 +378,7 @@ mod tests {
     let req = http::Request::builder().uri("https://example.com/p").body(()).unwrap();
     let mut log = HttpMessageLog::new(&req, false);
     log.upstream(&"https://backend.local/api?key=s3cret".parse::<http::Uri>().unwrap());
-    assert_eq!(log.upstream, "https://backend.local/api?key=s3cret");
+    assert!(format!("{log}").contains("https://backend.local/api?key=s3cret"));
   }
 
   #[test]
@@ -317,6 +387,6 @@ mod tests {
     let req = http::Request::builder().uri("https://example.com/p").body(()).unwrap();
     let mut log = HttpMessageLog::new(&req, true);
     log.upstream(&"https://backend.local/api".parse::<http::Uri>().unwrap());
-    assert_eq!(log.upstream, "https://backend.local/api");
+    assert!(format!("{log}").contains("https://backend.local/api"));
   }
 }


### PR DESCRIPTION
- **Build the access-log record lazily to cut per-request allocations.** The access-log record is now captured as cheap, reference-counted handles (request URI, method, headers) and formatted only when a log line is actually emitted, instead of eagerly building roughly eight owned strings on every request. This removes that per-request work when access logging is filtered out (for example, the stdout logger at `RUST_LOG=warn` or higher; a configured file logger always emits the access log). The emitted log line is byte-for-byte unchanged, and the query-redaction guarantee of `redact_query_in_access_log` is preserved: when redaction is enabled, query values are still masked at capture time so raw query strings are never retained in the record.