### PR TITLE
fix(alt-svc)!: advertise HTTP/3 on secure responses, decoupled from redirect config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,14 @@
 # CHANGELOG
 
-## 0.12.2 or 0.13.0 (Unreleased)
+## 0.13.0 (Unreleased)
+
+### Important Changes
+
+- **Breaking: rename `https_redirection_port` to `public_https_port`.** The option now represents the client-visible HTTPS/H3 port used by both HTTP->HTTPS redirects and HTTP/3 `Alt-Svc` advertisement. Existing configs using `https_redirection_port` must be updated. If clients already reach the same port as `listen_port_tls`, this option is still unnecessary.
 
 ### Improvement
 
+- **Fix HTTP/3 `Alt-Svc` advertisement for HTTPS-only deployments.** rpxy now advertises HTTP/3 on secure non-mTLS responses when HTTP/3 is enabled, independent of per-app HTTP redirect settings. Plain HTTP responses and mTLS apps do not advertise HTTP/3.
 - **Reduce per-request allocations in the forwarding-header path.** Building the outgoing `X-Forwarded-*` / `Proxy` headers no longer re-validates or re-allocates values that are already known: the constant headers (`X-Forwarded-Proto`, `X-Forwarded-Ssl`, `Proxy`) are written via `HeaderValue::from_static`, `X-Forwarded-Port` via `HeaderValue::from(u16)`, and `X-Real-IP` reuses the IP string already computed for `X-Forwarded-For` and is handed to `HeaderValue` without an extra copy. The immediate-peer forwarding entry is also no longer built twice per request, and request host parsing no longer constructs an error value on the success path. The forwarding/trust-boundary logic and every emitted header value are byte-for-byte unchanged. This trims roughly ten heap allocations per request on the common path; it is a CPU/allocation cleanup, not a measured throughput change (no throughput difference was observed on a loopback benchmark).
 - **Reduce per-request allocations in path routing and request-URI rebuilding.** Longest-prefix route matching now compares the request path bytes directly instead of allocating a `PathName` per request, and rebuilding the outgoing request URI now reuses the original path-and-query via a shallow clone (instead of copying it into a `Vec` and re-validating it) when no `replace_path` is configured. Routing decisions and the rewritten URI are byte-for-byte unchanged. Like the forwarding-header change above, this is a CPU/allocation cleanup rather than a measured throughput change.
 - **Avoid cloning the whole request header map on the sticky-cookie path (`sticky-cookie` feature).** When a request reaches a sticky-session (`StickyRoundRobin`) upstream group, extracting the sticky cookie no longer clones the entire `HeaderMap`; it reads the `Cookie` header(s) directly and only re-materializes the cookie tokens. Which cookie is consumed versus forwarded upstream, the recovered backend id, and all reject/ignore paths are unchanged. CPU/allocation cleanup only.

--- a/config-example.toml
+++ b/config-example.toml
@@ -32,10 +32,10 @@ listen_port_tls = 8443
 # [default: false]
 listen_ipv6 = false
 
-# Optional. If you listen on a custom port like 8443 but redirect with firewall to 443
-# When you specify this, the server uses this port in an "Alt-SVC" header for e.g. indicating support for HTTP/3 and also sends a redirection response 301 with specified port to the client for plaintext http request
-# Otherwise, the server sends Alt-SVC and 301 with the same port as `listen_port_tls`.
-# https_redirection_port = 443
+# Optional. Client-visible HTTPS/H3 port when it differs from `listen_port_tls`
+# (for example, when running behind a load balancer, firewall, or container port mapping).
+# Used for HTTP->HTTPS redirects and HTTP/3 Alt-Svc. Usually unnecessary if clients use `listen_port_tls`.
+# public_https_port = 443
 
 # Optional for h2 and http1.1
 tcp_listen_backlog = 1024

