### PR TITLE
fix(cache): key responses by client-facing effective URI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 .claude
+.codex
+.agents
 .vscode
 .private
+.env
 .tmp
 docker/log
 docker/cache

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bugfix
 
 - Fix: reject oversize HTTP/3 request bodies with an error instead of forwarding a silently truncated body upstream.
+- **Fix: partition the HTTP cache by the client-facing effective request URI (scheme + authoritative host + path/query) to prevent cross-virtual-host cache poisoning.** Previously, with the `cache` feature enabled, entries were keyed on the request URI after rewrite to the upstream target, so two virtual hosts sharing one upstream could serve each other's cached responses. The scheme is derived with the same trusted-forwarded-proxy boundary used elsewhere, and requests without a safe client-facing URI are served uncached (fail closed). This may lower the cache hit rate when virtual hosts intentionally share a backend; no config change is required.
 
 ## 0.13.2
 

--- a/README.md
+++ b/README.md
@@ -395,6 +395,8 @@ max_cache_each_size_on_memory = 65535 # optional. default is 64k, same as max_ca
 
 A *storable* (in the context of an HTTP message) response is stored if its size is less than or equal to `max_cache_each_size` in bytes. If it is also less than or equal to `max_cache_each_size_on_memory`, it is stored as an in-memory object. Otherwise, it is stored as a temporary file. Note that `max_cache_each_size` must be greater than or equal to `max_cache_each_size_on_memory`. Also note that once `rpxy` restarts or the config is updated, the cache is completely eliminated not only from the in-memory table but also from the file system.
 
