### PR TITLE
perf(forwarding): cut per-request allocations in forwarding-header path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.12.2 or 0.13.0 (Unreleased)
 
+### Improvement
+
+- **Reduce per-request allocations in the forwarding-header path.** Building the outgoing `X-Forwarded-*` / `Proxy` headers no longer re-validates or re-allocates values that are already known: the constant headers (`X-Forwarded-Proto`, `X-Forwarded-Ssl`, `Proxy`) are written via `HeaderValue::from_static`, `X-Forwarded-Port` via `HeaderValue::from(u16)`, and `X-Real-IP` reuses the IP string already computed for `X-Forwarded-For` and is handed to `HeaderValue` without an extra copy. The immediate-peer forwarding entry is also no longer built twice per request, and request host parsing no longer constructs an error value on the success path. The forwarding/trust-boundary logic and every emitted header value are byte-for-byte unchanged. This trims roughly ten heap allocations per request on the common path; it is a CPU/allocation cleanup, not a measured throughput change (no throughput difference was observed on a loopback benchmark).
+
 ### Internal
 
 - **Add an off-by-default `dhat-heap` feature for developer heap profiling.** Building `rpxy` with `--features dhat-heap` swaps the global allocator for the [dhat](https://crates.io/crates/dhat) heap profiler and writes a `dhat-heap.json` (viewable with `dhat/dh_view.html`) on a Ctrl-C graceful shutdown, so per-request allocation call-sites can be measured before micro-optimizing the request hot path. The feature is off by default and not built into release binaries: normal builds keep mimalloc (and the system allocator on illumos) and are unchanged in both behavior and dependencies. This is a development aid only; it is not a runtime or configuration change.

--- a/rpxy-lib/src/message_handler/header_ops/forwarding.rs
+++ b/rpxy-lib/src/message_handler/header_ops/forwarding.rs
@@ -90,25 +90,29 @@ pub(in crate::message_handler) fn add_forwarding_header(
   let peer_ip = canonicalize_ip(client_addr.to_canonical().ip());
   let has_forwarded = headers.contains_key(header::FORWARDED);
   let normalized_chain = normalize_forwarding_chain(headers, &peer_ip, tls, original_uri, trusted_forwarded_proxies);
-  let peer_entry = build_peer_forwarded_entry(headers, peer_ip, tls, original_uri);
 
   let (normalized_chain, normalized_for_ip_chain) = match forwarded_chain_to_xff(&normalized_chain) {
     Some(ip_chain) => (normalized_chain, ip_chain),
     None => {
       warn!("Normalized forwarding chain contains non-IP hops; falling back to peer-only forwarding view");
-      (vec![peer_entry.clone()], vec![peer_ip.to_string()])
+      // Only this rare fallback needs a freshly built peer entry, so build it here instead
+      // of eagerly on every request.
+      let peer_entry = build_peer_forwarded_entry(headers, peer_ip, tls, original_uri);
+      (vec![peer_entry], vec![peer_ip.to_string()])
     }
   };
 
-  // For X-Real-IP
-  let authoritative_client_ip = normalized_chain
-    .first()
-    .and_then(|entry| entry.for_node.ip_addr())
-    .map(|ip| ip.to_string())
-    .unwrap_or_else(|| peer_ip.to_string());
-
   // Update X-Forwarded-For with normalized chain
   overwrite_header_with_csv(headers, X_FORWARDED_FOR, &normalized_for_ip_chain)?;
+
+  // For X-Real-IP: reuse the IP string already formatted as the first element of the XFF
+  // chain (moved out by value, no clone or re-format). The chain is non-empty in both
+  // branches above, so the fallback to peer_ip only guards an impossible empty case and
+  // keeps the result byte-identical to formatting normalized_chain.first()'s IP directly.
+  let authoritative_client_ip = normalized_for_ip_chain
+    .into_iter()
+    .next()
+    .unwrap_or_else(|| peer_ip.to_string());
 
   // Preserve/update Forwarded only if it was present on input. If callers want to force
   // Forwarded generation, apply_upstream_options_to_header() will regenerate it later.
@@ -126,20 +130,26 @@ pub(in crate::message_handler) fn add_forwarding_header(
   make_cookie_single_line(headers)?;
 
   // Always overwrite these headers with rpxy's authoritative downstream view.
-  add_header_entry_overwrite_if_exist(headers, X_FORWARDED_PROTO, if tls { "https" } else { "http" })?;
-  add_header_entry_overwrite_if_exist(headers, X_FORWARDED_PORT, listen_addr.port().to_string())?;
+  // Constant values use HeaderValue::from_static (no runtime byte validation or allocation);
+  // the port uses HeaderValue::from(u16) (lighter than to_string() + parse). insert() replaces
+  // any existing values with a single value, matching add_header_entry_overwrite_if_exist.
+  headers.insert(
+    X_FORWARDED_PROTO,
+    HeaderValue::from_static(if tls { "https" } else { "http" }),
+  );
+  headers.insert(X_FORWARDED_PORT, HeaderValue::from(listen_addr.port()));
 
   /////////// As Nginx-Proxy
-  // x-real-ip
-  add_header_entry_overwrite_if_exist(headers, X_REAL_IP, authoritative_client_ip)?;
+  // x-real-ip: hand the owned String to HeaderValue without re-copying its bytes.
+  headers.insert(X_REAL_IP, HeaderValue::try_from(authoritative_client_ip)?);
   // x-forwarded-ssl
-  add_header_entry_overwrite_if_exist(headers, X_FORWARDED_SSL, if tls { "on" } else { "off" })?;
+  headers.insert(X_FORWARDED_SSL, HeaderValue::from_static(if tls { "on" } else { "off" }));
   // x-original-uri
   add_header_entry_overwrite_if_exist(headers, X_ORIGINAL_URI, original_uri.to_string())?;
   // x-forwarded-host
   overwrite_x_forwarded_host_from_original(headers, original_uri)?;
   // proxy
-  add_header_entry_overwrite_if_exist(headers, PROXY, "")?;
+  headers.insert(PROXY, HeaderValue::from_static(""));
 
   Ok(())
 }
@@ -1245,6 +1255,50 @@ mod tests {
       generate_forwarded_header(&chain).unwrap(),
       "for=192.0.2.1;proto=https;host=\"example.com:8443\""
     );
+  }
+
+  #[test]
+  fn constant_overwrite_headers_are_byte_identical_non_tls() {
+    // Guards the HeaderValue::from_static / from(u16) overwrites against accidental drift:
+    // the constant downstream-view headers must keep their exact byte values.
+    let mut headers = HeaderMap::new();
+    headers.insert(header::HOST, HeaderValue::from_static("app.example"));
+
+    add_forwarding_header(
+      &mut headers,
+      &"203.0.113.10:4321".parse().unwrap(),
+      &"192.0.2.1:8080".parse().unwrap(),
+      false,
+      &Uri::from_static("/"),
+      &[],
+    )
+    .unwrap();
+
+    assert_eq!(headers.get(X_FORWARDED_PROTO).unwrap(), "http");
+    assert_eq!(headers.get(X_FORWARDED_PORT).unwrap(), "8080");
+    assert_eq!(headers.get(X_FORWARDED_SSL).unwrap(), "off");
+    assert_eq!(headers.get(PROXY).unwrap(), "");
+  }
+
+  #[test]
+  fn constant_overwrite_headers_are_byte_identical_tls() {
+    let mut headers = HeaderMap::new();
+    headers.insert(header::HOST, HeaderValue::from_static("app.example"));
+
+    add_forwarding_header(
+      &mut headers,
+      &"203.0.113.10:4321".parse().unwrap(),
+      &"192.0.2.1:8443".parse().unwrap(),
+      true,
+      &Uri::from_static("/"),
+      &[],
+    )
+    .unwrap();
+
+    assert_eq!(headers.get(X_FORWARDED_PROTO).unwrap(), "https");
+    assert_eq!(headers.get(X_FORWARDED_PORT).unwrap(), "8443");
+    assert_eq!(headers.get(X_FORWARDED_SSL).unwrap(), "on");
+    assert_eq!(headers.get(PROXY).unwrap(), "");
   }
 
   /* ---------------------- client_visible_secure ---------------------- */

--- a/rpxy-lib/src/message_handler/request_ops.rs
+++ b/rpxy-lib/src/message_handler/request_ops.rs
@@ -19,8 +19,11 @@ impl<B> InspectParseHost for Request<B> {
       if v.starts_with(b"[") {
         // v6 address with bracket case. if port is specified, always it is in this case.
         let mut iter = v.split(|ptr| ptr == &b'[' || ptr == &b']');
-        iter.next().ok_or(anyhow!("Invalid Host header"))?; // first item is always blank
-        iter.next().ok_or(anyhow!("Invalid Host header")).map(|b| b.to_owned())
+        iter.next().ok_or_else(|| anyhow!("Invalid Host header"))?; // first item is always blank
+        iter
+          .next()
+          .ok_or_else(|| anyhow!("Invalid Host header"))
+          .map(|b| b.to_owned())
       } else if v.len() - v.split(|v| v == &b':').fold(0, |acc, s| acc + s.len()) >= 2 {
         // v6 address case, if 2 or more ':' is contained
         Ok(v.to_owned())
@@ -28,7 +31,7 @@ impl<B> InspectParseHost for Request<B> {
         // v4 address or hostname
         v.split(|colon| colon == &b':')
           .next()
-          .ok_or(anyhow!("Invalid Host header"))
+          .ok_or_else(|| anyhow!("Invalid Host header"))
           .map(|v| v.to_ascii_lowercase())
       }
     };


### PR DESCRIPTION
- **Reduce per-request allocations in the forwarding-header path.** Building the outgoing `X-Forwarded-*` / `Proxy` headers no longer re-validates or re-allocates values that are already known: the constant headers (`X-Forwarded-Proto`, `X-Forwarded-Ssl`, `Proxy`) are written via `HeaderValue::from_static`, `X-Forwarded-Port` via `HeaderValue::from(u16)`, and `X-Real-IP` reuses the IP string already computed for `X-Forwarded-For` and is handed to `HeaderValue` without an extra copy. The immediate-peer forwarding entry is also no longer built twice per request, and request host parsing no longer constructs an error value on the success path. The forwarding/trust-boundary logic and every emitted header value are byte-for-byte unchanged. This trims roughly ten heap allocations per request on the common path; it is a CPU/allocation cleanup, not a measured throughput change (no throughput difference was observed on a loopback benchmark).