### PR TITLE
perf(routing): avoid per-request allocations in path match and URI rebuild

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Improvement
 
 - **Reduce per-request allocations in the forwarding-header path.** Building the outgoing `X-Forwarded-*` / `Proxy` headers no longer re-validates or re-allocates values that are already known: the constant headers (`X-Forwarded-Proto`, `X-Forwarded-Ssl`, `Proxy`) are written via `HeaderValue::from_static`, `X-Forwarded-Port` via `HeaderValue::from(u16)`, and `X-Real-IP` reuses the IP string already computed for `X-Forwarded-For` and is handed to `HeaderValue` without an extra copy. The immediate-peer forwarding entry is also no longer built twice per request, and request host parsing no longer constructs an error value on the success path. The forwarding/trust-boundary logic and every emitted header value are byte-for-byte unchanged. This trims roughly ten heap allocations per request on the common path; it is a CPU/allocation cleanup, not a measured throughput change (no throughput difference was observed on a loopback benchmark).
+- **Reduce per-request allocations in path routing and request-URI rebuilding.** Longest-prefix route matching now compares the request path bytes directly instead of allocating a `PathName` per request, and rebuilding the outgoing request URI now reuses the original path-and-query via a shallow clone (instead of copying it into a `Vec` and re-validating it) when no `replace_path` is configured. Routing decisions and the rewritten URI are byte-for-byte unchanged. Like the forwarding-header change above, this is a CPU/allocation cleanup rather than a measured throughput change.
 
 ### Internal
 