+Cache entries are keyed on the scheme, host, and path/query the client requested, so different virtual hosts never share cached responses even when they proxy to the same backend.
+
 ### Automated Certificate Issuance and Renewal via TLS-ALPN-01 ACME Protocol
 
 This is a brand-new feature and may still be unstable. Thanks to [`rustls-acme`](https://github.com/FlorianUekermann/rustls-acme), automatic issuance and renewal of certificates are finally available in `rpxy`. To enable this feature, you need to specify the following entries in `config.toml`.

--- a/rpxy-lib/src/forwarder/cache/cache_main.rs
+++ b/rpxy-lib/src/forwarder/cache/cache_main.rs
@@ -140,7 +140,7 @@ impl RpxyCache {
         return;
       };
 
-      let cache_key = derive_cache_key_from_uri(&uri);
+      let cache_key = derive_cache_key_from_effective_uri(&uri);
       let cache_object = CacheObject::new(policy_clone, target, hash);
       // The file (if any) is now fully written and renamed into place, so it is safe to publish
       // the metadata; this also accounts for the file count and evicts any displaced file.
@@ -155,7 +155,7 @@ impl RpxyCache {
   /// Get cached response
   pub(crate) async fn get<R>(&self, req: &Request<R>) -> Option<Response<ResponseBody>> {
     trace!("Current cache status: (total, on-memory, file) = {:?}", self.count().await);
-    let cache_key = derive_cache_key_from_uri(req.uri());
+    let cache_key = derive_cache_key_from_effective_uri(req.uri());
 
     // First check cache chance
     let cached_object = self.inner.get(&cache_key).ok()??;
@@ -787,7 +787,11 @@ fn derive_filename_from_uri(uri: &hyper::Uri) -> String {
   general_purpose::URL_SAFE_NO_PAD.encode(digest)
 }
 
-fn derive_cache_key_from_uri(uri: &hyper::Uri) -> String {
+/// Derive the LRU cache key from the client-facing effective request URI. The caller MUST pass
+/// the effective URI (scheme + authority + path/query, as the client addressed it), NOT the
+/// upstream-rewritten request URI - otherwise distinct client-facing vhosts that rewrite to the
+/// same upstream target would collide on one key (cross-vhost cache poisoning).
+fn derive_cache_key_from_effective_uri(uri: &hyper::Uri) -> String {
   uri.to_string()
 }
 
@@ -1061,7 +1065,7 @@ mod tests {
       // Intentionally wrong: an on-memory hit must not consult this hash.
       Bytes::from_static(&[0u8; 32]),
     );
-    let cache_key = derive_cache_key_from_uri(&uri);
+    let cache_key = derive_cache_key_from_effective_uri(&uri);
     cache.inner.push(&cache_key, &cache_object).unwrap();
 
     let req = Request::builder().uri(uri.clone()).body(()).unwrap();
@@ -1251,7 +1255,7 @@ mod tests {
     let manager = LruCacheManager::new(10);
     let file_store = test_file_store();
     let uri: Uri = "http://example.com/x".parse().unwrap();
-    let key = derive_cache_key_from_uri(&uri);
+    let key = derive_cache_key_from_effective_uri(&uri);
 
     let path_a = dir.join("file-a");
     fs::write(&path_a, b"AAAA").await.unwrap();
@@ -1289,7 +1293,7 @@ mod tests {
     let manager = LruCacheManager::new(10);
     let file_store = test_file_store();
     let uri: Uri = "http://example.com/x".parse().unwrap();
-    let key = derive_cache_key_from_uri(&uri);
+    let key = derive_cache_key_from_effective_uri(&uri);
 
     let path_a = dir.join("file-a");
     fs::write(&path_a, b"AAAA").await.unwrap();
@@ -1329,7 +1333,7 @@ mod tests {
       CacheFileOrOnMemory::File(path_a.clone()),
       Bytes::from_static(&[1u8; 32]),
     );
-    publish_cache_object(&manager, &file_store, &derive_cache_key_from_uri(&uri_x), obj_a).await;
+    publish_cache_object(&manager, &file_store, &derive_cache_key_from_effective_uri(&uri_x), obj_a).await;
     assert_eq!(file_store.count().await, 1);
 
     let uri_y: Uri = "http://example.com/y".parse().unwrap();
@@ -1338,7 +1342,7 @@ mod tests {
       CacheFileOrOnMemory::OnMemory(Bytes::from_static(b"small")),
       Bytes::from_static(&[2u8; 32]),
     );
-    publish_cache_object(&manager, &file_store, &derive_cache_key_from_uri(&uri_y), obj_b).await;
+    publish_cache_object(&manager, &file_store, &derive_cache_key_from_effective_uri(&uri_y), obj_b).await;
 
     assert!(
       fs::metadata(&path_a).await.is_err(),
@@ -1397,7 +1401,7 @@ mod tests {
   async fn evict_if_generation_spares_newer_entry() {
     let manager = LruCacheManager::new(10);
     let uri: Uri = "http://example.com/x".parse().unwrap();
-    let key = derive_cache_key_from_uri(&uri);
+    let key = derive_cache_key_from_effective_uri(&uri);
 
     let obj_a = CacheObject::new(
       fresh_policy(&uri),

--- a/rpxy-lib/src/forwarder/cache/mod.rs
+++ b/rpxy-lib/src/forwarder/cache/mod.rs
@@ -3,3 +3,11 @@ mod cache_main;
 
 pub use cache_error::CacheError;
 pub(crate) use cache_main::{RpxyCache, get_policy_if_cacheable};
+
+/// Client-facing effective request URI (scheme + authority + path/query), captured by the
+/// handler before the upstream rewrite and carried to the forwarder via request extensions.
+/// Used as the cache key input so cache entries are partitioned per client-facing vhost and
+/// scheme instead of per upstream target. When this extension is absent the forwarder bypasses
+/// the cache (fail closed) rather than keying on the upstream-rewritten URI.
+#[derive(Clone, Debug)]
+pub(crate) struct ClientFacingEffectiveUri(pub(crate) http::Uri);

--- a/rpxy-lib/src/forwarder/client.rs
+++ b/rpxy-lib/src/forwarder/client.rs
@@ -15,7 +15,7 @@ use hyper_util::client::legacy::{
 use std::sync::Arc;
 
 #[cfg(feature = "cache")]
-use super::cache::{RpxyCache, get_policy_if_cacheable};
+use super::cache::{ClientFacingEffectiveUri, RpxyCache, get_policy_if_cacheable};
 
 #[async_trait]
 /// Definition of the forwarder that simply forward requests from downstream client to upstream app servers.
@@ -46,37 +46,43 @@ where
     #[cfg(feature = "cache")]
     {
       let mut synth_req = None;
-      if self.cache.is_some() {
-        // try reading from cache
-        if let Some(cached_response) = self.cache.as_ref().unwrap().get(&req).await {
-          // if found, return it as response.
-          info!("Cache hit - Return from cache");
-          return Ok(cached_response);
-        };
-
-        // Synthetic request copy used just for caching (cannot clone request object...)
-        synth_req = Some(build_synth_req_for_cache(&req));
+      if let Some(cache) = self.cache.as_ref() {
+        // The cache is keyed on the client-facing effective URI captured by the handler before
+        // the upstream rewrite and carried in request extensions. When it is absent we fail
+        // closed: bypass the cache entirely rather than keying on the upstream-rewritten request
+        // URI (which would collide across client-facing vhosts sharing one upstream target).
+        if let Some(effective_uri) = cache_effective_uri(&req) {
+          // Synthetic request copy used just for caching (cannot clone request object...)
+          let sreq = build_synth_req_for_cache(&req, &effective_uri);
+          // try reading from cache
+          if let Some(cached_response) = cache.get(&sreq).await {
+            // if found, return it as response.
+            info!("Cache hit - Return from cache");
+            return Ok(cached_response);
+          };
+          synth_req = Some(sreq);
+        }
       }
       let res = self.request_directly(req).await;
 
-      if self.cache.is_none() {
+      // No cache configured: return the upstream response uncached.
+      let Some(cache) = self.cache.as_ref() else {
         return res.map(|inner| inner.map(ResponseBody::Incoming));
-      }
+      };
 
-      // check cacheability and store it if cacheable
-      let Ok(Some(cache_policy)) = get_policy_if_cacheable(synth_req.as_ref(), res.as_ref().ok()) else {
+      // check cacheability and store it if cacheable. `synth_req` is None when the cache was
+      // bypassed above (no client-facing effective URI); skip the store in that case too.
+      let Some(synth_req) = synth_req else {
+        return res.map(|inner| inner.map(ResponseBody::Incoming));
+      };
+      let Ok(Some(cache_policy)) = get_policy_if_cacheable(Some(&synth_req), res.as_ref().ok()) else {
         return res.map(|inner| inner.map(ResponseBody::Incoming));
       };
       let (parts, body) = res.unwrap().into_parts();
 
       // Get streamed body without waiting for the arrival of the body,
       // which is done simultaneously with caching.
-      let stream_body = self
-        .cache
-        .as_ref()
-        .unwrap()
-        .put(synth_req.unwrap().uri(), body, &cache_policy)
-        .await?;
+      let stream_body = cache.put(synth_req.uri(), body, &cache_policy).await?;
 
       // response with body being cached in background
       let new_res = Response::from_parts(parts, ResponseBody::Streamed(stream_body));
@@ -244,12 +250,69 @@ where
 }
 
 #[cfg(feature = "cache")]
-/// Build synthetic request to cache
-fn build_synth_req_for_cache<T>(req: &Request<T>) -> Request<()> {
-  let mut builder = Request::builder().method(req.method()).uri(req.uri()).version(req.version());
+/// Read the client-facing effective URI the handler placed in request extensions, if any.
+/// `None` means the forwarder must bypass the cache for this request (fail closed); the cache is
+/// never keyed on the upstream-rewritten request URI.
+fn cache_effective_uri<B>(req: &Request<B>) -> Option<http::Uri> {
+  req.extensions().get::<ClientFacingEffectiveUri>().map(|e| e.0.clone())
+}
+
+#[cfg(feature = "cache")]
+/// Build synthetic request to cache, keyed on the client-facing effective URI (not the
+/// upstream-rewritten request URI). Method, version, and headers are copied from the live
+/// request; only the URI is overridden with the client-facing effective URI so the cache key
+/// and `CachePolicy` partition per client-facing vhost and scheme.
+fn build_synth_req_for_cache<T>(req: &Request<T>, effective_uri: &http::Uri) -> Request<()> {
+  let mut builder = Request::builder()
+    .method(req.method())
+    .uri(effective_uri.clone())
+    .version(req.version());
   // TODO: Include request extensions only if a future cache policy needs them.
   for (header_key, header_value) in req.headers() {
     builder = builder.header(header_key, header_value);
   }
   builder.body(()).unwrap()
+}
+
+#[cfg(all(test, feature = "cache"))]
+mod tests {
+  use super::*;
+  use http::{HeaderValue, Method, Uri, header};
+
+  #[test]
+  fn synth_req_uses_effective_uri_not_request_uri() {
+    // The live request carries the post-rewrite upstream URI; the synthetic cache request must
+    // be keyed on the client-facing effective URI instead, while copying method and headers. A
+    // failure here guards against the cache reverting to the upstream-rewritten request URI.
+    let mut req = Request::builder()
+      .method(Method::POST)
+      .uri(Uri::from_static("http://upstream.internal:9000/u"))
+      .body(())
+      .unwrap();
+    req
+      .headers_mut()
+      .insert(header::ACCEPT_ENCODING, HeaderValue::from_static("gzip"));
+
+    let effective = Uri::from_static("https://vhost.example/u");
+    let synth = build_synth_req_for_cache(&req, &effective);
+
+    assert_eq!(synth.uri().to_string(), "https://vhost.example/u");
+    assert_eq!(synth.method(), Method::POST);
+    assert_eq!(synth.headers().get(header::ACCEPT_ENCODING).unwrap(), "gzip");
+  }
+
+  #[test]
+  fn cache_effective_uri_reads_inserted_extension_else_none() {
+    // Pins the forwarder side of the wiring: it reads back exactly the `ClientFacingEffectiveUri`
+    // type the handler inserts (type contract), and an absent extension yields None (bypass).
+    let mut req = Request::builder()
+      .uri(Uri::from_static("http://upstream.internal:9000/u"))
+      .body(())
+      .unwrap();
+    assert!(cache_effective_uri(&req).is_none(), "no extension must bypass the cache");
+    req
+      .extensions_mut()
+      .insert(ClientFacingEffectiveUri(Uri::from_static("https://vhost.example/u")));
+    assert_eq!(cache_effective_uri(&req).unwrap().to_string(), "https://vhost.example/u");
+  }
 }

--- a/rpxy-lib/src/forwarder/mod.rs
+++ b/rpxy-lib/src/forwarder/mod.rs
@@ -9,3 +9,5 @@ pub(crate) use client::ForwardRequest;
 
 #[cfg(feature = "cache")]
 pub(crate) use cache::CacheError;
+#[cfg(feature = "cache")]
+pub(crate) use cache::ClientFacingEffectiveUri;

--- a/rpxy-lib/src/message_handler/handler_manipulate_messages.rs
+++ b/rpxy-lib/src/message_handler/handler_manipulate_messages.rs
@@ -92,7 +92,16 @@ where
     remove_hop_header(headers);
     // Capture the client-visible scheme from the inbound forwarding headers BEFORE
     // add_forwarding_header() overwrites X-Forwarded-Proto with rpxy's listener TLS state.
-    // Used by the sticky-cookie `Secure` attribute on the response side.
+    // Used by the sticky-cookie `Secure` attribute (response side) and, when the cache feature
+    // is enabled, the cache effective-URI key (request side). The two consumers call the shared
+    // scheme boundary independently so neither feature depends on the other.
+    #[cfg(feature = "cache")]
+    let client_scheme = client_visible_scheme(
+      tls_enabled,
+      client_addr,
+      headers,
+      &self.globals.proxy_config.trusted_forwarded_proxies,
+    );
     #[cfg(feature = "sticky-cookie")]
     let sticky_cookie_secure = client_visible_secure(
       tls_enabled,
@@ -171,9 +180,11 @@ where
     // Default-app fallback hardening: when the request was matched via the `default_app`
     // path, the incoming `Host` is untrusted. Force-overwrite it with the default app's
     // authoritative server_name. Observational forwarding headers such as
-    // `X-Forwarded-Host` are rebuilt earlier by `add_forwarding_header()`.
-    if let Some(authoritative_host) = fallback_host {
-      apply_default_app_host_rewrite(headers, authoritative_host)?;
+    // `X-Forwarded-Host` are rebuilt earlier by `add_forwarding_header()`. Bind the rewrite
+    // target as `default_app_host` (not `authoritative_host`) so it does not shadow the outer
+    // client-facing `authoritative_host`, which the cache effective URI must keep using.
+    if let Some(default_app_host) = fallback_host {
+      apply_default_app_host_rewrite(headers, default_app_host)?;
     }
 
     // update uri in request
@@ -206,7 +217,33 @@ where
       update_request_line(req, upstream_chosen, upstream_candidates)?;
     }
 
+    // Carry the client-facing effective URI to the forwarder/cache boundary via request
+    // extensions (see `insert_client_facing_effective_uri`). Built from `client_scheme`,
+    // `authoritative_host`, and `original_uri` captured above, before the upstream rewrite, so
+    // the cache keys on the client-facing vhost and scheme rather than the upstream target.
+    #[cfg(feature = "cache")]
+    insert_client_facing_effective_uri(req, client_scheme, authoritative_host.as_deref(), &original_uri);
+
     Ok(context)
+  }
+}
+
+/// Build and insert the client-facing effective URI into `req`'s extensions for the cache
+/// boundary. Built from the client-visible `scheme`, the original (client-facing) `authority`,
+/// and the original request URI's path/query; when no safe effective URI can be built the
+/// extension is left absent so the forwarder bypasses the cache (fail closed). A free function so
+/// the handler-to-forwarder cache wiring can be unit-tested without constructing a full handler.
+#[cfg(feature = "cache")]
+fn insert_client_facing_effective_uri<B>(req: &mut Request<B>, scheme: &str, authority: Option<&str>, original_uri: &Uri) {
+  match build_client_facing_effective_uri(scheme, authority, original_uri) {
+    Some(effective_uri) => {
+      req
+        .extensions_mut()
+        .insert(crate::forwarder::ClientFacingEffectiveUri(effective_uri));
+    }
+    None => {
+      debug!("cache: no safe client-facing effective URI; cache will be bypassed for this request");
+    }
   }
 }
 
@@ -271,6 +308,31 @@ fn rebuild_path_and_query(req_uri: &Uri, replace_path: Option<&PathName>, matche
 mod tests {
   use super::*;
   use crate::name_exp::ByteName;
+
+  #[cfg(feature = "cache")]
+  #[test]
+  fn insert_effective_uri_inserts_client_facing_uri() {
+    // Pins the handler side of the cache wiring: the effective URI built from the client-visible
+    // scheme + client-facing authority + original path/query is inserted as the extension the
+    // forwarder reads. A failure here catches a dropped insert, a wrong type, or a wrong value.
+    let mut req: Request<()> = Request::new(());
+    insert_client_facing_effective_uri(&mut req, "https", Some("vhost.example"), &Uri::from_static("/p?q=1"));
+    let ext = req
+      .extensions()
+      .get::<crate::forwarder::ClientFacingEffectiveUri>()
+      .expect("effective URI extension must be present");
+    assert_eq!(ext.0.to_string(), "https://vhost.example/p?q=1");
+  }
+
+  #[cfg(feature = "cache")]
+  #[test]
+  fn insert_effective_uri_absent_authority_leaves_no_extension() {
+    // No safe authority -> no extension inserted -> the forwarder bypasses the cache (fail
+    // closed) instead of keying on the upstream-rewritten URI.
+    let mut req: Request<()> = Request::new(());
+    insert_client_facing_effective_uri(&mut req, "http", None, &Uri::from_static("/p"));
+    assert!(req.extensions().get::<crate::forwarder::ClientFacingEffectiveUri>().is_none());
+  }
 
   #[cfg(any(feature = "http3-quinn", feature = "http3-s2n"))]
   fn proxy_config_for_h3_alt_svc(http3: bool, public_https_port: Option<u16>) -> crate::globals::ProxyConfig {

--- a/rpxy-lib/src/message_handler/header_ops/forwarding.rs
+++ b/rpxy-lib/src/message_handler/header_ops/forwarding.rs
@@ -835,20 +835,56 @@ fn push_forwarded_port(out: &mut String, port: &ForwardedPort) {
 }
 
 /* -------------------------------------------------------------------------------------------------- */
-/* Client-visible scheme detection (used by sticky-cookie Secure attribute                            */
+/* Client-visible scheme detection (sticky-cookie Secure attribute + cache effective-URI key)                            */
 /* -------------------------------------------------------------------------------------------------- */
 
-/// Decide whether the request's client-visible scheme is HTTPS, for the purpose of
-/// setting the `Secure` attribute on response Set-Cookie values.
+/// Decide the request's client-visible scheme (`"https"` or `"http"`).
 ///
-/// 1. If the rpxy listener is TLS-terminating, return true.
+/// Shared by the sticky-cookie `Secure` attribute and the cache key (client-facing effective
+/// URI). The decision is fail-closed and bounded by the trusted-forwarded-proxy boundary:
+///
+/// 1. If the rpxy listener is TLS-terminating, return `"https"`.
 /// 2. Otherwise, only honor forwarding-derived scheme when the immediate peer is in
-///    `trusted_forwarded_proxies` (same trust boundary as the forwarding-header policy).
+///    `trusted_forwarded_proxies` (same trust boundary as the forwarding-header policy); an
+///    untrusted peer is always `"http"` regardless of inbound forwarding headers.
 /// 3. Header priority: `X-Forwarded-Proto` first comma-element wins; fall back to the
 ///    `proto=` parameter of the first `Forwarded` entry.
-/// 4. Any parse failure fails closed to false (debug-logged, not warn-logged) and does
-///    NOT fall through to the lower-priority source — a malformed `X-Forwarded-Proto`
-///    short-circuits without consulting `Forwarded`.
+/// 4. Only a `https` value (case-insensitive) maps to `"https"`; every other value, an absent
+///    value, or any parse failure maps to `"http"`. A parse failure does NOT fall through to
+///    the lower-priority source — a malformed `X-Forwarded-Proto` short-circuits without
+///    consulting `Forwarded`.
+#[cfg(any(feature = "cache", feature = "sticky-cookie"))]
+pub(in crate::message_handler) fn client_visible_scheme(
+  tls_enabled: bool,
+  client_addr: &SocketAddr,
+  headers: &HeaderMap,
+  trusted_forwarded_proxies: &[IpNet],
+) -> &'static str {
+  if tls_enabled {
+    return "https";
+  }
+  let peer_ip = canonicalize_ip(client_addr.to_canonical().ip());
+  if !is_trusted_proxy(&peer_ip, trusted_forwarded_proxies) {
+    return "http";
+  }
+  let scheme = match xforwarded_proto_first(headers) {
+    Err(()) => return "http", // XFP parse failure: fail closed, do NOT fall through
+    Ok(Some(s)) => Some(s),
+    Ok(None) => match forwarded_first_proto(headers) {
+      Err(()) => return "http", // Forwarded parse failure: fail closed
+      Ok(s) => s,
+    },
+  };
+  if scheme.is_some_and(|s| s.eq_ignore_ascii_case("https")) {
+    "https"
+  } else {
+    "http"
+  }
+}
+
+/// Whether the request's client-visible scheme is HTTPS, for the sticky-cookie `Secure`
+/// attribute. Thin wrapper over [`client_visible_scheme`]; `Secure` is set iff the scheme is
+/// `https`.
 #[cfg(feature = "sticky-cookie")]
 pub(in crate::message_handler) fn client_visible_secure(
   tls_enabled: bool,
@@ -856,22 +892,7 @@ pub(in crate::message_handler) fn client_visible_secure(
   headers: &HeaderMap,
   trusted_forwarded_proxies: &[IpNet],
 ) -> bool {
-  if tls_enabled {
-    return true;
-  }
-  let peer_ip = canonicalize_ip(client_addr.to_canonical().ip());
-  if !is_trusted_proxy(&peer_ip, trusted_forwarded_proxies) {
-    return false;
-  }
-  let scheme = match xforwarded_proto_first(headers) {
-    Err(()) => return false, // XFP parse failure: fail closed, do NOT fall through
-    Ok(Some(s)) => Some(s),
-    Ok(None) => match forwarded_first_proto(headers) {
-      Err(()) => return false, // Forwarded parse failure: fail closed
-      Ok(s) => s,
-    },
-  };
-  scheme.is_some_and(|s| s.eq_ignore_ascii_case("https"))
+  client_visible_scheme(tls_enabled, client_addr, headers, trusted_forwarded_proxies) == "https"
 }
 
 /// Read the first comma-separated element of `X-Forwarded-Proto`.
@@ -883,7 +904,7 @@ pub(in crate::message_handler) fn client_visible_secure(
 /// - `Err(())` when the header is present but unreadable (non-UTF-8 etc.). Caller MUST
 ///   NOT fall back; doing so would let a malformed XFP enable a low-priority `Forwarded:
 ///   proto=https` to elevate `Secure`.
-#[cfg(feature = "sticky-cookie")]
+#[cfg(any(feature = "cache", feature = "sticky-cookie"))]
 fn xforwarded_proto_first(headers: &HeaderMap) -> Result<Option<String>, ()> {
   let raw = match join_header_values(headers, X_FORWARDED_PROTO) {
     Ok(Some(v)) => v,
@@ -911,7 +932,7 @@ fn xforwarded_proto_first(headers: &HeaderMap) -> Result<Option<String>, ()> {
 /// - `Ok(None)` when the header is absent, the first entry has no `proto=`, or the value
 ///   is empty.
 /// - `Err(())` on header value / quoted-string parse failure (fail-closed signal).
-#[cfg(feature = "sticky-cookie")]
+#[cfg(any(feature = "cache", feature = "sticky-cookie"))]
 fn forwarded_first_proto(headers: &HeaderMap) -> Result<Option<String>, ()> {
   let raw = match join_header_values(headers, header::FORWARDED) {
     Ok(Some(v)) => v,
@@ -944,6 +965,31 @@ fn forwarded_first_proto(headers: &HeaderMap) -> Result<Option<String>, ()> {
     };
   }
   Ok(None)
+}
+
+/// Build the client-facing effective request URI used as the cache key input:
+/// `scheme://authority/path?query`. Returns `None` when no safe authority is available, so the
+/// caller bypasses the cache rather than keying on the upstream-rewritten URI (fail closed).
+///
+/// - `scheme`: the client-visible scheme from [`client_visible_scheme`] (`"http"`/`"https"`).
+/// - `authority`: the original authoritative host (`host[:port]`) captured before the upstream
+///   rewrite; `None` (no Host and no URI authority) yields `None`.
+/// - `original_uri`: the request URI as received from the client; its path-and-query is used,
+///   defaulting to `/` when absent.
+#[cfg(feature = "cache")]
+pub(in crate::message_handler) fn build_client_facing_effective_uri(
+  scheme: &str,
+  authority: Option<&str>,
+  original_uri: &Uri,
+) -> Option<Uri> {
+  let authority = authority?;
+  let path_and_query = original_uri.path_and_query().map(|pq| pq.as_str()).unwrap_or("/");
+  Uri::builder()
+    .scheme(scheme)
+    .authority(authority)
+    .path_and_query(path_and_query)
+    .build()
+    .ok()
 }
 
 #[cfg(test)]
@@ -1881,21 +1927,149 @@ mod tests {
     assert_eq!(headers.get(PROXY).unwrap(), "");
   }
 
-  /* ---------------------- client_visible_secure ---------------------- */
+  /* ---------------------- client_visible_secure / client_visible_scheme ---------------------- */
 
-  #[cfg(feature = "sticky-cookie")]
+  // Shared by the sticky-cookie wrapper tests and the cache scheme/effective-URI tests; the
+  // scheme boundary is shared by both features.
+  #[cfg(any(feature = "cache", feature = "sticky-cookie"))]
   fn untrusted_addr() -> SocketAddr {
     "203.0.113.10:4321".parse().unwrap()
   }
 
-  #[cfg(feature = "sticky-cookie")]
+  #[cfg(any(feature = "cache", feature = "sticky-cookie"))]
   fn trusted_addr() -> SocketAddr {
     "10.1.2.3:1234".parse().unwrap()
   }
 
-  #[cfg(feature = "sticky-cookie")]
+  #[cfg(any(feature = "cache", feature = "sticky-cookie"))]
   fn cidr_10() -> Vec<IpNet> {
     trusted(&["10.0.0.0/8"])
+  }
+
+  /* -------- client_visible_scheme (cache effective-URI scheme source) -------- */
+
+  #[cfg(feature = "cache")]
+  #[test]
+  fn cvscheme_tls_listener_is_https_regardless_of_headers() {
+    let mut headers = HeaderMap::new();
+    headers.insert(X_FORWARDED_PROTO, HeaderValue::from_static("http"));
+    assert_eq!(client_visible_scheme(true, &untrusted_addr(), &headers, &[]), "https");
+  }
+
+  #[cfg(feature = "cache")]
+  #[test]
+  fn cvscheme_untrusted_plaintext_peer_is_http_even_with_xfp_https() {
+    let mut headers = HeaderMap::new();
+    headers.insert(X_FORWARDED_PROTO, HeaderValue::from_static("https"));
+    assert_eq!(client_visible_scheme(false, &untrusted_addr(), &headers, &cidr_10()), "http");
+  }
+
+  #[cfg(feature = "cache")]
+  #[test]
+  fn cvscheme_trusted_plaintext_peer_honors_xfp_https() {
+    let mut headers = HeaderMap::new();
+    headers.insert(X_FORWARDED_PROTO, HeaderValue::from_static("https"));
+    assert_eq!(client_visible_scheme(false, &trusted_addr(), &headers, &cidr_10()), "https");
+  }
+
+  #[cfg(feature = "cache")]
+  #[test]
+  fn cvscheme_trusted_plaintext_peer_falls_back_to_forwarded_proto() {
+    let mut headers = HeaderMap::new();
+    headers.insert(header::FORWARDED, HeaderValue::from_static("proto=https"));
+    assert_eq!(client_visible_scheme(false, &trusted_addr(), &headers, &cidr_10()), "https");
+  }
+
+  #[cfg(feature = "cache")]
+  #[test]
+  fn cvscheme_malformed_xfp_fails_closed_to_http() {
+    // Non-UTF-8 X-Forwarded-Proto must short-circuit to http even with a valid lower-priority
+    // Forwarded: proto=https present.
+    let mut headers = HeaderMap::new();
+    headers.insert(
+      X_FORWARDED_PROTO,
+      HeaderValue::from_bytes(b"\xffhttps").expect("HeaderValue accepts non-UTF-8 bytes"),
+    );
+    headers.insert(header::FORWARDED, HeaderValue::from_static("proto=https"));
+    assert_eq!(client_visible_scheme(false, &trusted_addr(), &headers, &cidr_10()), "http");
+  }
+
+  /* -------- build_client_facing_effective_uri -------- */
+
+  #[cfg(feature = "cache")]
+  #[test]
+  fn effuri_origin_form_http() {
+    let original = Uri::from_static("/path?q=1");
+    let uri = build_client_facing_effective_uri("http", Some("app.example"), &original).unwrap();
+    assert_eq!(uri.to_string(), "http://app.example/path?q=1");
+  }
+
+  #[cfg(feature = "cache")]
+  #[test]
+  fn effuri_origin_form_https() {
+    let original = Uri::from_static("/path?q=1");
+    let uri = build_client_facing_effective_uri("https", Some("app.example"), &original).unwrap();
+    assert_eq!(uri.to_string(), "https://app.example/path?q=1");
+  }
+
+  #[cfg(feature = "cache")]
+  #[test]
+  fn effuri_authority_with_port_is_preserved() {
+    let original = Uri::from_static("/p");
+    let uri = build_client_facing_effective_uri("https", Some("app.example:8443"), &original).unwrap();
+    assert_eq!(uri.to_string(), "https://app.example:8443/p");
+  }
+
+  #[cfg(feature = "cache")]
+  #[test]
+  fn effuri_missing_path_defaults_to_slash() {
+    // Authority-form original URI (no path component, e.g. CONNECT) -> path defaults to "/".
+    let mut parts = http::uri::Parts::default();
+    parts.authority = Some("host.example".parse().unwrap());
+    let original = Uri::from_parts(parts).unwrap();
+    assert!(original.path_and_query().is_none(), "test precondition: no path_and_query");
+    let uri = build_client_facing_effective_uri("http", Some("app.example"), &original).unwrap();
+    assert_eq!(uri.to_string(), "http://app.example/");
+  }
+
+  #[cfg(feature = "cache")]
+  #[test]
+  fn effuri_absent_authority_returns_none_for_cache_bypass() {
+    let original = Uri::from_static("/p");
+    assert!(build_client_facing_effective_uri("http", None, &original).is_none());
+  }
+
+  #[cfg(feature = "cache")]
+  #[test]
+  fn effuri_authority_param_wins_over_original_uri_authority() {
+    // Absolute-form original URI carries its own authority, but the effective URI must use the
+    // authoritative-host argument (the client-facing authority), not the URI's authority.
+    let original = Uri::from_static("http://upstream.internal:9000/p?q=2");
+    let uri = build_client_facing_effective_uri("https", Some("vhost.example"), &original).unwrap();
+    assert_eq!(uri.to_string(), "https://vhost.example/p?q=2");
+  }
+
+  /* -------- cache-key partitioning (regression intent for cross-vhost cache poisoning) -------- */
+
+  #[cfg(feature = "cache")]
+  #[test]
+  fn effuri_distinct_authority_yields_distinct_uri() {
+    // Two client-facing vhosts that may rewrite to the same upstream must produce distinct
+    // effective URIs (hence distinct cache keys): this is the cross-vhost-poisoning guard.
+    let original = Uri::from_static("/shared/path");
+    let a = build_client_facing_effective_uri("https", Some("a.example"), &original).unwrap();
+    let b = build_client_facing_effective_uri("https", Some("b.example"), &original).unwrap();
+    assert_ne!(a.to_string(), b.to_string());
+  }
+
+  #[cfg(feature = "cache")]
+  #[test]
+  fn effuri_distinct_scheme_yields_distinct_uri() {
+    // http and https variants of the same vhost+path must not collide on one cache key.
+    let original = Uri::from_static("/p");
+    let http = build_client_facing_effective_uri("http", Some("app.example"), &original).unwrap();
+    let https = build_client_facing_effective_uri("https", Some("app.example"), &original).unwrap();
+    assert_ne!(http.to_string(), https.to_string());
   }
 
   #[cfg(feature = "sticky-cookie")]

--- a/rpxy-lib/src/message_handler/header_ops/mod.rs
+++ b/rpxy-lib/src/message_handler/header_ops/mod.rs
@@ -10,6 +10,10 @@ pub(super) use common::{add_header_entry_overwrite_if_exist, host_from_uri_or_ho
 pub(super) use forwarding::add_forwarding_header;
 #[cfg(feature = "sticky-cookie")]
 pub(super) use forwarding::client_visible_secure;
+// Only the cache path consumes the re-exported `client_visible_scheme` name; under
+// sticky-cookie the scheme helper is reached internally via `client_visible_secure`.
+#[cfg(feature = "cache")]
+pub(super) use forwarding::{build_client_facing_effective_uri, client_visible_scheme};
 pub(super) use hop::{extract_upgrade, remove_connection_header, remove_hop_header};
 pub(crate) use redact::DebugHeaders;
 #[cfg(feature = "sticky-cookie")]


### PR DESCRIPTION
- **Fix: partition the HTTP cache by the client-facing effective request URI (scheme + authoritative host + path/query) to prevent cross-virtual-host cache poisoning.** Previously, with the `cache` feature enabled, entries were keyed on the request URI after rewrite to the upstream target, so two virtual hosts sharing one upstream could serve each other's cached responses. The scheme is derived with the same trusted-forwarded-proxy boundary used elsewhere, and requests without a safe client-facing URI are served uncached (fail closed). This may lower the cache hit rate when virtual hosts intentionally share a backend; no config change is required.