### PR TITLE
chore(refactor): fix some internal constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - **Nits: clean up in-source TODO comments.** Empty or stale markers were removed, Japanese-only notes were translated, and the remaining future-work comments were clarified without changing runtime behavior.
 - **Refactor: clear scoped Clippy carry-over warnings in the forwarding-header and hop-header helpers.** The cleanup reshapes nested control flow, fixes doc-comment placement, and adds direct `Upgrade` extraction tests without changing header parsing or proxy behavior.
 - **Refactor: remove an unused sticky-cookie duration getter.** The stored sticky-cookie duration is still used when generating `Set-Cookie` metadata, and the current cookie lifetime behavior is unchanged.
+- **Refactor: replace the hard-coded sticky-cookie duration with a named constant and add a defensive validation guard.** The 300-second default is now `STICKY_COOKIE_DURATION_SECS`, and `StickyCookieConfig::try_new` rejects non-positive durations at build time. No behavior change.
 
 ## 0.13.1
 

--- a/rpxy-lib/src/backend/load_balance/sticky_cookie.rs
+++ b/rpxy-lib/src/backend/load_balance/sticky_cookie.rs
@@ -1,5 +1,5 @@
 use super::{LoadBalanceError, LoadBalanceResult, sticky_cookie_seal::build_sticky_cookie_aad};
-use crate::error::RpxyResult;
+use crate::error::{RpxyError, RpxyResult};
 use chrono::{TimeZone, Utc};
 use derive_builder::Builder;
 use std::{borrow::Cow, sync::Arc};
@@ -172,6 +172,11 @@ impl StickyCookieConfig {
   /// re-validating and re-allocating it on every request. An invalid component (NUL byte) is thus
   /// rejected when the backend is built (startup/config reload), not on each request.
   pub fn try_new(name: &str, server_name: &str, path_opt: &Option<String>, duration: i64) -> RpxyResult<Self> {
+    if duration <= 0 {
+      return Err(RpxyError::InvalidStickyCookieConfig(format!(
+        "sticky_cookie_duration must be positive, got {duration}"
+      )));
+    }
     let name = name.to_string();
     let name_prefix = format!("{name}=");
     let domain = server_name.to_ascii_lowercase();
@@ -261,6 +266,16 @@ mod tests {
       )
     );
   }
+
+  #[test]
+  fn try_new_rejects_non_positive_duration() {
+    for duration in [0, -1] {
+      let err = StickyCookieConfig::try_new(STICKY_COOKIE_NAME, "example.com", &Some("/path".to_string()), duration).unwrap_err();
+      assert!(matches!(err, RpxyError::InvalidStickyCookieConfig(_)));
+      assert!(err.to_string().contains("sticky_cookie_duration must be positive"));
+    }
+  }
+
   #[test]
   fn to_string_works() {
     let sc = StickyCookie {

--- a/rpxy-lib/src/backend/upstream.rs
+++ b/rpxy-lib/src/backend/upstream.rs
@@ -5,7 +5,7 @@ use super::load_balance::{
 use super::load_balance::{LoadBalanceStickyBuilder, StickyCookieConfig};
 use super::upstream_opts::UpstreamOption;
 #[cfg(feature = "sticky-cookie")]
-use crate::constants::STICKY_COOKIE_NAME;
+use crate::constants::{STICKY_COOKIE_DURATION_SECS, STICKY_COOKIE_NAME};
 #[cfg(feature = "health-check")]
 use crate::globals::HealthCheckConfig;
 use crate::{
@@ -278,8 +278,8 @@ impl UpstreamCandidatesBuilder {
         lb_opts::ROUND_ROBIN => LoadBalance::RoundRobin(LoadBalanceRoundRobinBuilder::default().build().unwrap()),
         #[cfg(feature = "sticky-cookie")]
         lb_opts::STICKY_ROUND_ROBIN => {
-          // TODO: Make sticky cookie name and duration configurable.
-          let sticky_config = StickyCookieConfig::try_new(STICKY_COOKIE_NAME, server_name, path_opt, 300)?;
+          let sticky_config =
+            StickyCookieConfig::try_new(STICKY_COOKIE_NAME, server_name, path_opt, STICKY_COOKIE_DURATION_SECS)?;
           LoadBalance::StickyRoundRobin(
             LoadBalanceStickyBuilder::default()
               .sticky_config(sticky_config)

--- a/rpxy-lib/src/constants.rs
+++ b/rpxy-lib/src/constants.rs
@@ -33,6 +33,10 @@ pub mod H3 {
 /// Current cookie name for sticky load-balancing tokens.
 pub const STICKY_COOKIE_NAME: &str = "rpxy_sticky_token";
 
+#[cfg(feature = "sticky-cookie")]
+/// Default sticky-cookie lifetime in seconds.
+pub const STICKY_COOKIE_DURATION_SECS: i64 = 300;
+
 #[cfg(feature = "cache")]
 // # of entries in cache
 pub const MAX_CACHE_ENTRY: usize = 1_000;

--- a/rpxy-lib/src/error.rs
+++ b/rpxy-lib/src/error.rs
@@ -96,6 +96,9 @@ pub enum RpxyError {
   #[error("Invalid sticky cookie AAD: {0}")]
   InvalidStickyCookieAad(String),
   #[cfg(feature = "sticky-cookie")]
+  #[error("Invalid sticky cookie configuration: {0}")]
+  InvalidStickyCookieConfig(String),
+  #[cfg(feature = "sticky-cookie")]
   #[error("Failed to seal sticky cookie value")]
   FailedToSealStickyCookie,
 


### PR DESCRIPTION
- **Refactor: replace the hard-coded sticky-cookie duration with a named constant and add a defensive validation guard.** The 300-second default is now `STICKY_COOKIE_DURATION_SECS`, and `StickyCookieConfig::try_new` rejects non-positive durations at build time. No behavior change.