--- a/rpxy-bin/src/config/toml.rs
+++ b/rpxy-bin/src/config/toml.rs
@@ -129,7 +129,7 @@ impl ConfigTomlExt for ConfigToml {
       // This includes a case that plaintext HTTP listener is not enabled.
       ensure!(
         proxy_config.https_port.is_some(),
-        "public_https_port must be some only when https_port is specified"
+        "`public_https_port` can only be set when the TLS listener `listen_port_tls` is configured"
       );
     }
     if !(proxy_config.https_port.is_some() && proxy_config.http_port.is_some()) {
@@ -342,7 +342,7 @@ impl TryInto<ProxyConfig> for &ConfigToml {
     if self.public_https_port.is_some() {
       ensure!(
         proxy_config.https_port.is_some(),
-        "public_https_port can be explicitly specified only when https_port is specified"
+        "`public_https_port` can only be set when the TLS listener `listen_port_tls` is configured"
       );
     }
 

--- a/rpxy-bin/src/config/toml.rs
+++ b/rpxy-bin/src/config/toml.rs
@@ -61,7 +61,7 @@ impl OneOrMany {
 /// - `listen_address_v4`: Optional IPv4 address(es) to bind (default: 0.0.0.0). Accepts a single string or an array.
 /// - `listen_address_v6`: Optional IPv6 address(es) to bind (default: ::). Accepts a single string or an array.
 /// - `listen_ipv6`: Enable IPv6 listening. If listen_address_v6 is not specified, binds to '::' when true, and disables IPv6 when false (default: false).
-/// - `https_redirection_port`: Optional port for HTTP to HTTPS redirection.
+/// - `public_https_port`: Optional client-visible HTTPS/H3 port used for redirects and Alt-Svc.
 /// - `tcp_listen_backlog`: Optional TCP backlog size.
 /// - `max_concurrent_streams`: Optional max concurrent streams.
 /// - `max_clients`: Optional max client connections.
@@ -77,6 +77,9 @@ pub struct ConfigToml {
   pub listen_address_v4: Option<OneOrMany>,
   pub listen_address_v6: Option<OneOrMany>,
   pub listen_ipv6: Option<bool>,
+  pub public_https_port: Option<u16>,
+  /// Removed in 0.13. Keep this tombstone so old configs fail with a clear error
+  /// instead of being accepted as an ignored unknown field.
   pub https_redirection_port: Option<u16>,
   pub tcp_listen_backlog: Option<u32>,
   pub max_concurrent_streams: Option<u32>,
@@ -121,12 +124,12 @@ impl ConfigTomlExt for ConfigToml {
     if proxy_config.http_port.is_none() {
       ensure!(all_apps_have_tls, "Some apps serve only plaintext HTTP");
     }
-    if proxy_config.https_redirection_port.is_some() {
-      // When https_redirection_port is specified, at least TLS is enabled globally.
+    if proxy_config.public_https_port.is_some() {
+      // When public_https_port is specified or derived, at least TLS is enabled globally.
       // This includes a case that plaintext HTTP listener is not enabled.
       ensure!(
         proxy_config.https_port.is_some(),
-        "https_redirection_port must be some only when https_port is specified"
+        "public_https_port must be some only when https_port is specified"
       );
     }
     if !(proxy_config.https_port.is_some() && proxy_config.http_port.is_some()) {
@@ -314,15 +317,16 @@ impl TryInto<ProxyConfig> for &ConfigToml {
   type Error = anyhow::Error;
 
   fn try_into(self) -> std::result::Result<ProxyConfig, Self::Error> {
+    ensure!(
+      self.https_redirection_port.is_none(),
+      "`https_redirection_port` was renamed to `public_https_port` in 0.13; update your config"
+    );
+
     let mut proxy_config = ProxyConfig {
       // listen port and socket
       http_port: self.listen_port,
       https_port: self.listen_port_tls,
-      https_redirection_port: if self.https_redirection_port.is_some() {
-        self.https_redirection_port
-      } else {
-        self.listen_port_tls
-      },
+      public_https_port: self.public_https_port.or(self.listen_port_tls),
       ..Default::default()
     };
     ensure!(
@@ -335,10 +339,10 @@ impl TryInto<ProxyConfig> for &ConfigToml {
         anyhow!("http_port and https_port must be different")
       );
     }
-    if self.https_redirection_port.is_some() {
+    if self.public_https_port.is_some() {
       ensure!(
-        proxy_config.https_port.is_some() && proxy_config.http_port.is_some(),
-        "https_redirection_port can be explicitly specified only when both http_port and https_port are specified"
+        proxy_config.https_port.is_some(),
+        "public_https_port can be explicitly specified only when https_port is specified"
       );
     }
 
@@ -1036,6 +1040,53 @@ mod tests {
     let config: ConfigToml = toml::from_str(toml_str).unwrap();
     let proxy_config: ProxyConfig = (&config).try_into().unwrap();
     assert_eq!(proxy_config.max_clients_per_ip, 16);
+  }
+
+  #[test]
+  fn public_https_port_defaults_to_listen_port_tls() {
+    let toml_str = r#"
+      listen_port_tls = 2443
+    "#;
+    let config: ConfigToml = toml::from_str(toml_str).unwrap();
+    let proxy_config: ProxyConfig = (&config).try_into().unwrap();
+    assert_eq!(proxy_config.public_https_port, Some(2443));
+  }
+
+  #[test]
+  fn public_https_port_accepts_https_only_without_listen_port() {
+    let toml_str = r#"
+      listen_port_tls = 2443
+      public_https_port = 443
+    "#;
+    let config: ConfigToml = toml::from_str(toml_str).unwrap();
+    let proxy_config: ProxyConfig = (&config).try_into().unwrap();
+    assert_eq!(proxy_config.http_port, None);
+    assert_eq!(proxy_config.https_port, Some(2443));
+    assert_eq!(proxy_config.public_https_port, Some(443));
+  }
+
+  #[test]
+  fn public_https_port_requires_https_port() {
+    let toml_str = r#"
+      listen_port = 8080
+      public_https_port = 443
+    "#;
+    let config: ConfigToml = toml::from_str(toml_str).unwrap();
+    let result: Result<ProxyConfig, _> = (&config).try_into();
+    assert!(result.is_err());
+    assert!(result.err().unwrap().to_string().contains("public_https_port"));
+  }
+
+  #[test]
+  fn old_https_redirection_port_is_rejected() {
+    let toml_str = r#"
+      listen_port_tls = 2443
+      https_redirection_port = 443
+    "#;
+    let config: ConfigToml = toml::from_str(toml_str).unwrap();
+    let result: Result<ProxyConfig, _> = (&config).try_into();
+    assert!(result.is_err());
+    assert!(result.err().unwrap().to_string().contains("public_https_port"));
   }
 
   #[test]

--- a/rpxy-lib/src/globals.rs
+++ b/rpxy-lib/src/globals.rs
@@ -55,10 +55,11 @@ pub struct ProxyConfig {
   pub http_port: Option<u16>,
   /// https port listening for TLS by default
   pub https_port: Option<u16>,
-  /// https redirection port that notifies the client the port to connect to.
-  /// This is used when the reverse proxy is behind a middlebox mapping the https port A to the reverse proxy's https port B.
-  /// Typically, it is the container environment. (e.g. the host exposes 443 and the container exposes 8443 for https, then the redirection port is 443)
-  pub https_redirection_port: Option<u16>,
+  /// Client-visible HTTPS/H3 port advertised to downstream clients.
+  /// This is used when the reverse proxy is behind a middlebox mapping the client-visible HTTPS port A
+  /// to the reverse proxy's local HTTPS port B. Typically, it is the container environment.
+  /// (e.g. the host exposes 443 and the container exposes 8443 for HTTPS, then this port is 443)
+  pub public_https_port: Option<u16>,
   /// tcp listen backlog
   pub tcp_listen_backlog: u32,
 
@@ -126,7 +127,7 @@ impl Default for ProxyConfig {
       listen_sockets: Vec::new(),
       http_port: None,
       https_port: None,
-      https_redirection_port: None,
+      public_https_port: None,
       tcp_listen_backlog: TCP_LISTEN_BACKLOG,
 
       // TODO: Reconsider each timeout values

--- a/rpxy-lib/src/message_handler/handler_main.rs
+++ b/rpxy-lib/src/message_handler/handler_main.rs
@@ -135,11 +135,7 @@ where
         "Redirect to secure connection: {}",
         <&ServerName as TryInto<String>>::try_into(&backend_app.server_name).unwrap_or_default()
       );
-      return secure_redirection_response(
-        &backend_app.server_name,
-        self.globals.proxy_config.https_redirection_port,
-        &req,
-      );
+      return secure_redirection_response(&backend_app.server_name, self.globals.proxy_config.public_https_port, &req);
     }
 
     // Find reverse proxy for given path and choose one of upstream host
@@ -223,7 +219,7 @@ where
     if res_backend.status() != StatusCode::SWITCHING_PROTOCOLS {
       // Generate response to client
       self
-        .generate_response_forwarded(&mut res_backend, backend_app)
+        .generate_response_forwarded(&mut res_backend, backend_app, tls_enabled)
         .map_err(|e| HttpError::FailedToGenerateDownstreamResponse(e.to_string()))?;
       return Ok(res_backend);
     }

--- a/rpxy-lib/src/message_handler/handler_manipulate_messages.rs
+++ b/rpxy-lib/src/message_handler/handler_manipulate_messages.rs
@@ -20,7 +20,12 @@ where
 
   #[allow(unused_variables)]
   /// Manipulate a response message sent from a backend application to forward downstream to a client.
-  pub(super) fn generate_response_forwarded<B>(&self, response: &mut Response<B>, backend_app: &BackendApp) -> Result<()> {
+  pub(super) fn generate_response_forwarded<B>(
+    &self,
+    response: &mut Response<B>,
+    backend_app: &BackendApp,
+    is_secure_transport: bool,
+  ) -> Result<()> {
     let headers = response.headers_mut();
     remove_connection_header(headers);
     remove_hop_header(headers);
@@ -30,17 +35,12 @@ where
     {
       // Manipulate ALT_SVC allowing h3 in response message only when mutual TLS is not enabled
       // TODO: This is a workaround for avoiding a client authentication in HTTP/3
-      if self.globals.proxy_config.http3
-        && backend_app.https_redirection.is_some()
-        && backend_app.mutual_tls.as_ref().is_some_and(|v| !v)
-      {
-        if let Some(port) = self.globals.proxy_config.https_redirection_port {
-          add_header_entry_overwrite_if_exist(
-            headers,
-            header::ALT_SVC,
-            format!("h3=\":{}\"; ma={}", port, self.globals.proxy_config.h3_alt_svc_max_age),
-          )?;
-        }
+      if let Some(port) = h3_alt_svc_port(&self.globals.proxy_config, backend_app.mutual_tls, is_secure_transport) {
+        add_header_entry_overwrite_if_exist(
+          headers,
+          header::ALT_SVC,
+          format!("h3=\":{}\"; ma={}", port, self.globals.proxy_config.h3_alt_svc_max_age),
+        )?;
       } else {
         // remove alt-svc to disallow requests via http3
         headers.remove(header::ALT_SVC);
@@ -215,6 +215,19 @@ where
   }
 }
 
+#[cfg(any(feature = "http3-quinn", feature = "http3-s2n"))]
+fn h3_alt_svc_port(
+  proxy_config: &crate::globals::ProxyConfig,
+  backend_mutual_tls: Option<bool>,
+  is_secure_transport: bool,
+) -> Option<u16> {
+  if proxy_config.http3 && is_secure_transport && backend_mutual_tls == Some(false) {
+    proxy_config.public_https_port
+  } else {
+    None
+  }
+}
+
 /// Build the path-and-query for the outgoing upstream request.
 ///
 /// Without `replace_path`, the original request path+query is reused as-is via a shallow
@@ -250,6 +263,47 @@ fn rebuild_path_and_query(req_uri: &Uri, replace_path: Option<&PathName>, matche
 mod tests {
   use super::*;
   use crate::name_exp::ByteName;
+
+  #[cfg(any(feature = "http3-quinn", feature = "http3-s2n"))]
+  fn proxy_config_for_h3_alt_svc(http3: bool, public_https_port: Option<u16>) -> crate::globals::ProxyConfig {
+    crate::globals::ProxyConfig {
+      http3,
+      public_https_port,
+      ..Default::default()
+    }
+  }
+
+  #[cfg(any(feature = "http3-quinn", feature = "http3-s2n"))]
+  #[test]
+  fn h3_alt_svc_port_advertises_on_secure_non_mtls_transport() {
+    let proxy_config = proxy_config_for_h3_alt_svc(true, Some(443));
+    assert_eq!(h3_alt_svc_port(&proxy_config, Some(false), true), Some(443));
+  }
+
+  #[cfg(any(feature = "http3-quinn", feature = "http3-s2n"))]
+  #[test]
+  fn h3_alt_svc_port_does_not_advertise_on_plain_http() {
+    let proxy_config = proxy_config_for_h3_alt_svc(true, Some(443));
+    assert_eq!(h3_alt_svc_port(&proxy_config, Some(false), false), None);
+  }
+
+  #[cfg(any(feature = "http3-quinn", feature = "http3-s2n"))]
+  #[test]
+  fn h3_alt_svc_port_does_not_advertise_for_mtls_or_plaintext_app() {
+    let proxy_config = proxy_config_for_h3_alt_svc(true, Some(443));
+    assert_eq!(h3_alt_svc_port(&proxy_config, Some(true), true), None);
+    assert_eq!(h3_alt_svc_port(&proxy_config, None, true), None);
+  }
+
+  #[cfg(any(feature = "http3-quinn", feature = "http3-s2n"))]
+  #[test]
+  fn h3_alt_svc_port_requires_h3_enabled_and_public_port() {
+    let h3_disabled = proxy_config_for_h3_alt_svc(false, Some(443));
+    assert_eq!(h3_alt_svc_port(&h3_disabled, Some(false), true), None);
+
+    let no_public_port = proxy_config_for_h3_alt_svc(true, None);
+    assert_eq!(h3_alt_svc_port(&no_public_port, Some(false), true), None);
+  }
 
   #[test]
   fn rebuild_path_and_query_none_preserves_path_and_query() {


### PR DESCRIPTION
- **Breaking: rename `https_redirection_port` to `public_https_port`.** The option now represents the client-visible HTTPS/H3 port used by both HTTP->HTTPS redirects and HTTP/3 `Alt-Svc` advertisement. Existing configs using `https_redirection_port` must be updated. If clients already reach the same port as `listen_port_tls`, this option is still unnecessary.