--- a/rpxy-lib/src/backend/upstream.rs
+++ b/rpxy-lib/src/backend/upstream.rs
@@ -93,21 +93,26 @@ impl PathManager {
   /// trie使ってlongest prefix match させてもいいけどルート記述は少ないと思われるので、
   /// コスト的にこの程度で十分では。
   pub fn get<'a>(&self, path_str: impl Into<Cow<'a, str>>) -> Option<&UpstreamCandidates> {
-    let path_name = &path_str.to_path_name();
+    // Match directly on the request path bytes. `to_path_name()`/`PathName::from(&str)` does not
+    // lowercase (paths are case-sensitive), so `path_str.as_bytes()` is exactly the bytes that
+    // matching used before, just without allocating a `PathName` per request.
+    let path_str = path_str.into();
+    let path_bytes = path_str.as_bytes();
 
     let matched_upstream = self
       .inner
       .iter()
-      .filter(|(route_bytes, _)| {
-        path_name.starts_with(route_bytes) && {
+      .filter(|(route, _)| {
+        let route_bytes: &[u8] = route.as_ref();
+        path_bytes.starts_with(route_bytes) && {
           route_bytes.len() == 1 // route = '/', i.e., default
-            || path_name.get(route_bytes.len()).map_or(
+            || path_bytes.get(route_bytes.len()).map_or(
               true, // exact case
               |p| p == &b'/'
             ) // sub-path case
         }
       })
-      .max_by_key(|(route_bytes, _)| route_bytes.len());
+      .max_by_key(|(route, _)| route.len());
     matched_upstream.map(|(path, u)| {
       trace!(
         "Found upstream: {:?}",
@@ -295,6 +300,43 @@ impl UpstreamCandidates {
 mod test {
   #[allow(unused)]
   use super::*;
+
+  #[test]
+  fn path_manager_get_matches_longest_prefix_and_path_boundary() {
+    use crate::globals::{AppConfig, ReverseProxyConfig, UpstreamUri};
+
+    fn rp(path: Option<&str>) -> ReverseProxyConfig {
+      ReverseProxyConfig {
+        path: path.map(str::to_string),
+        replace_path: None,
+        upstream: vec![UpstreamUri {
+          inner: "http://127.0.0.1:8080".parse().unwrap(),
+        }],
+        upstream_options: None,
+        load_balance: None,
+        #[cfg(feature = "health-check")]
+        health_check: None,
+      }
+    }
+
+    let cfg = AppConfig {
+      app_name: "test".to_string(),
+      server_name: "example.com".to_string(),
+      reverse_proxy: vec![rp(None), rp(Some("/foo"))], // None => default "/"
+      tls: None,
+    };
+    let pm = PathManager::try_from(&cfg).unwrap();
+
+    // exact match on /foo
+    assert_eq!(pm.get("/foo").unwrap().path, "/foo".to_path_name());
+    // sub-path under /foo matches /foo (the boundary after the prefix is '/')
+    assert_eq!(pm.get("/foo/bar").unwrap().path, "/foo".to_path_name());
+    // /foobar must NOT be matched by /foo (boundary is not '/'); falls back to default "/"
+    assert_eq!(pm.get("/foobar").unwrap().path, "/".to_path_name());
+    // default route
+    assert_eq!(pm.get("/").unwrap().path, "/".to_path_name());
+    assert_eq!(pm.get("/other").unwrap().path, "/".to_path_name());
+  }
 
   #[cfg(feature = "sticky-cookie")]
   #[test]

--- a/rpxy-lib/src/message_handler/handler_manipulate_messages.rs
+++ b/rpxy-lib/src/message_handler/handler_manipulate_messages.rs
@@ -3,10 +3,10 @@ use crate::{
   backend::{BackendApp, UpstreamCandidates},
   constants::RESPONSE_HEADER_SERVER,
   log::*,
-  name_exp::ServerName,
+  name_exp::{PathName, ServerName},
 };
 use anyhow::{Result, anyhow, ensure};
-use http::{HeaderValue, Request, Response, Uri, header};
+use http::{HeaderValue, Request, Response, Uri, header, uri::PathAndQuery};
 use hyper_util::client::legacy::connect::Connect;
 use std::net::SocketAddr;
 
@@ -190,23 +190,13 @@ where
     let new_uri = Uri::builder()
       .scheme(upstream_chosen.uri.scheme().unwrap().as_str())
       .authority(upstream_chosen.uri.authority().unwrap().as_str());
-    let org_pq = req.uri().path_and_query().map(|pq| pq.as_str()).unwrap_or("/").as_bytes();
 
-    // replace some parts of path if opt_replace_path is enabled for chosen upstream
-    let new_pq = match &upstream_candidates.replace_path {
-      Some(new_path) => {
-        let matched_path: &[u8] = upstream_candidates.path.as_ref();
-        ensure!(
-          !matched_path.is_empty() && org_pq.len() >= matched_path.len(),
-          "Upstream uri `path and query` is broken"
-        );
-        let mut new_pq = Vec::<u8>::with_capacity(org_pq.len() - matched_path.len() + new_path.len());
-        new_pq.extend_from_slice(new_path.as_ref());
-        new_pq.extend_from_slice(&org_pq[matched_path.len()..]);
-        new_pq
-      }
-      None => org_pq.to_vec(),
-    };
+    // Build the upstream path+query (applying replace_path if configured for this group).
+    let new_pq = rebuild_path_and_query(
+      req.uri(),
+      upstream_candidates.replace_path.as_ref(),
+      &upstream_candidates.path,
+    )?;
     *req.uri_mut() = new_uri.path_and_query(new_pq).build()?;
 
     // upgrade
@@ -222,5 +212,67 @@ where
     }
 
     Ok(context)
+  }
+}
+
+/// Build the path-and-query for the outgoing upstream request.
+///
+/// Without `replace_path`, the original request path+query is reused as-is via a shallow
+/// `PathAndQuery` clone (no byte copy or re-validation), falling back to `/` when the request
+/// carries none. With `replace_path`, the matched route prefix is swapped for the replacement
+/// path while preserving the remainder (and any query string).
+fn rebuild_path_and_query(req_uri: &Uri, replace_path: Option<&PathName>, matched_path: &PathName) -> Result<PathAndQuery> {
+  let Some(new_path) = replace_path else {
+    return Ok(
+      req_uri
+        .path_and_query()
+        .cloned()
+        .unwrap_or_else(|| PathAndQuery::from_static("/")),
+    );
+  };
+
+  let org_pq = req_uri.path_and_query().map(|pq| pq.as_str()).unwrap_or("/").as_bytes();
+  let matched: &[u8] = matched_path.as_ref();
+  ensure!(
+    !matched.is_empty() && org_pq.len() >= matched.len(),
+    "Upstream uri `path and query` is broken"
+  );
+  let mut v = Vec::<u8>::with_capacity(org_pq.len() - matched.len() + new_path.len());
+  v.extend_from_slice(new_path.as_ref());
+  v.extend_from_slice(&org_pq[matched.len()..]);
+  // Wrap InvalidUri in http::Error so the error type matches the previous
+  // `.path_and_query(Vec).build()?` path exactly.
+  let pq = PathAndQuery::try_from(v).map_err(http::Error::from)?;
+  Ok(pq)
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::name_exp::ByteName;
+
+  #[test]
+  fn rebuild_path_and_query_none_preserves_path_and_query() {
+    let uri = Uri::from_static("http://example.com/a/b?x=1&y=2");
+    let matched = "/".to_path_name();
+    let pq = rebuild_path_and_query(&uri, None, &matched).unwrap();
+    assert_eq!(pq.as_str(), "/a/b?x=1&y=2");
+  }
+
+  #[test]
+  fn rebuild_path_and_query_none_defaults_to_root_when_absent() {
+    let uri = Uri::from_static("http://example.com");
+    let matched = "/".to_path_name();
+    let pq = rebuild_path_and_query(&uri, None, &matched).unwrap();
+    assert_eq!(pq.as_str(), "/");
+  }
+
+  #[test]
+  fn rebuild_path_and_query_replaces_matched_prefix_keeping_query() {
+    let uri = Uri::from_static("http://example.com/foo/bar?q=1");
+    let matched = "/foo".to_path_name();
+    let replace = "/new".to_path_name();
+    let pq = rebuild_path_and_query(&uri, Some(&replace), &matched).unwrap();
+    assert_eq!(pq.as_str(), "/new/bar?q=1");
   }
 }


### PR DESCRIPTION
- **Reduce per-request allocations in path routing and request-URI rebuilding.** Longest-prefix route matching now compares the request path bytes directly instead of allocating a `PathName` per request, and rebuilding the outgoing request URI now reuses the original path-and-query via a shallow clone (instead of copying it into a `Vec` and re-validating it) when no `replace_path` is configured. Routing decisions and the rewritten URI are byte-for-byte unchanged. Like the forwarding-header change above, this is a CPU/allocation cleanup rather than a measured throughput change.