### PR TITLE
fix(message_handler): enforce request body size limit on h1/h2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## 0.13.2 or 0.14.0 (Unreleased)
 
+### Important Changes
+
+- **HTTP/1.1 and HTTP/2 now have a 256 MiB default request body cap.** Previously HTTP/1.1 and HTTP/2 had no body size limit. Operators handling >256 MiB uploads via HTTP/1.1 or HTTP/2 must explicitly set `request_max_body_size` to a larger value in the top-level config (effectively-unlimited deployments set a deliberately large value within TOML's signed-64-bit integer range, e.g. `9000000000000` for ~9 TB). The HTTP/3 default is unchanged. The previous `experimental.h3.request_max_body_size` key continues to work as a deprecated HTTP/3-specific override and emits a startup warning; it will be removed in 0.14.0.
+
+### Bugfix
+
+- **Fix: enforce a request body size limit on HTTP/1.1 and HTTP/2.** Previously rpxy enforced `request_max_body_size` only on HTTP/3; a client could stream arbitrarily many request body bytes via HTTP/1.1 or HTTP/2 with no proxy-side bound, allowing a denial-of-service via unbounded request bodies. The same limit (default 256 MiB, matching the previous HTTP/3-only default) now applies to all three protocols, configurable via a new top-level `request_max_body_size` TOML key. Oversize requests with a known `Content-Length` are rejected up front with `413 Payload Too Large` before any upstream contact (HTTP/1.x responses include `Connection: close` so the unread body bytes are not fed into a recycled connection; HTTP/2 and HTTP/3 close the affected stream in-band); oversize chunked / streamed bodies are detected mid-flight by a per-request body adapter which emits one `error!` log line of the form "Request body exceeded limit: received N bytes, maximum allowed M" and surfaces to the client as an upstream-forwarder error (typically 502) or a connection drop, with the log line identifying the cause. HTTP/3's pre-existing streaming-overrun behaviour is preserved; HTTP/3 also newly gets the CL-known 413 pre-flight by routing through the unified handler entry. The internal representation moved from `usize` to `Option<usize>` (`None` = unlimited; `Some(0)` preserves the previous HTTP/3 "reject any non-empty body" semantics).
+
 ## 0.13.1
 
 ### Bugfix

--- a/README.md
+++ b/README.md
@@ -348,18 +348,23 @@ The [`./bench`](./bench/) directory contains a very simple example of `rpxy` con
 ```toml
 [experimental.h3]
 alt_svc_max_age = 3600
-# Limits the total HTTP/3 request body size per request stream.
-# If omitted, the default is 268435456 bytes (256 MiB).
-request_max_body_size = 65536
 max_concurrent_connections = 10000
 max_concurrent_bidistream = 100
 max_concurrent_unistream = 100
 max_idle_timeout = 10
 ```
 
-`request_max_body_size` limits the total HTTP/3 request body size per request stream.
-The body is processed as a stream; this setting is not a preallocated memory buffer size.
-Set this explicitly to a smaller value in production when large uploads are not required.
+The request body size limit is no longer HTTP/3-specific. Configure it via the **top-level** `request_max_body_size` key, which applies uniformly to HTTP/1.1, HTTP/2, and HTTP/3:
+
+```toml
+# Top-level (applies to h1/h2/h3 alike).
+# Default: 268435456 bytes (256 MiB).
+request_max_body_size = 65536
+```
+
+The body is processed as a stream; this setting is not a preallocated memory buffer size. Requests whose `Content-Length` exceeds the limit are rejected up front with `413 Payload Too Large` before any upstream contact; chunked / streamed bodies are detected mid-flight and the stream/connection is reset. Set this explicitly to a smaller value in production when large uploads are not required. For effectively-unlimited deployments, set a deliberately large value within TOML's signed-64-bit integer range (e.g. `9000000000000` for ~9 TB); there is no special "0 = unlimited" sentinel — `0` means "reject any non-empty body".
+
+The previous HTTP/3-only `experimental.h3.request_max_body_size` key continues to work as a deprecated override for the HTTP/3 path only and emits a startup warning. It will be removed in 0.14.0; migrate to the top-level key.
 
 ### Client Authentication via Client Certificates
 

--- a/config-example.toml
+++ b/config-example.toml
@@ -75,6 +75,15 @@ max_clients = 512
 # query strings.
 # redact_query_in_access_log = true
 
+# Optional. Maximum inbound request body size in bytes. Applies uniformly to HTTP/1.1, HTTP/2,
+# and HTTP/3. Default: 268435456 (256 MiB). Requests whose Content-Length exceeds this limit
+# are rejected up front with `413 Payload Too Large` before any upstream contact; chunked /
+# streamed bodies are detected mid-flight and the stream/connection is reset. Set lower when
+# large uploads are not required. For effectively-unlimited deployments, set a deliberately
+# large value within TOML's signed-64-bit integer range (e.g. 9000000000000 for ~9 TB);
+# there is no special "0 = unlimited" sentinel (0 means "reject any non-empty body").
+# request_max_body_size = 65536 # bytes
+
 # Optional. Required when any reverse_proxy entry uses load_balance = "sticky".
 # Value must be a 32-byte secret encoded as unpadded base64url.
 # Generate with: openssl rand -base64 32 | tr '+/' '-_' | tr -d '=\n'
@@ -196,9 +205,10 @@ connection_handling_timeout = 0 # sec
 # If this specified, h3 is enabled
 [experimental.h3]
 alt_svc_max_age = 3600             # sec
-# Limits the total HTTP/3 request body size per request stream.
-# Default: 268435456 bytes (256 MiB). Set lower when large uploads are not required.
-request_max_body_size = 65536      # bytes
+# DEPRECATED in 0.13.2; will be removed in 0.14.0. Use the top-level `request_max_body_size`
+# instead (which now applies to h1/h2/h3 alike). When this key is set it overrides the
+# top-level value for the HTTP/3 path only, and rpxy emits a startup warning.
+# request_max_body_size = 65536    # bytes
 max_concurrent_connections = 10000
 max_concurrent_bidistream = 100
 max_concurrent_unistream = 100

--- a/rpxy-bin/src/config/toml.rs
+++ b/rpxy-bin/src/config/toml.rs
@@ -68,7 +68,7 @@ impl OneOrMany {
 /// - `max_clients_per_ip`: Optional max concurrent connections per source IP (0 disables it).
 /// - `trusted_forwarded_proxies`: Optional CIDR(s) or built-in alias names whose incoming forwarding headers are trusted.
 /// - `redact_query_in_access_log`: Optional. Redact query-string values in the access log (default: false).
-/// - `request_max_body_size`: Optional maximum inbound request body size in bytes; applied to h1/h2/h3 alike. Defaults to 256 MiB. Effectively-unlimited deployments use a deliberately large value (e.g. `usize::MAX`).
+/// - `request_max_body_size`: Optional maximum inbound request body size in bytes; applied to h1/h2/h3 alike. Defaults to 256 MiB. Effectively-unlimited deployments use a deliberately large value within TOML's signed 64-bit integer range (e.g. `9000000000000` for ~9 TB).
 /// - `apps`: Optional application definitions.
 /// - `default_app`: Optional default application name.
 /// - `experimental`: Optional experimental features.
@@ -1462,9 +1462,13 @@ mod tests {
     "#;
     let config: ConfigToml = toml::from_str(toml_str).unwrap();
     let proxy_config: ProxyConfig = (&config).try_into().unwrap();
-    // Default is 256 MiB matching DEFAULTS::REQUEST_MAX_BODY_SIZE; verify the order of
-    // magnitude rather than hard-coding 268_435_456 here (the constant lives in rpxy-lib).
-    assert_eq!(proxy_config.request_max_body_size, Some(268_435_456));
+    // Default is 256 MiB matching DEFAULTS::REQUEST_MAX_BODY_SIZE; assert against
+    // ProxyConfig::default() so the test does not have to be updated if the constant
+    // (which lives in rpxy-lib) changes.
+    assert_eq!(
+      proxy_config.request_max_body_size,
+      ProxyConfig::default().request_max_body_size
+    );
   }
 
   /// The deprecated `experimental.h3.request_max_body_size` continues to populate the h3

--- a/rpxy-bin/src/config/toml.rs
+++ b/rpxy-bin/src/config/toml.rs
@@ -68,6 +68,7 @@ impl OneOrMany {
 /// - `max_clients_per_ip`: Optional max concurrent connections per source IP (0 disables it).
 /// - `trusted_forwarded_proxies`: Optional CIDR(s) or built-in alias names whose incoming forwarding headers are trusted.
 /// - `redact_query_in_access_log`: Optional. Redact query-string values in the access log (default: false).
+/// - `request_max_body_size`: Optional maximum inbound request body size in bytes; applied to h1/h2/h3 alike. Defaults to 256 MiB. Effectively-unlimited deployments use a deliberately large value (e.g. `usize::MAX`).
 /// - `apps`: Optional application definitions.
 /// - `default_app`: Optional default application name.
 /// - `experimental`: Optional experimental features.
@@ -89,6 +90,11 @@ pub struct ConfigToml {
   pub sticky_cookie_secret: Option<String>,
   pub trusted_forwarded_proxies: Option<OneOrMany>,
   pub redact_query_in_access_log: Option<bool>,
+  /// Maximum inbound request body size in bytes (applies to h1/h2/h3 alike). When unset
+  /// the loader substitutes the default (`DEFAULTS::REQUEST_MAX_BODY_SIZE`, 256 MiB).
+  /// `experimental.h3.request_max_body_size` continues to function as a deprecated
+  /// h3-only override; it will be removed in 0.14.0.
+  pub request_max_body_size: Option<usize>,
   pub apps: Option<Apps>,
   pub default_app: Option<String>,
   pub experimental: Option<Experimental>,
@@ -378,6 +384,12 @@ impl TryInto<ProxyConfig> for &ConfigToml {
       proxy_config.redact_query_in_access_log = redact;
     }
 
+    // Inbound request body size limit (h1/h2/h3 uniform; unset retains the default
+    // applied in `ProxyConfig::default`).
+    if let Some(n) = self.request_max_body_size {
+      proxy_config.request_max_body_size = Some(n);
+    }
+
     // experimental
     if let Some(exp) = &self.experimental {
       #[cfg(any(feature = "http3-quinn", feature = "http3-s2n"))]
@@ -388,7 +400,12 @@ impl TryInto<ProxyConfig> for &ConfigToml {
             proxy_config.h3_alt_svc_max_age = x;
           }
           if let Some(x) = h3option.request_max_body_size {
-            proxy_config.h3_request_max_body_size = x;
+            warn!(
+              "`experimental.h3.request_max_body_size` is deprecated and will be removed in 0.14.0; \
+               use the top-level `request_max_body_size` instead. \
+               The h3 path will use the deprecated value until then."
+            );
+            proxy_config.h3_request_max_body_size = Some(x);
           }
           if let Some(x) = h3option.max_concurrent_connections {
             proxy_config.h3_max_concurrent_connections = x;
@@ -1393,14 +1410,7 @@ mod tests {
 
   #[test]
   fn validate_server_name_rejects_invalid_label_syntax() {
-    for name in [
-      "",
-      ".example.com",
-      "example.com.",
-      "a..b.com",
-      "-bad.example",
-      "bad-.example",
-    ] {
+    for name in ["", ".example.com", "example.com.", "a..b.com", "-bad.example", "bad-.example"] {
       assert!(validate_server_name(name).is_err(), "expected reject: {name:?}");
     }
     // over-long label (64 chars) and over-long name (>253 chars)
@@ -1413,7 +1423,7 @@ mod tests {
   #[test]
   fn validate_server_name_rejects_wildcard_underscore_ipv6_idn() {
     for name in [
-      "*.example.com",     // wildcard: unsupported
+      "*.example.com",      // wildcard: unsupported
       "_dmarc.example.com", // underscore: not a valid TLS SNI hostname
       "::1",                // IPv6 literal
       "2001:db8::1",        // IPv6 literal
@@ -1429,6 +1439,55 @@ mod tests {
     assert!(
       err.to_string().contains("Invalid server_name"),
       "error must be the validation error: {err}"
+    );
+  }
+
+  /// Top-level `request_max_body_size` flows into `ProxyConfig.request_max_body_size`.
+  #[test]
+  fn request_max_body_size_top_level_populates_proxy_config() {
+    let toml_str = r#"
+      listen_port = 8080
+      request_max_body_size = 100000
+    "#;
+    let config: ConfigToml = toml::from_str(toml_str).unwrap();
+    let proxy_config: ProxyConfig = (&config).try_into().unwrap();
+    assert_eq!(proxy_config.request_max_body_size, Some(100_000));
+  }
+
+  /// Unset top-level key falls back to the default (256 MiB applied by `ProxyConfig::default()`).
+  #[test]
+  fn request_max_body_size_default_when_unset() {
+    let toml_str = r#"
+      listen_port = 8080
+    "#;
+    let config: ConfigToml = toml::from_str(toml_str).unwrap();
+    let proxy_config: ProxyConfig = (&config).try_into().unwrap();
+    // Default is 256 MiB matching DEFAULTS::REQUEST_MAX_BODY_SIZE; verify the order of
+    // magnitude rather than hard-coding 268_435_456 here (the constant lives in rpxy-lib).
+    assert_eq!(proxy_config.request_max_body_size, Some(268_435_456));
+  }
+
+  /// The deprecated `experimental.h3.request_max_body_size` continues to populate the h3
+  /// override and takes precedence on the h3 path. (Both fields are `Option<usize>`;
+  /// h3-side enforcement uses `h3.or(global)`.)
+  #[cfg(any(feature = "http3-quinn", feature = "http3-s2n"))]
+  #[test]
+  fn request_max_body_size_h3_override_populates_h3_field_and_takes_precedence() {
+    let toml_str = r#"
+      listen_port = 8080
+      request_max_body_size = 100000
+      [experimental.h3]
+      request_max_body_size = 65536
+    "#;
+    let config: ConfigToml = toml::from_str(toml_str).unwrap();
+    let proxy_config: ProxyConfig = (&config).try_into().unwrap();
+    // Top-level still wins for h1/h2.
+    assert_eq!(proxy_config.request_max_body_size, Some(100_000));
+    // H3 override populated; combined via `h3.or(global)` it wins on the h3 path.
+    assert_eq!(proxy_config.h3_request_max_body_size, Some(65_536));
+    assert_eq!(
+      proxy_config.h3_request_max_body_size.or(proxy_config.request_max_body_size),
+      Some(65_536)
     );
   }
 }

--- a/rpxy-lib/src/constants.rs
+++ b/rpxy-lib/src/constants.rs
@@ -7,11 +7,21 @@ pub const MAX_CLIENTS: usize = 512;
 pub const MAX_CLIENTS_PER_IP: usize = 0; // 0 disables the per-IP connection limit
 pub const MAX_CONCURRENT_STREAMS: u32 = 64;
 
+/// Protocol-agnostic defaults that apply to h1/h2/h3 alike.
+#[allow(non_snake_case)]
+pub mod DEFAULTS {
+  /// Default `request_max_body_size` applied to every protocol when unconfigured. 256 MiB.
+  /// Conservative bound that closes the unbounded-body DoS hole on h1/h2 while matching the
+  /// historical h3-only default so existing h3 deployments see no change. Operators with
+  /// larger uploads override via the top-level `request_max_body_size` TOML key; an
+  /// effectively-unlimited deployment uses a deliberately large value (e.g. `usize::MAX`).
+  pub const REQUEST_MAX_BODY_SIZE: usize = 268_435_456;
+}
+
 #[allow(non_snake_case)]
 #[cfg(any(feature = "http3-quinn", feature = "http3-s2n"))]
 pub mod H3 {
   pub const ALT_SVC_MAX_AGE: u32 = 3600;
-  pub const REQUEST_MAX_BODY_SIZE: usize = 268_435_456; // 256MB
   pub const MAX_CONCURRENT_CONNECTIONS: u32 = 4096;
   pub const MAX_CONCURRENT_BIDISTREAM: u32 = 64;
   pub const MAX_CONCURRENT_UNISTREAM: u32 = 64;

--- a/rpxy-lib/src/constants.rs
+++ b/rpxy-lib/src/constants.rs
@@ -14,7 +14,8 @@ pub mod DEFAULTS {
   /// Conservative bound that closes the unbounded-body DoS hole on h1/h2 while matching the
   /// historical h3-only default so existing h3 deployments see no change. Operators with
   /// larger uploads override via the top-level `request_max_body_size` TOML key; an
-  /// effectively-unlimited deployment uses a deliberately large value (e.g. `usize::MAX`).
+  /// effectively-unlimited deployment uses a deliberately large value within TOML's signed
+  /// 64-bit integer range (e.g. `9000000000000` for ~9 TB).
   pub const REQUEST_MAX_BODY_SIZE: usize = 268_435_456;
 }
 

--- a/rpxy-lib/src/error.rs
+++ b/rpxy-lib/src/error.rs
@@ -50,6 +50,8 @@ pub enum RpxyError {
   #[cfg(any(feature = "http3-quinn", feature = "http3-s2n"))]
   #[error("Exceeds max request body size for HTTP/3")]
   H3TooLargeBody,
+  #[error("Request body exceeded limit: received {received} bytes, maximum allowed {limit}")]
+  RequestBodyTooLarge { received: usize, limit: usize },
 
   #[cfg(feature = "http3-quinn")]
   #[error("Invalid rustls TLS version: {0}")]

--- a/rpxy-lib/src/globals.rs
+++ b/rpxy-lib/src/globals.rs
@@ -96,6 +96,13 @@ pub struct ProxyConfig {
   /// timeout to handle a connection, total time of receive request, serve, and send response. this might limits the max length of response.
   pub connection_handling_timeout: Option<Duration>,
 
+  /// Maximum allowed inbound request body size in bytes.
+  /// `None` means unlimited; `Some(n)` enforces an `n`-byte upper bound (including
+  /// `Some(0)`, which rejects any non-empty body). Applies to h1/h2 and serves as the
+  /// fallback for h3 when `h3_request_max_body_size` is `None`.
+  /// Default after config load is `Some(DEFAULTS::REQUEST_MAX_BODY_SIZE)`.
+  pub request_max_body_size: Option<usize>,
+
   #[cfg(feature = "cache")]
   pub cache_enabled: bool,
   #[cfg(feature = "cache")]
@@ -112,8 +119,13 @@ pub struct ProxyConfig {
   pub http3: bool,
   #[cfg(any(feature = "http3-quinn", feature = "http3-s2n"))]
   pub h3_alt_svc_max_age: u32,
+  /// HTTP/3-specific override for `request_max_body_size`.
+  /// `None` (the default after config load) inherits the top-level
+  /// `request_max_body_size`; `Some(n)` overrides on the h3 path only. Populated from the
+  /// deprecated `experimental.h3.request_max_body_size` TOML key during the 0.13.x
+  /// deprecation window; removed in 0.14.0.
   #[cfg(any(feature = "http3-quinn", feature = "http3-s2n"))]
-  pub h3_request_max_body_size: usize,
+  pub h3_request_max_body_size: Option<usize>,
   #[cfg(any(feature = "http3-quinn", feature = "http3-s2n"))]
   pub h3_max_concurrent_bidistream: u32,
   #[cfg(any(feature = "http3-quinn", feature = "http3-s2n"))]
@@ -147,6 +159,7 @@ impl Default for ProxyConfig {
       sni_consistency: true,
       trusted_forwarded_proxies: Vec::new(),
       connection_handling_timeout: None,
+      request_max_body_size: Some(DEFAULTS::REQUEST_MAX_BODY_SIZE),
 
       #[cfg(feature = "proxy-protocol")]
       tcp_recv_proxy_protocol: None,
@@ -167,7 +180,7 @@ impl Default for ProxyConfig {
       #[cfg(any(feature = "http3-quinn", feature = "http3-s2n"))]
       h3_alt_svc_max_age: H3::ALT_SVC_MAX_AGE,
       #[cfg(any(feature = "http3-quinn", feature = "http3-s2n"))]
-      h3_request_max_body_size: H3::REQUEST_MAX_BODY_SIZE,
+      h3_request_max_body_size: None,
       #[cfg(any(feature = "http3-quinn", feature = "http3-s2n"))]
       h3_max_concurrent_connections: H3::MAX_CONCURRENT_CONNECTIONS,
       #[cfg(any(feature = "http3-quinn", feature = "http3-s2n"))]

--- a/rpxy-lib/src/hyper_ext/body_type.rs
+++ b/rpxy-lib/src/hyper_ext/body_type.rs
@@ -1,9 +1,12 @@
 use super::body::IncomingLike;
-use crate::error::RpxyError;
+use crate::{error::RpxyError, log::*};
 use futures::channel::mpsc::Receiver;
 use http_body_util::{BodyExt, Empty, Full, StreamBody, combinators};
 use hyper::body::{Body, Bytes, Frame, Incoming};
-use std::pin::Pin;
+use std::{
+  pin::Pin,
+  task::{Context, Poll},
+};
 
 /// Type for synthetic boxed body
 pub type BoxBody = combinators::BoxBody<Bytes, hyper::Error>;
@@ -18,13 +21,111 @@ pub(crate) fn full(body: Bytes) -> BoxBody {
   Full::new(body).map_err(|never| match never {}).boxed()
 }
 
+/* ------------------------------------ */
+/// Generic length-limited body wrapper. Counts the data bytes seen via `poll_frame` and
+/// returns `RpxyError::RequestBodyTooLarge` (with a single `error!` log line) when the
+/// running total crosses the configured limit.
+///
+/// After overrun the wrapper enters a tripped state: subsequent polls do **not** drain
+/// the inner body further and the error is returned exactly once, with `Poll::Ready(None)`
+/// signalling end-of-stream thereafter. This guarantees that trailer-bearing or
+/// non-data frames from the inner body cannot slip through after the limit is exceeded.
+///
+/// `limit = None` means unlimited and the wrapper short-circuits per `poll_frame` without
+/// updating the counter, so unconfigured deployments pay no per-frame cost. The wrapper is
+/// generic so it can be instantiated over `Full<Bytes>` or `StreamBody<_>` for unit tests
+/// without needing to construct a real `hyper::body::Incoming`.
+pub struct LimitedBody<B> {
+  inner: B,
+  limit: Option<usize>,
+  received: usize,
+  /// Overrun latch. `false` (initial) = forward inner frames normally. `true` = overrun
+  /// has occurred and the `RequestBodyTooLarge` error has been surfaced once in the
+  /// poll that crossed the limit; subsequent polls return `Poll::Ready(None)` instead
+  /// of draining the inner body further (so trailers / non-data frames cannot slip
+  /// through after the limit is exceeded).
+  tripped: bool,
+}
+
+impl<B> LimitedBody<B> {
+  pub fn new(inner: B, limit: Option<usize>) -> Self {
+    Self {
+      inner,
+      limit,
+      received: 0,
+      tripped: false,
+    }
+  }
+}
+
+impl<B> Body for LimitedBody<B>
+where
+  B: Body<Data = bytes::Bytes> + Unpin,
+  B::Error: Into<RpxyError>,
+{
+  type Data = bytes::Bytes;
+  type Error = RpxyError;
+
+  fn poll_frame(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
+    let this = self.get_mut();
+    // Tripped latch: the error has already been surfaced once; subsequent polls return
+    // end-of-stream without ever polling the inner body again, so pending trailers /
+    // non-data frames cannot slip through after the limit is exceeded.
+    if this.tripped {
+      return Poll::Ready(None);
+    }
+    let Some(limit) = this.limit else {
+      // Unlimited fast path: no counting, just forward.
+      return Pin::new(&mut this.inner).poll_frame(cx).map_err(Into::into);
+    };
+    match Pin::new(&mut this.inner).poll_frame(cx) {
+      Poll::Pending => Poll::Pending,
+      Poll::Ready(None) => Poll::Ready(None),
+      Poll::Ready(Some(Err(e))) => Poll::Ready(Some(Err(e.into()))),
+      Poll::Ready(Some(Ok(frame))) => {
+        if let Some(data) = frame.data_ref() {
+          this.received = this.received.saturating_add(data.len());
+          if this.received > limit {
+            error!(
+              "Request body exceeded limit: received {} bytes, maximum allowed {}",
+              this.received, limit
+            );
+            // Surface the error in this poll; the latch makes subsequent polls
+            // signal end-of-stream so no further frames (trailers etc.) leak out.
+            this.tripped = true;
+            return Poll::Ready(Some(Err(RpxyError::RequestBodyTooLarge {
+              received: this.received,
+              limit,
+            })));
+          }
+        }
+        Poll::Ready(Some(Ok(frame)))
+      }
+    }
+  }
+
+  fn is_end_stream(&self) -> bool {
+    self.tripped || self.inner.is_end_stream()
+  }
+
+  fn size_hint(&self) -> hyper::body::SizeHint {
+    self.inner.size_hint()
+  }
+}
+
+/// Concrete request-body wrapper used by the h1/h2 listener.
+pub type LimitedIncoming = LimitedBody<Incoming>;
+
 #[allow(unused)]
 /* ------------------------------------ */
 /// Request body used in this project
-/// - Incoming: just a type that only forwards the downstream request body to upstream.
-/// - IncomingLike: a Incoming-like type in which channel is used
+/// - Incoming: client-facing inbound body (h1/h2). Wrapped in `LimitedIncoming` so the
+///   configured `request_max_body_size` is enforced as the body streams; an
+///   `Option<usize>` limit of `None` disables the check.
+/// - IncomingLike: a Incoming-like type in which channel is used (h3 path; the h3 body
+///   forwarder enforces the limit before the channel is fed)
 pub enum RequestBody {
-  Incoming(Incoming),
+  Incoming(LimitedIncoming),
   IncomingLike(IncomingLike),
 }
 
@@ -37,7 +138,7 @@ impl Body for RequestBody {
     cx: &mut std::task::Context<'_>,
   ) -> std::task::Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
     match self.get_mut() {
-      RequestBody::Incoming(incoming) => Pin::new(incoming).poll_frame(cx).map_err(RpxyError::HyperBodyError),
+      RequestBody::Incoming(limited) => Pin::new(limited).poll_frame(cx),
       RequestBody::IncomingLike(incoming_like) => Pin::new(incoming_like).poll_frame(cx),
     }
   }
@@ -74,5 +175,117 @@ impl Body for ResponseBody {
       ResponseBody::Streamed(streamed) => Pin::new(streamed).poll_frame(cx),
     }
     .map_err(RpxyError::HyperBodyError)
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use http_body_util::{BodyExt, Full};
+
+  /// Generic-over-Body test path. `LimitedBody<Full<Bytes>>` lets us hit the wrapper
+  /// without constructing a `hyper::body::Incoming` (which has no public constructor).
+  /// Production type `LimitedIncoming = LimitedBody<Incoming>` shares this exact code.
+
+  /// Under-limit body passes through; counters do not raise an error.
+  #[tokio::test]
+  async fn limited_body_under_limit_passes_through() {
+    let inner = Full::new(Bytes::from_static(b"hello world"));
+    let limited = LimitedBody::new(inner, Some(64));
+    let collected = limited.collect().await.unwrap().to_bytes();
+    assert_eq!(collected.as_ref(), b"hello world");
+  }
+
+  /// Equal-to-limit boundary: 11 bytes with limit 11 passes (the check is strict `>`).
+  #[tokio::test]
+  async fn limited_body_equal_to_limit_passes() {
+    let inner = Full::new(Bytes::from_static(b"hello world"));
+    let limited = LimitedBody::new(inner, Some(11));
+    let collected = limited.collect().await.unwrap().to_bytes();
+    assert_eq!(collected.len(), 11);
+  }
+
+  /// Strictly over the limit yields `RpxyError::RequestBodyTooLarge` with the running
+  /// received count and the configured limit reported.
+  #[tokio::test]
+  async fn limited_body_over_limit_errors_with_counts() {
+    let inner = Full::new(Bytes::from_static(b"hello world"));
+    let limited = LimitedBody::new(inner, Some(5));
+    let err = limited.collect().await.unwrap_err();
+    match err {
+      RpxyError::RequestBodyTooLarge { received, limit } => {
+        assert_eq!(limit, 5);
+        assert!(received > 5, "received={received} should exceed limit=5");
+      }
+      other => panic!("expected RequestBodyTooLarge, got {other:?}"),
+    }
+  }
+
+  /// `None` limit short-circuits the count and never errors, even for a body larger
+  /// than any practical limit would allow.
+  #[tokio::test]
+  async fn limited_body_unlimited_when_none() {
+    let big = Bytes::from(vec![0u8; 4 * 1024 * 1024]);
+    let inner = Full::new(big);
+    let limited = LimitedBody::new(inner, None);
+    let collected = limited.collect().await.unwrap().to_bytes();
+    assert_eq!(collected.len(), 4 * 1024 * 1024);
+  }
+
+  /// Empty body (no frames) is fine under any limit, including `Some(0)`.
+  #[tokio::test]
+  async fn limited_body_empty_under_zero_limit_passes() {
+    let inner = Full::new(Bytes::new());
+    let limited = LimitedBody::new(inner, Some(0));
+    let collected = limited.collect().await.unwrap().to_bytes();
+    assert!(collected.is_empty());
+  }
+
+  /// `Some(0)` rejects any non-empty body (preserves the previous h3 `= 0` semantics).
+  #[tokio::test]
+  async fn limited_body_zero_limit_rejects_non_empty() {
+    let inner = Full::new(Bytes::from_static(b"x"));
+    let limited = LimitedBody::new(inner, Some(0));
+    let err = limited.collect().await.unwrap_err();
+    assert!(matches!(err, RpxyError::RequestBodyTooLarge { received: 1, limit: 0 }));
+  }
+
+  /// After overrun, subsequent polls return `None` (end-of-stream) rather than draining
+  /// the inner body further. This guarantees trailer / non-data frames cannot slip
+  /// through after the limit is exceeded, even if a caller keeps polling past the
+  /// error frame.
+  #[tokio::test]
+  async fn limited_body_tripped_state_returns_none_after_error() {
+    use std::{
+      future::poll_fn,
+      pin::Pin,
+      task::{Context, Poll, Waker},
+    };
+
+    let inner = Full::new(Bytes::from_static(b"hello world"));
+    let mut limited = LimitedBody::new(inner, Some(5));
+    let waker = Waker::noop();
+    let mut cx = Context::from_waker(waker);
+
+    // First poll: overrun -> error frame.
+    let first = poll_fn(|cx| match Pin::new(&mut limited).poll_frame(cx) {
+      Poll::Ready(v) => Poll::Ready(v),
+      Poll::Pending => Poll::Ready(None),
+    })
+    .await;
+    match first {
+      Some(Err(RpxyError::RequestBodyTooLarge { limit: 5, .. })) => {}
+      other => panic!("expected RequestBodyTooLarge on first poll, got {other:?}"),
+    }
+
+    // Second poll: must be None (tripped-exhausted), NOT another frame from inner.
+    let second = match Pin::new(&mut limited).poll_frame(&mut cx) {
+      Poll::Ready(v) => v,
+      Poll::Pending => panic!("expected Ready"),
+    };
+    assert!(second.is_none(), "post-overrun poll must return None, got {second:?}");
+
+    // is_end_stream reflects the tripped state too.
+    assert!(limited.is_end_stream());
   }
 }

--- a/rpxy-lib/src/hyper_ext/mod.rs
+++ b/rpxy-lib/src/hyper_ext/mod.rs
@@ -12,5 +12,7 @@ pub(crate) mod rt {
 #[allow(unused)]
 pub(crate) mod body {
   pub(crate) use super::body_incoming_like::IncomingLike;
-  pub(crate) use super::body_type::{BoundedStreamBody, BoxBody, RequestBody, ResponseBody, empty, full};
+  pub(crate) use super::body_type::{
+    BoundedStreamBody, BoxBody, LimitedBody, LimitedIncoming, RequestBody, ResponseBody, empty, full,
+  };
 }

--- a/rpxy-lib/src/message_handler/handler_main.rs
+++ b/rpxy-lib/src/message_handler/handler_main.rs
@@ -3,7 +3,7 @@ use super::{
   http_log::HttpMessageLog,
   http_result::{HttpError, HttpResult},
   request_ops::InspectParseHost,
-  synthetic_response::{secure_redirection_response, synthetic_error_response},
+  synthetic_response::{secure_redirection_response, synthetic_error_response, synthetic_error_response_with_close},
 };
 #[cfg(feature = "sticky-cookie")]
 use crate::backend::StickyCookieConfig;
@@ -73,6 +73,11 @@ where
       l.client_addr(&client_addr);
     }
 
+    // Capture before `req` is moved into the inner handler; needed by
+    // `synthetic_error_response_with_close` on the PayloadTooLarge path (h1.x must close
+    // the connection so the unread body bytes don't get fed into a recycled connection).
+    let request_version = req.version();
+
     let http_result = self
       .handle_request_inner(&mut log_data, req, client_addr, listen_addr, tls_enabled, tls_server_name)
       .await;
@@ -92,11 +97,16 @@ where
           Some(l) => error!("{e}: {l}"),
           None => error!("{e}: client={client_addr}"),
         }
+        let close_connection = matches!(e, HttpError::PayloadTooLarge);
         let code = StatusCode::from(e);
         if let Some(l) = log_data.as_mut() {
           l.status_code(&code).output();
         }
-        synthetic_error_response(code)
+        if close_connection {
+          synthetic_error_response_with_close(code, request_version)
+        } else {
+          synthetic_error_response(code)
+        }
       }
     }
   }
@@ -126,6 +136,15 @@ where
         return Err(HttpError::SniHostInconsistency);
       }
     }
+
+    // Pre-flight Content-Length check: reject oversize requests with 413 before any
+    // upstream contact. Placed AFTER host inspection and SNI consistency so that
+    // malformed-host (400) / SNI-mismatch (421) requests get their specific status codes
+    // even when they also carry an oversize Content-Length. The streaming-overrun case
+    // is enforced separately at the body adapter (HTTP/1.x and HTTP/2 via the
+    // `LimitedIncoming` wrapper, HTTP/3 via its dedicated body-forwarding task) and
+    // surfaces as a body error rather than a clean 413.
+    check_content_length_limit(&req, self.globals.proxy_config.request_max_body_size)?;
     // Find backend application for given server_name, and drop if incoming request is invalid as request.
     // `default_app` fallback is plaintext-HTTP only (see README and backend_main.rs). TLS requests
     // with an unknown host are rejected regardless of `sni_consistency`.
@@ -280,5 +299,96 @@ where
     });
 
     Ok(res_backend)
+  }
+}
+
+/// Pre-flight `Content-Length` check.
+///
+/// Returns `Err(HttpError::PayloadTooLarge)` only when the inbound request advertises a
+/// `Content-Length` that exceeds the configured `limit` (i.e. an oversize upload we can
+/// detect *before* contacting the upstream). Returns `Ok(())` when the limit is `None`
+/// (unlimited), when the header is absent or malformed (chunked / streamed bodies are
+/// caught later by the body adapter), or when the announced length is within the limit.
+fn check_content_length_limit<B>(req: &Request<B>, limit: Option<usize>) -> HttpResult<()> {
+  let Some(limit) = limit else {
+    return Ok(());
+  };
+  let Some(value) = req.headers().get(http::header::CONTENT_LENGTH) else {
+    return Ok(());
+  };
+  // Malformed Content-Length: let the downstream parser (hyper) handle it; we are only
+  // responsible for the size-bound check here.
+  let Ok(s) = value.to_str() else { return Ok(()) };
+  let Ok(n) = s.parse::<usize>() else { return Ok(()) };
+  if n > limit {
+    return Err(HttpError::PayloadTooLarge);
+  }
+  Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  fn req_with_cl(value: &str) -> Request<()> {
+    let mut req = Request::new(());
+    req.headers_mut().insert(http::header::CONTENT_LENGTH, value.parse().unwrap());
+    req
+  }
+
+  /// CL strictly above the limit -> 413.
+  #[test]
+  fn check_content_length_limit_rejects_oversize() {
+    let req = req_with_cl("100");
+    let err = check_content_length_limit(&req, Some(50)).unwrap_err();
+    assert!(matches!(err, HttpError::PayloadTooLarge));
+  }
+
+  /// CL equal to the limit -> allow (boundary).
+  #[test]
+  fn check_content_length_limit_allows_equal_to_limit() {
+    let req = req_with_cl("50");
+    assert!(check_content_length_limit(&req, Some(50)).is_ok());
+  }
+
+  /// CL below the limit -> allow.
+  #[test]
+  fn check_content_length_limit_allows_under_limit() {
+    let req = req_with_cl("10");
+    assert!(check_content_length_limit(&req, Some(50)).is_ok());
+  }
+
+  /// Header absent (chunked / streamed) -> defer to the streaming body adapter; ok here.
+  #[test]
+  fn check_content_length_limit_passes_when_header_absent() {
+    let req: Request<()> = Request::new(());
+    assert!(check_content_length_limit(&req, Some(50)).is_ok());
+  }
+
+  /// Malformed CL value -> ok (let hyper handle the bad-request rejection downstream).
+  #[test]
+  fn check_content_length_limit_passes_on_malformed_header() {
+    let req = req_with_cl("not-a-number");
+    assert!(check_content_length_limit(&req, Some(50)).is_ok());
+  }
+
+  /// `None` limit -> unlimited; no rejection regardless of CL value.
+  #[test]
+  fn check_content_length_limit_unlimited_when_none() {
+    let req = req_with_cl("999999999");
+    assert!(check_content_length_limit(&req, None).is_ok());
+  }
+
+  /// `Some(0)` semantics: only the zero-length body passes (current h3 behaviour
+  /// preserved for the unified limit).
+  #[test]
+  fn check_content_length_limit_zero_rejects_non_empty() {
+    let req = req_with_cl("1");
+    assert!(matches!(
+      check_content_length_limit(&req, Some(0)).unwrap_err(),
+      HttpError::PayloadTooLarge
+    ));
+    let req = req_with_cl("0");
+    assert!(check_content_length_limit(&req, Some(0)).is_ok());
   }
 }

--- a/rpxy-lib/src/message_handler/handler_main.rs
+++ b/rpxy-lib/src/message_handler/handler_main.rs
@@ -317,10 +317,12 @@ fn check_content_length_limit<B>(req: &Request<B>, limit: Option<usize>) -> Http
     return Ok(());
   };
   // Malformed Content-Length: let the downstream parser (hyper) handle it; we are only
-  // responsible for the size-bound check here.
+  // responsible for the size-bound check here. Parse as `u64` so that a syntactically
+  // valid but very large value (e.g. > 4 GiB on a 32-bit target) does not silently fall
+  // out of `usize::parse` and skip the pre-flight 413; the comparison is widened to `u64`.
   let Ok(s) = value.to_str() else { return Ok(()) };
-  let Ok(n) = s.parse::<usize>() else { return Ok(()) };
-  if n > limit {
+  let Ok(n) = s.parse::<u64>() else { return Ok(()) };
+  if n > limit as u64 {
     return Err(HttpError::PayloadTooLarge);
   }
   Ok(())

--- a/rpxy-lib/src/message_handler/handler_main.rs
+++ b/rpxy-lib/src/message_handler/handler_main.rs
@@ -319,7 +319,8 @@ fn check_content_length_limit<B>(req: &Request<B>, limit: Option<usize>) -> Http
   // Malformed Content-Length: let the downstream parser (hyper) handle it; we are only
   // responsible for the size-bound check here. Parse as `u64` so that a syntactically
   // valid but very large value (e.g. > 4 GiB on a 32-bit target) does not silently fall
-  // out of `usize::parse` and skip the pre-flight 413; the comparison is widened to `u64`.
+  // out of `s.parse::<usize>()` and skip the pre-flight 413; the comparison is widened
+  // to `u64`.
   let Ok(s) = value.to_str() else { return Ok(()) };
   let Ok(n) = s.parse::<u64>() else { return Ok(()) };
   if n > limit as u64 {
@@ -392,5 +393,27 @@ mod tests {
     ));
     let req = req_with_cl("0");
     assert!(check_content_length_limit(&req, Some(0)).is_ok());
+  }
+
+  /// Regression: an oversize CL whose numeric value would overflow `usize` on a 32-bit
+  /// target (and `u64::MAX` even on 64-bit) must still be rejected as PayloadTooLarge.
+  /// Parsing as `u64` and comparing against `limit as u64` is what guarantees this; a
+  /// previous `s.parse::<usize>()` would have failed on 32-bit and silently skipped the
+  /// pre-flight 413.
+  #[test]
+  fn check_content_length_limit_rejects_value_overflowing_usize() {
+    // Larger than usize::MAX on a 32-bit target (4_294_967_295) and larger than any
+    // realistic `request_max_body_size`; still well within u64 (u64::MAX ~= 1.8e19).
+    let req = req_with_cl("9999999999999");
+    let err = check_content_length_limit(&req, Some(256 * 1024 * 1024)).unwrap_err();
+    assert!(matches!(err, HttpError::PayloadTooLarge));
+    // u64::MAX as a header value is still rejected (the largest value that parses).
+    let req = req_with_cl(&u64::MAX.to_string());
+    let err = check_content_length_limit(&req, Some(256 * 1024 * 1024)).unwrap_err();
+    assert!(matches!(err, HttpError::PayloadTooLarge));
+    // A value that does not even fit in `u64` is treated as malformed and deferred to
+    // the streaming body adapter (consistent with the existing malformed-header test).
+    let req = req_with_cl("99999999999999999999999999");
+    assert!(check_content_length_limit(&req, Some(256 * 1024 * 1024)).is_ok());
   }
 }

--- a/rpxy-lib/src/message_handler/http_result.rs
+++ b/rpxy-lib/src/message_handler/http_result.rs
@@ -36,6 +36,8 @@ pub enum HttpError {
   // NoUpgradeExtensionInRequest,
   // #[error("Response does not have an upgrade extension")]
   // NoUpgradeExtensionInResponse,
+  #[error("Request body exceeds configured maximum size")]
+  PayloadTooLarge,
   #[error(transparent)]
   Other(#[from] anyhow::Error),
 }
@@ -54,9 +56,23 @@ impl From<HttpError> for StatusCode {
       HttpError::FailedToGenerateDownstreamResponse(_) => StatusCode::INTERNAL_SERVER_ERROR,
       HttpError::FailedToUpgrade(_) => StatusCode::INTERNAL_SERVER_ERROR,
       HttpError::FailedToGetResponseFromBackend(_) => StatusCode::BAD_GATEWAY,
+      HttpError::PayloadTooLarge => StatusCode::PAYLOAD_TOO_LARGE,
       // HttpError::NoUpgradeExtensionInRequest => StatusCode::BAD_REQUEST,
       // HttpError::NoUpgradeExtensionInResponse => StatusCode::BAD_GATEWAY,
       _ => StatusCode::INTERNAL_SERVER_ERROR,
     }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  /// Pin the bug-fix mapping: PayloadTooLarge surfaces as 413.
+  #[test]
+  fn payload_too_large_maps_to_413() {
+    let code: StatusCode = HttpError::PayloadTooLarge.into();
+    assert_eq!(code, StatusCode::PAYLOAD_TOO_LARGE);
+    assert_eq!(code.as_u16(), 413);
   }
 }

--- a/rpxy-lib/src/message_handler/synthetic_response.rs
+++ b/rpxy-lib/src/message_handler/synthetic_response.rs
@@ -4,7 +4,7 @@ use crate::{
   hyper_ext::body::{ResponseBody, empty},
   name_exp::ServerName,
 };
-use http::{Request, Response, StatusCode, Uri};
+use http::{Request, Response, StatusCode, Uri, Version, header};
 
 /// build http response with status code of 4xx and 5xx
 pub(crate) fn synthetic_error_response(status_code: StatusCode) -> RpxyResult<Response<ResponseBody>> {
@@ -13,6 +13,71 @@ pub(crate) fn synthetic_error_response(status_code: StatusCode) -> RpxyResult<Re
     .body(ResponseBody::Boxed(empty()))
     .unwrap();
   Ok(res)
+}
+
+/// Build a 4xx/5xx synthetic response that closes the connection on h1.
+///
+/// HTTP/1.x has no in-band stream-close mechanism, so when we reject a request before
+/// consuming its body (e.g. a 413 Payload Too Large from the pre-flight Content-Length
+/// check) the client could otherwise keep streaming the rest of the body into a
+/// connection we want to recycle. Set `Connection: close` for HTTP/1.0 and HTTP/1.1; for
+/// HTTP/2 and HTTP/3 the response naturally closes only the affected stream and no
+/// header is needed. `request_version` is captured at the handler entry before the
+/// request value is moved into the inner handler.
+pub(crate) fn synthetic_error_response_with_close(
+  status_code: StatusCode,
+  request_version: Version,
+) -> RpxyResult<Response<ResponseBody>> {
+  let mut builder = Response::builder().status(status_code);
+  if matches!(request_version, Version::HTTP_10 | Version::HTTP_11) {
+    builder = builder.header(header::CONNECTION, "close");
+  }
+  let res = builder.body(ResponseBody::Boxed(empty())).unwrap();
+  Ok(res)
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  /// HTTP/1.1: `Connection: close` is inserted so the unread body can't be fed into a
+  /// recycled connection.
+  #[test]
+  fn close_aware_413_h1_inserts_connection_close() {
+    let res = synthetic_error_response_with_close(StatusCode::PAYLOAD_TOO_LARGE, Version::HTTP_11).unwrap();
+    assert_eq!(res.status(), StatusCode::PAYLOAD_TOO_LARGE);
+    assert_eq!(
+      res.headers().get(header::CONNECTION).map(|v| v.as_bytes()),
+      Some(b"close".as_ref())
+    );
+  }
+
+  /// HTTP/1.0: same as HTTP/1.1 — the stream-close mechanism is connection-level.
+  #[test]
+  fn close_aware_413_h10_inserts_connection_close() {
+    let res = synthetic_error_response_with_close(StatusCode::PAYLOAD_TOO_LARGE, Version::HTTP_10).unwrap();
+    assert_eq!(
+      res.headers().get(header::CONNECTION).map(|v| v.as_bytes()),
+      Some(b"close".as_ref())
+    );
+  }
+
+  /// HTTP/2: stream close happens in-band via `END_STREAM`; no `Connection: close`
+  /// header (and the http crate would reject one as forbidden in h2 if it ever reached
+  /// the writer).
+  #[test]
+  fn close_aware_413_h2_omits_connection_close() {
+    let res = synthetic_error_response_with_close(StatusCode::PAYLOAD_TOO_LARGE, Version::HTTP_2).unwrap();
+    assert_eq!(res.status(), StatusCode::PAYLOAD_TOO_LARGE);
+    assert!(res.headers().get(header::CONNECTION).is_none());
+  }
+
+  /// HTTP/3: same as h2 — connection header is not used; stream close is protocol-native.
+  #[test]
+  fn close_aware_413_h3_omits_connection_close() {
+    let res = synthetic_error_response_with_close(StatusCode::PAYLOAD_TOO_LARGE, Version::HTTP_3).unwrap();
+    assert!(res.headers().get(header::CONNECTION).is_none());
+  }
 }
 
 /// Generate synthetic response message of a redirection to https host with 301

--- a/rpxy-lib/src/proxy/proxy_h3.rs
+++ b/rpxy-lib/src/proxy/proxy_h3.rs
@@ -117,19 +117,31 @@ where
 
     // Buffering and sending body through channel for protocol conversion like h3 -> h2/http1.1
     // The underling buffering, i.e., buffer given by the API recv_data.await?, is handled by quinn.
-    let max_body_size = self.globals.proxy_config.h3_request_max_body_size;
+    //
+    // Effective h3 body-size limit: the deprecated h3-specific override (`h3_request_max_body_size`,
+    // set via `experimental.h3.request_max_body_size`) wins when present; otherwise inherit the
+    // global `request_max_body_size`. Both are `Option<usize>` — `None` means unlimited and skips
+    // the count entirely. The pre-flight Content-Length check in `handle_request_inner` covers
+    // CL-known oversize uploads with a clean 413; this loop covers chunked / streaming overrun.
+    let effective_body_limit: Option<usize> = self
+      .globals
+      .proxy_config
+      .h3_request_max_body_size
+      .or(self.globals.proxy_config.request_max_body_size);
     self.globals.runtime_handle.spawn(async move {
       let mut sender = body_sender;
       let mut size = 0usize;
       while let Some(mut body) = recv_stream.recv_data().await? {
         trace!("HTTP/3 incoming request body: remaining {}", body.remaining());
         size += body.remaining();
-        if size > max_body_size {
-          error!(
-            "Exceeds max request body size for HTTP/3: received {}, maximum_allowed {}",
-            size, max_body_size
-          );
-          return Err(RpxyError::H3TooLargeBody);
+        if let Some(limit) = effective_body_limit {
+          if size > limit {
+            error!(
+              "Exceeds max request body size for HTTP/3: received {}, maximum_allowed {}",
+              size, limit
+            );
+            return Err(RpxyError::H3TooLargeBody);
+          }
         }
         // create stream body to save memory, shallow copy (increment of ref-count) to Bytes using copy_to_bytes
         sender.send_data(body.copy_to_bytes(body.remaining())).await?;

--- a/rpxy-lib/src/proxy/proxy_main.rs
+++ b/rpxy-lib/src/proxy/proxy_main.rs
@@ -5,7 +5,7 @@ use crate::{
   error::*,
   globals::Globals,
   hyper_ext::{
-    body::{RequestBody, ResponseBody},
+    body::{LimitedIncoming, RequestBody, ResponseBody},
     rt::LocalExecutor,
   },
   log::*,
@@ -45,6 +45,12 @@ fn set_tcp_nodelay(stream: &TcpStream, peer: SocketAddr) {
 /* -------------------------------------------------------------------------------------------------------- */
 /// Wrapper function to handle request for HTTP/1.1 and HTTP/2
 /// HTTP/3 is handled in proxy_h3.rs which directly calls the message handler
+///
+/// `request_max_body_size` is passed in explicitly (rather than reached through
+/// `handler.globals`) because `HttpMessageHandler.globals` is `pub(super)` and not
+/// reachable from this module; the caller (the proxy accept loop) already has direct
+/// access to its own `globals` and threads the value down. `None` means unlimited; in
+/// that case `LimitedIncoming` short-circuits its per-frame counter.
 async fn serve_request<T>(
   req: Request<Incoming>,
   handler: Arc<HttpMessageHandler<T>>,
@@ -52,13 +58,14 @@ async fn serve_request<T>(
   listen_addr: SocketAddr,
   tls_enabled: bool,
   tls_server_name: Option<ServerName>,
+  request_max_body_size: Option<usize>,
 ) -> RpxyResult<Response<ResponseBody>>
 where
   T: Send + Sync + Connect + Clone,
 {
   handler
     .handle_request(
-      req.map(RequestBody::Incoming),
+      req.map(|incoming| RequestBody::Incoming(LimitedIncoming::new(incoming, request_max_body_size))),
       client_addr,
       listen_addr,
       tls_enabled,
@@ -296,6 +303,7 @@ where
     let tls_enabled = self.listener_spec.tls_enabled();
     let listening_on = self.listener_spec.listening_on;
     let handling_timeout = self.globals.proxy_config.connection_handling_timeout;
+    let request_max_body_size = self.globals.proxy_config.request_max_body_size;
 
     self.globals.runtime_handle.clone().spawn(async move {
       // Hold the per-IP connection slot for the whole connection lifetime.
@@ -310,6 +318,7 @@ where
             listening_on,
             tls_enabled,
             tls_server_name.clone(),
+            request_max_body_size,
           )
         }),
       );


### PR DESCRIPTION
### Important Changes

- **HTTP/1.1 and HTTP/2 now have a 256 MiB default request body cap.** Previously HTTP/1.1 and HTTP/2 had no body size limit. Operators handling >256 MiB uploads via HTTP/1.1 or HTTP/2 must explicitly set `request_max_body_size` to a larger value in the top-level config (effectively-unlimited deployments set a deliberately large value within TOML's signed-64-bit integer range, e.g. `9000000000000` for ~9 TB). The HTTP/3 default is unchanged. The previous `experimental.h3.request_max_body_size` key continues to work as a deprecated HTTP/3-specific override and emits a startup warning; it will be removed in 0.14.0.

### Bugfix

- **Fix: enforce a request body size limit on HTTP/1.1 and HTTP/2.** Previously rpxy enforced `request_max_body_size` only on HTTP/3; a client could stream arbitrarily many request body bytes via HTTP/1.1 or HTTP/2 with no proxy-side bound, allowing a denial-of-service via unbounded request bodies. The same limit (default 256 MiB, matching the previous HTTP/3-only default) now applies to all three protocols, configurable via a new top-level `request_max_body_size` TOML key. Oversize requests with a known `Content-Length` are rejected up front with `413 Payload Too Large` before any upstream contact (HTTP/1.x responses include `Connection: close` so the unread body bytes are not fed into a recycled connection; HTTP/2 and HTTP/3 close the affected stream in-band); oversize chunked / streamed bodies are detected mid-flight by a per-request body adapter which emits one `error!` log line of the form "Request body exceeded limit: received N bytes, maximum allowed M" and surfaces to the client as an upstream-forwarder error (typically 502) or a connection drop, with the log line identifying the cause. HTTP/3's pre-existing streaming-overrun behaviour is preserved; HTTP/3 also newly gets the CL-known 413 pre-flight by routing through the unified handler entry. The internal representation moved from `usize` to `Option<usize>` (`None` = unlimited; `Some(0)` preserves the previous HTTP/3 "reject any non-empty body" semantics).