### PR TITLE
feat(revert): The per-virtual-host cache partitioning introduced in 0.13.3 has been withdrawn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.13.4 or 0.14.0 (Unreleased)
 
+### Important Changes
+
+- **The per-virtual-host cache partitioning introduced in 0.13.3 has been withdrawn.** With the `cache` feature compiled in, every request paid for the partitioning (capturing the client-visible scheme and building the client-facing URI) even when no cache was configured, and every cache hit built an extra synthetic request - a cost on the request-forwarding hot path that this proxy layer should not carry. Cache entries are again keyed on the request URI forwarded upstream (after the rewrite to the upstream target), as in releases before 0.13.3, so the partitioning by client-facing effective request URI described in the 0.13.3 notes is no longer current behavior. Correctness for cached responses that vary on forwarded attributes now relies on the origin declaring the variation, per the standard HTTP shared-cache contract: a backend that serves different content depending on the original (client-facing) host, scheme, or URI - notably when several virtual hosts are flattened onto one upstream via `set_upstream_host` or the `default_app` fallback - must emit an appropriate `Vary` header on such responses or mark them non-cacheable.
+
 ## 0.13.3
 
 ### Important Changes

--- a/README.md
+++ b/README.md
@@ -400,7 +400,7 @@ A *storable* (in the context of an HTTP message) response is stored if its size 
 
 The total bytes retained by the cache are additionally capped by `max_cache_total_size` (default 1 GiB): when storing a new response would exceed it, the least recently used entries are evicted until the new response fits. The ceiling bounds the data referenced by live cache entries; transient extra disk usage can briefly appear while responses are being stored or evicted files are being deleted.
 
-Cache entries are keyed on the scheme, host, and path/query the client requested, so different virtual hosts never share cached responses even when they proxy to the same backend.
+Cache entries are keyed on the request URI forwarded upstream, and response variation is governed by the standard HTTP caching contract: if a backend serves different content depending on forwarded attributes such as the original host, scheme, or URI — in particular when multiple virtual hosts are flattened onto one upstream via `set_upstream_host` or the `default_app` fallback — it must declare an appropriate `Vary` header on such responses (or make them non-cacheable).
 
 ### Automated Certificate Issuance and Renewal via TLS-ALPN-01 ACME Protocol
 

--- a/config-example.toml
+++ b/config-example.toml
@@ -229,6 +229,7 @@ max_cache_entry = 1000               # optional. default is 1k
 max_cache_each_size = 65535          # optional. default is 64k
 max_cache_each_size_on_memory = 65535 # optional. default is 64k, same as max_cache_each_size (cacheable objects are served from memory by default; the file tier engages when max_cache_each_size is raised beyond this). if 0, it is always file cache. Worst-case memory use is max_cache_entry x this value.
 max_cache_total_size = "1g"          # optional. default is 1 GiB. ceiling on the total bytes retained by the cache across both tiers; accepts an integer (bytes) or a string with a binary suffix ("256m", "1g"). set "unlimited" to disable (0 also works, but note that 0 means "always file cache" for max_cache_each_size_on_memory above, so the string form is recommended here).
+# Note: cached responses are keyed on the request URI forwarded upstream. A backend that varies content by the original (client-facing) host, scheme, or URI - e.g. multiple virtual hosts flattened onto one upstream via set_upstream_host or default_app - must emit an appropriate `Vary` header on cacheable responses or mark them non-cacheable.
 
 # ACME settings. Unless specified, ACME is disabled.
 [experimental.acme]

--- a/rpxy-lib/src/forwarder/cache/cache_main.rs
+++ b/rpxy-lib/src/forwarder/cache/cache_main.rs
@@ -140,7 +140,7 @@ impl RpxyCache {
         return;
       };
 
-      let cache_key = derive_cache_key_from_effective_uri(&uri);
+      let cache_key = derive_cache_key_from_uri(&uri);
       let cache_object = CacheObject::new(policy_clone, target, hash, size);
       // The file (if any) is now fully written and renamed into place, so it is safe to publish
       // the metadata; this also accounts for the file count and evicts any displaced file.
@@ -159,7 +159,7 @@ impl RpxyCache {
       self.count().await,
       self.inner.total_bytes()
     );
-    let cache_key = derive_cache_key_from_effective_uri(req.uri());
+    let cache_key = derive_cache_key_from_uri(req.uri());
 
     // First check cache chance
     let cached_object = self.inner.get(&cache_key).ok()??;
@@ -1101,11 +1101,12 @@ fn derive_filename_from_uri(uri: &hyper::Uri) -> String {
   general_purpose::URL_SAFE_NO_PAD.encode(digest)
 }
 
-/// Derive the LRU cache key from the client-facing effective request URI. The caller MUST pass
-/// the effective URI (scheme + authority + path/query, as the client addressed it), NOT the
-/// upstream-rewritten request URI - otherwise distinct client-facing vhosts that rewrite to the
-/// same upstream target would collide on one key (cross-vhost cache poisoning).
-fn derive_cache_key_from_effective_uri(uri: &hyper::Uri) -> String {
+/// Derive the LRU cache key from the URI passed into the cache layer - the upstream-facing
+/// request URI seen by the forwarder after the handler's rewrite. Host matching and `Vary`
+/// matching are delegated to `http-cache-semantics`. On Host-flattened paths (such as
+/// `set_upstream_host` or the `default_app` fallback) the backend must emit an appropriate
+/// `Vary` header, or avoid cacheable responses, if forwarded attributes change response content.
+fn derive_cache_key_from_uri(uri: &hyper::Uri) -> String {
   uri.to_string()
 }
 
@@ -1380,7 +1381,7 @@ mod tests {
       Bytes::from_static(&[0u8; 32]),
       object.len(),
     );
-    let cache_key = derive_cache_key_from_effective_uri(&uri);
+    let cache_key = derive_cache_key_from_uri(&uri);
     cache.inner.push(&cache_key, &cache_object).unwrap();
 
     let req = Request::builder().uri(uri.clone()).body(()).unwrap();
@@ -1572,7 +1573,7 @@ mod tests {
     let manager = LruCacheManager::new(10, None);
     let file_store = test_file_store();
     let uri: Uri = "http://example.com/x".parse().unwrap();
-    let key = derive_cache_key_from_effective_uri(&uri);
+    let key = derive_cache_key_from_uri(&uri);
 
     let path_a = dir.join("file-a");
     fs::write(&path_a, b"AAAA").await.unwrap();
@@ -1612,7 +1613,7 @@ mod tests {
     let manager = LruCacheManager::new(10, None);
     let file_store = test_file_store();
     let uri: Uri = "http://example.com/x".parse().unwrap();
-    let key = derive_cache_key_from_effective_uri(&uri);
+    let key = derive_cache_key_from_uri(&uri);
 
     let path_a = dir.join("file-a");
     fs::write(&path_a, b"AAAA").await.unwrap();
@@ -1655,7 +1656,7 @@ mod tests {
       Bytes::from_static(&[1u8; 32]),
       4,
     );
-    publish_cache_object(&manager, &file_store, &derive_cache_key_from_effective_uri(&uri_x), obj_a).await;
+    publish_cache_object(&manager, &file_store, &derive_cache_key_from_uri(&uri_x), obj_a).await;
     assert_eq!(file_store.count().await, 1);
 
     let uri_y: Uri = "http://example.com/y".parse().unwrap();
@@ -1665,7 +1666,7 @@ mod tests {
       Bytes::from_static(&[2u8; 32]),
       5,
     );
-    publish_cache_object(&manager, &file_store, &derive_cache_key_from_effective_uri(&uri_y), obj_b).await;
+    publish_cache_object(&manager, &file_store, &derive_cache_key_from_uri(&uri_y), obj_b).await;
 
     assert!(
       fs::metadata(&path_a).await.is_err(),
@@ -1690,7 +1691,7 @@ mod tests {
   /// Parse a URI and derive its cache key (shorthand for the ceiling tests).
   fn key_of(uri: &str) -> (Uri, String) {
     let uri: Uri = uri.parse().unwrap();
-    let key = derive_cache_key_from_effective_uri(&uri);
+    let key = derive_cache_key_from_uri(&uri);
     (uri, key)
   }
 
@@ -2357,7 +2358,7 @@ mod tests {
   async fn evict_if_generation_spares_newer_entry() {
     let manager = LruCacheManager::new(10, None);
     let uri: Uri = "http://example.com/x".parse().unwrap();
-    let key = derive_cache_key_from_effective_uri(&uri);
+    let key = derive_cache_key_from_uri(&uri);
 
     let obj_a = CacheObject::new(
       fresh_policy(&uri),

--- a/rpxy-lib/src/forwarder/cache/mod.rs
+++ b/rpxy-lib/src/forwarder/cache/mod.rs
@@ -3,11 +3,3 @@ mod cache_main;
 
 pub use cache_error::CacheError;
 pub(crate) use cache_main::{RpxyCache, get_policy_if_cacheable};
-
-/// Client-facing effective request URI (scheme + authority + path/query), captured by the
-/// handler before the upstream rewrite and carried to the forwarder via request extensions.
-/// Used as the cache key input so cache entries are partitioned per client-facing vhost and
-/// scheme instead of per upstream target. When this extension is absent the forwarder bypasses
-/// the cache (fail closed) rather than keying on the upstream-rewritten URI.
-#[derive(Clone, Debug)]
-pub(crate) struct ClientFacingEffectiveUri(pub(crate) http::Uri);

--- a/rpxy-lib/src/forwarder/client.rs
+++ b/rpxy-lib/src/forwarder/client.rs
@@ -14,7 +14,7 @@ use hyper_util::client::legacy::{
 use std::sync::Arc;
 
 #[cfg(feature = "cache")]
-use super::cache::{ClientFacingEffectiveUri, RpxyCache, get_policy_if_cacheable};
+use super::cache::{RpxyCache, get_policy_if_cacheable};
 
 #[async_trait]
 /// Definition of the forwarder that simply forward requests from downstream client to upstream app servers.
@@ -44,36 +44,29 @@ where
   async fn request(&self, req: Request<B1>) -> Result<Response<ResponseBody>, Self::Error> {
     #[cfg(feature = "cache")]
     {
-      let mut synth_req = None;
-      if let Some(cache) = self.cache.as_ref() {
-        // The cache is keyed on the client-facing effective URI captured by the handler before
-        // the upstream rewrite and carried in request extensions. When it is absent we fail
-        // closed: bypass the cache entirely rather than keying on the upstream-rewritten request
-        // URI (which would collide across client-facing vhosts sharing one upstream target).
-        if let Some(effective_uri) = cache_effective_uri(&req) {
-          // Synthetic request copy used just for caching (cannot clone request object...)
-          let sreq = build_synth_req_for_cache(&req, &effective_uri);
-          // try reading from cache
-          if let Some(cached_response) = cache.get(&sreq).await {
-            // if found, return it as response.
-            info!("Cache hit - Return from cache");
-            return Ok(cached_response);
-          };
-          synth_req = Some(sreq);
-        }
+      // No cache configured: forward directly and return the upstream response uncached.
+      let Some(cache) = self.cache.as_ref() else {
+        return self
+          .request_directly(req)
+          .await
+          .map(|inner| inner.map(ResponseBody::Incoming));
+      };
+
+      // The cache is keyed on the request URI seen here, i.e. the upstream-facing URI after the
+      // handler's rewrite. Host and `Vary` matching are delegated to `http-cache-semantics`.
+      // try reading from cache
+      if let Some(cached_response) = cache.get(&req).await {
+        // if found, return it as response.
+        info!("Cache hit - Return from cache");
+        return Ok(cached_response);
       }
+
+      // Synthetic request copy used just for caching (cannot clone request object...); built only
+      // on the miss path, before the live request is moved into the upstream client below.
+      let synth_req = build_synth_req_for_cache(&req);
       let res = self.request_directly(req).await;
 
-      // No cache configured: return the upstream response uncached.
-      let Some(cache) = self.cache.as_ref() else {
-        return res.map(|inner| inner.map(ResponseBody::Incoming));
-      };
-
-      // check cacheability and store it if cacheable. `synth_req` is None when the cache was
-      // bypassed above (no client-facing effective URI); skip the store in that case too.
-      let Some(synth_req) = synth_req else {
-        return res.map(|inner| inner.map(ResponseBody::Incoming));
-      };
+      // check cacheability and store it if cacheable
       let Ok(Some(cache_policy)) = get_policy_if_cacheable(Some(&synth_req), res.as_ref().ok()) else {
         return res.map(|inner| inner.map(ResponseBody::Incoming));
       };
@@ -249,23 +242,11 @@ where
 }
 
 #[cfg(feature = "cache")]
-/// Read the client-facing effective URI the handler placed in request extensions, if any.
-/// `None` means the forwarder must bypass the cache for this request (fail closed); the cache is
-/// never keyed on the upstream-rewritten request URI.
-fn cache_effective_uri<B>(req: &Request<B>) -> Option<http::Uri> {
-  req.extensions().get::<ClientFacingEffectiveUri>().map(|e| e.0.clone())
-}
-
-#[cfg(feature = "cache")]
-/// Build synthetic request to cache, keyed on the client-facing effective URI (not the
-/// upstream-rewritten request URI). Method, version, and headers are copied from the live
-/// request; only the URI is overridden with the client-facing effective URI so the cache key
-/// and `CachePolicy` partition per client-facing vhost and scheme.
-fn build_synth_req_for_cache<T>(req: &Request<T>, effective_uri: &http::Uri) -> Request<()> {
-  let mut builder = Request::builder()
-    .method(req.method())
-    .uri(effective_uri.clone())
-    .version(req.version());
+/// Build synthetic request to cache (cannot clone request object). The live request is moved
+/// into the upstream client on the miss path, so this copy carries the URI, method, version,
+/// and headers the cache layer needs for the `CachePolicy` and the store.
+fn build_synth_req_for_cache<T>(req: &Request<T>) -> Request<()> {
+  let mut builder = Request::builder().method(req.method()).uri(req.uri()).version(req.version());
   // TODO: Include request extensions only if a future cache policy needs them.
   for (header_key, header_value) in req.headers() {
     builder = builder.header(header_key, header_value);
@@ -279,39 +260,24 @@ mod tests {
   use http::{HeaderValue, Method, Uri, header};
 
   #[test]
-  fn synth_req_uses_effective_uri_not_request_uri() {
-    // The live request carries the post-rewrite upstream URI; the synthetic cache request must
-    // be keyed on the client-facing effective URI instead, while copying method and headers. A
-    // failure here guards against the cache reverting to the upstream-rewritten request URI.
+  fn synth_req_copies_live_request_uri_method_version_and_headers() {
+    // The synthetic cache request must mirror the live request (URI included): the cache is
+    // keyed on the request URI seen by the forwarder, not on any separately carried URI.
     let mut req = Request::builder()
       .method(Method::POST)
       .uri(Uri::from_static("http://upstream.internal:9000/u"))
+      .version(http::Version::HTTP_2)
       .body(())
       .unwrap();
     req
       .headers_mut()
       .insert(header::ACCEPT_ENCODING, HeaderValue::from_static("gzip"));
 
-    let effective = Uri::from_static("https://vhost.example/u");
-    let synth = build_synth_req_for_cache(&req, &effective);
+    let synth = build_synth_req_for_cache(&req);
 
-    assert_eq!(synth.uri().to_string(), "https://vhost.example/u");
+    assert_eq!(synth.uri(), &Uri::from_static("http://upstream.internal:9000/u"));
     assert_eq!(synth.method(), Method::POST);
+    assert_eq!(synth.version(), http::Version::HTTP_2);
     assert_eq!(synth.headers().get(header::ACCEPT_ENCODING).unwrap(), "gzip");
-  }
-
-  #[test]
-  fn cache_effective_uri_reads_inserted_extension_else_none() {
-    // Pins the forwarder side of the wiring: it reads back exactly the `ClientFacingEffectiveUri`
-    // type the handler inserts (type contract), and an absent extension yields None (bypass).
-    let mut req = Request::builder()
-      .uri(Uri::from_static("http://upstream.internal:9000/u"))
-      .body(())
-      .unwrap();
-    assert!(cache_effective_uri(&req).is_none(), "no extension must bypass the cache");
-    req
-      .extensions_mut()
-      .insert(ClientFacingEffectiveUri(Uri::from_static("https://vhost.example/u")));
-    assert_eq!(cache_effective_uri(&req).unwrap().to_string(), "https://vhost.example/u");
   }
 }

--- a/rpxy-lib/src/forwarder/mod.rs
+++ b/rpxy-lib/src/forwarder/mod.rs
@@ -9,5 +9,3 @@ pub(crate) use client::ForwardRequest;
 
 #[cfg(feature = "cache")]
 pub(crate) use cache::CacheError;
-#[cfg(feature = "cache")]
-pub(crate) use cache::ClientFacingEffectiveUri;

--- a/rpxy-lib/src/message_handler/handler_manipulate_messages.rs
+++ b/rpxy-lib/src/message_handler/handler_manipulate_messages.rs
@@ -91,16 +91,7 @@ where
     remove_hop_header(headers);
     // Capture the client-visible scheme from the inbound forwarding headers BEFORE
     // add_forwarding_header() overwrites X-Forwarded-Proto with rpxy's listener TLS state.
-    // Used by the sticky-cookie `Secure` attribute (response side) and, when the cache feature
-    // is enabled, the cache effective-URI key (request side). The two consumers call the shared
-    // scheme boundary independently so neither feature depends on the other.
-    #[cfg(feature = "cache")]
-    let client_scheme = client_visible_scheme(
-      tls_enabled,
-      client_addr,
-      headers,
-      &self.globals.proxy_config.trusted_forwarded_proxies,
-    );
+    // Used by the sticky-cookie `Secure` attribute (response side).
     #[cfg(feature = "sticky-cookie")]
     let sticky_cookie_secure = client_visible_secure(
       tls_enabled,
@@ -179,7 +170,7 @@ where
     // authoritative server_name. Observational forwarding headers such as
     // `X-Forwarded-Host` are rebuilt earlier by `add_forwarding_header()`. Bind the rewrite
     // target as `default_app_host` (not `authoritative_host`) so it does not shadow the outer
-    // client-facing `authoritative_host`, which the cache effective URI must keep using.
+    // client-facing `authoritative_host` captured above.
     if let Some(default_app_host) = fallback_host {
       apply_default_app_host_rewrite(headers, default_app_host)?;
     }
@@ -214,33 +205,7 @@ where
       update_request_line(req, upstream_chosen, upstream_candidates)?;
     }
 
-    // Carry the client-facing effective URI to the forwarder/cache boundary via request
-    // extensions (see `insert_client_facing_effective_uri`). Built from `client_scheme`,
-    // `authoritative_host`, and `original_uri` captured above, before the upstream rewrite, so
-    // the cache keys on the client-facing vhost and scheme rather than the upstream target.
-    #[cfg(feature = "cache")]
-    insert_client_facing_effective_uri(req, client_scheme, authoritative_host.as_deref(), &original_uri);
-
     Ok(context)
-  }
-}
-
-/// Build and insert the client-facing effective URI into `req`'s extensions for the cache
-/// boundary. Built from the client-visible `scheme`, the original (client-facing) `authority`,
-/// and the original request URI's path/query; when no safe effective URI can be built the
-/// extension is left absent so the forwarder bypasses the cache (fail closed). A free function so
-/// the handler-to-forwarder cache wiring can be unit-tested without constructing a full handler.
-#[cfg(feature = "cache")]
-fn insert_client_facing_effective_uri<B>(req: &mut Request<B>, scheme: &str, authority: Option<&str>, original_uri: &Uri) {
-  match build_client_facing_effective_uri(scheme, authority, original_uri) {
-    Some(effective_uri) => {
-      req
-        .extensions_mut()
-        .insert(crate::forwarder::ClientFacingEffectiveUri(effective_uri));
-    }
-    None => {
-      debug!("cache: no safe client-facing effective URI; cache will be bypassed for this request");
-    }
   }
 }
 
@@ -305,31 +270,6 @@ fn rebuild_path_and_query(req_uri: &Uri, replace_path: Option<&PathName>, matche
 mod tests {
   use super::*;
   use crate::name_exp::ByteName;
-
-  #[cfg(feature = "cache")]
-  #[test]
-  fn insert_effective_uri_inserts_client_facing_uri() {
-    // Pins the handler side of the cache wiring: the effective URI built from the client-visible
-    // scheme + client-facing authority + original path/query is inserted as the extension the
-    // forwarder reads. A failure here catches a dropped insert, a wrong type, or a wrong value.
-    let mut req: Request<()> = Request::new(());
-    insert_client_facing_effective_uri(&mut req, "https", Some("vhost.example"), &Uri::from_static("/p?q=1"));
-    let ext = req
-      .extensions()
-      .get::<crate::forwarder::ClientFacingEffectiveUri>()
-      .expect("effective URI extension must be present");
-    assert_eq!(ext.0.to_string(), "https://vhost.example/p?q=1");
-  }
-
-  #[cfg(feature = "cache")]
-  #[test]
-  fn insert_effective_uri_absent_authority_leaves_no_extension() {
-    // No safe authority -> no extension inserted -> the forwarder bypasses the cache (fail
-    // closed) instead of keying on the upstream-rewritten URI.
-    let mut req: Request<()> = Request::new(());
-    insert_client_facing_effective_uri(&mut req, "http", None, &Uri::from_static("/p"));
-    assert!(req.extensions().get::<crate::forwarder::ClientFacingEffectiveUri>().is_none());
-  }
 
   #[cfg(any(feature = "http3-quinn", feature = "http3-s2n"))]
   fn proxy_config_for_h3_alt_svc(http3: bool, public_https_port: Option<u16>) -> crate::globals::ProxyConfig {

--- a/rpxy-lib/src/message_handler/header_ops/forwarding.rs
+++ b/rpxy-lib/src/message_handler/header_ops/forwarding.rs
@@ -835,13 +835,13 @@ fn push_forwarded_port(out: &mut String, port: &ForwardedPort) {
 }
 
 /* -------------------------------------------------------------------------------------------------- */
-/* Client-visible scheme detection (sticky-cookie Secure attribute + cache effective-URI key)                            */
+/* Client-visible scheme detection (sticky-cookie Secure attribute)                                    */
 /* -------------------------------------------------------------------------------------------------- */
 
 /// Decide the request's client-visible scheme (`"https"` or `"http"`).
 ///
-/// Shared by the sticky-cookie `Secure` attribute and the cache key (client-facing effective
-/// URI). The decision is fail-closed and bounded by the trusted-forwarded-proxy boundary:
+/// Backs the sticky-cookie `Secure` attribute (via [`client_visible_secure`]). The decision is
+/// fail-closed and bounded by the trusted-forwarded-proxy boundary:
 ///
 /// 1. If the rpxy listener is TLS-terminating, return `"https"`.
 /// 2. Otherwise, only honor forwarding-derived scheme when the immediate peer is in
@@ -853,8 +853,8 @@ fn push_forwarded_port(out: &mut String, port: &ForwardedPort) {
 ///    value, or any parse failure maps to `"http"`. A parse failure does NOT fall through to
 ///    the lower-priority source — a malformed `X-Forwarded-Proto` short-circuits without
 ///    consulting `Forwarded`.
-#[cfg(any(feature = "cache", feature = "sticky-cookie"))]
-pub(in crate::message_handler) fn client_visible_scheme(
+#[cfg(feature = "sticky-cookie")]
+fn client_visible_scheme(
   tls_enabled: bool,
   client_addr: &SocketAddr,
   headers: &HeaderMap,
@@ -904,7 +904,7 @@ pub(in crate::message_handler) fn client_visible_secure(
 /// - `Err(())` when the header is present but unreadable (non-UTF-8 etc.). Caller MUST
 ///   NOT fall back; doing so would let a malformed XFP enable a low-priority `Forwarded:
 ///   proto=https` to elevate `Secure`.
-#[cfg(any(feature = "cache", feature = "sticky-cookie"))]
+#[cfg(feature = "sticky-cookie")]
 fn xforwarded_proto_first(headers: &HeaderMap) -> Result<Option<String>, ()> {
   let raw = match join_header_values(headers, X_FORWARDED_PROTO) {
     Ok(Some(v)) => v,
@@ -932,7 +932,7 @@ fn xforwarded_proto_first(headers: &HeaderMap) -> Result<Option<String>, ()> {
 /// - `Ok(None)` when the header is absent, the first entry has no `proto=`, or the value
 ///   is empty.
 /// - `Err(())` on header value / quoted-string parse failure (fail-closed signal).
-#[cfg(any(feature = "cache", feature = "sticky-cookie"))]
+#[cfg(feature = "sticky-cookie")]
 fn forwarded_first_proto(headers: &HeaderMap) -> Result<Option<String>, ()> {
   let raw = match join_header_values(headers, header::FORWARDED) {
     Ok(Some(v)) => v,
@@ -965,31 +965,6 @@ fn forwarded_first_proto(headers: &HeaderMap) -> Result<Option<String>, ()> {
     };
   }
   Ok(None)
-}
-
-/// Build the client-facing effective request URI used as the cache key input:
-/// `scheme://authority/path?query`. Returns `None` when no safe authority is available, so the
-/// caller bypasses the cache rather than keying on the upstream-rewritten URI (fail closed).
-///
-/// - `scheme`: the client-visible scheme from [`client_visible_scheme`] (`"http"`/`"https"`).
-/// - `authority`: the original authoritative host (`host[:port]`) captured before the upstream
-///   rewrite; `None` (no Host and no URI authority) yields `None`.
-/// - `original_uri`: the request URI as received from the client; its path-and-query is used,
-///   defaulting to `/` when absent.
-#[cfg(feature = "cache")]
-pub(in crate::message_handler) fn build_client_facing_effective_uri(
-  scheme: &str,
-  authority: Option<&str>,
-  original_uri: &Uri,
-) -> Option<Uri> {
-  let authority = authority?;
-  let path_and_query = original_uri.path_and_query().map(|pq| pq.as_str()).unwrap_or("/");
-  Uri::builder()
-    .scheme(scheme)
-    .authority(authority)
-    .path_and_query(path_and_query)
-    .build()
-    .ok()
 }
 
 #[cfg(test)]
@@ -1927,149 +1902,22 @@ mod tests {
     assert_eq!(headers.get(PROXY).unwrap(), "");
   }
 
-  /* ---------------------- client_visible_secure / client_visible_scheme ---------------------- */
+  /* ---------------------- client_visible_secure ---------------------- */
 
-  // Shared by the sticky-cookie wrapper tests and the cache scheme/effective-URI tests; the
-  // scheme boundary is shared by both features.
-  #[cfg(any(feature = "cache", feature = "sticky-cookie"))]
+  // Address/CIDR fixtures for the sticky-cookie scheme-boundary tests below.
+  #[cfg(feature = "sticky-cookie")]
   fn untrusted_addr() -> SocketAddr {
     "203.0.113.10:4321".parse().unwrap()
   }
 
-  #[cfg(any(feature = "cache", feature = "sticky-cookie"))]
+  #[cfg(feature = "sticky-cookie")]
   fn trusted_addr() -> SocketAddr {
     "10.1.2.3:1234".parse().unwrap()
   }
 
-  #[cfg(any(feature = "cache", feature = "sticky-cookie"))]
+  #[cfg(feature = "sticky-cookie")]
   fn cidr_10() -> Vec<IpNet> {
     trusted(&["10.0.0.0/8"])
-  }
-
-  /* -------- client_visible_scheme (cache effective-URI scheme source) -------- */
-
-  #[cfg(feature = "cache")]
-  #[test]
-  fn cvscheme_tls_listener_is_https_regardless_of_headers() {
-    let mut headers = HeaderMap::new();
-    headers.insert(X_FORWARDED_PROTO, HeaderValue::from_static("http"));
-    assert_eq!(client_visible_scheme(true, &untrusted_addr(), &headers, &[]), "https");
-  }
-
-  #[cfg(feature = "cache")]
-  #[test]
-  fn cvscheme_untrusted_plaintext_peer_is_http_even_with_xfp_https() {
-    let mut headers = HeaderMap::new();
-    headers.insert(X_FORWARDED_PROTO, HeaderValue::from_static("https"));
-    assert_eq!(client_visible_scheme(false, &untrusted_addr(), &headers, &cidr_10()), "http");
-  }
-
-  #[cfg(feature = "cache")]
-  #[test]
-  fn cvscheme_trusted_plaintext_peer_honors_xfp_https() {
-    let mut headers = HeaderMap::new();
-    headers.insert(X_FORWARDED_PROTO, HeaderValue::from_static("https"));
-    assert_eq!(client_visible_scheme(false, &trusted_addr(), &headers, &cidr_10()), "https");
-  }
-
-  #[cfg(feature = "cache")]
-  #[test]
-  fn cvscheme_trusted_plaintext_peer_falls_back_to_forwarded_proto() {
-    let mut headers = HeaderMap::new();
-    headers.insert(header::FORWARDED, HeaderValue::from_static("proto=https"));
-    assert_eq!(client_visible_scheme(false, &trusted_addr(), &headers, &cidr_10()), "https");
-  }
-
-  #[cfg(feature = "cache")]
-  #[test]
-  fn cvscheme_malformed_xfp_fails_closed_to_http() {
-    // Non-UTF-8 X-Forwarded-Proto must short-circuit to http even with a valid lower-priority
-    // Forwarded: proto=https present.
-    let mut headers = HeaderMap::new();
-    headers.insert(
-      X_FORWARDED_PROTO,
-      HeaderValue::from_bytes(b"\xffhttps").expect("HeaderValue accepts non-UTF-8 bytes"),
-    );
-    headers.insert(header::FORWARDED, HeaderValue::from_static("proto=https"));
-    assert_eq!(client_visible_scheme(false, &trusted_addr(), &headers, &cidr_10()), "http");
-  }
-
-  /* -------- build_client_facing_effective_uri -------- */
-
-  #[cfg(feature = "cache")]
-  #[test]
-  fn effuri_origin_form_http() {
-    let original = Uri::from_static("/path?q=1");
-    let uri = build_client_facing_effective_uri("http", Some("app.example"), &original).unwrap();
-    assert_eq!(uri.to_string(), "http://app.example/path?q=1");
-  }
-
-  #[cfg(feature = "cache")]
-  #[test]
-  fn effuri_origin_form_https() {
-    let original = Uri::from_static("/path?q=1");
-    let uri = build_client_facing_effective_uri("https", Some("app.example"), &original).unwrap();
-    assert_eq!(uri.to_string(), "https://app.example/path?q=1");
-  }
-
-  #[cfg(feature = "cache")]
-  #[test]
-  fn effuri_authority_with_port_is_preserved() {
-    let original = Uri::from_static("/p");
-    let uri = build_client_facing_effective_uri("https", Some("app.example:8443"), &original).unwrap();
-    assert_eq!(uri.to_string(), "https://app.example:8443/p");
-  }
-
-  #[cfg(feature = "cache")]
-  #[test]
-  fn effuri_missing_path_defaults_to_slash() {
-    // Authority-form original URI (no path component, e.g. CONNECT) -> path defaults to "/".
-    let mut parts = http::uri::Parts::default();
-    parts.authority = Some("host.example".parse().unwrap());
-    let original = Uri::from_parts(parts).unwrap();
-    assert!(original.path_and_query().is_none(), "test precondition: no path_and_query");
-    let uri = build_client_facing_effective_uri("http", Some("app.example"), &original).unwrap();
-    assert_eq!(uri.to_string(), "http://app.example/");
-  }
-
-  #[cfg(feature = "cache")]
-  #[test]
-  fn effuri_absent_authority_returns_none_for_cache_bypass() {
-    let original = Uri::from_static("/p");
-    assert!(build_client_facing_effective_uri("http", None, &original).is_none());
-  }
-
-  #[cfg(feature = "cache")]
-  #[test]
-  fn effuri_authority_param_wins_over_original_uri_authority() {
-    // Absolute-form original URI carries its own authority, but the effective URI must use the
-    // authoritative-host argument (the client-facing authority), not the URI's authority.
-    let original = Uri::from_static("http://upstream.internal:9000/p?q=2");
-    let uri = build_client_facing_effective_uri("https", Some("vhost.example"), &original).unwrap();
-    assert_eq!(uri.to_string(), "https://vhost.example/p?q=2");
-  }
-
-  /* -------- cache-key partitioning (regression intent for cross-vhost cache poisoning) -------- */
-
-  #[cfg(feature = "cache")]
-  #[test]
-  fn effuri_distinct_authority_yields_distinct_uri() {
-    // Two client-facing vhosts that may rewrite to the same upstream must produce distinct
-    // effective URIs (hence distinct cache keys): this is the cross-vhost-poisoning guard.
-    let original = Uri::from_static("/shared/path");
-    let a = build_client_facing_effective_uri("https", Some("a.example"), &original).unwrap();
-    let b = build_client_facing_effective_uri("https", Some("b.example"), &original).unwrap();
-    assert_ne!(a.to_string(), b.to_string());
-  }
-
-  #[cfg(feature = "cache")]
-  #[test]
-  fn effuri_distinct_scheme_yields_distinct_uri() {
-    // http and https variants of the same vhost+path must not collide on one cache key.
-    let original = Uri::from_static("/p");
-    let http = build_client_facing_effective_uri("http", Some("app.example"), &original).unwrap();
-    let https = build_client_facing_effective_uri("https", Some("app.example"), &original).unwrap();
-    assert_ne!(http.to_string(), https.to_string());
   }
 
   #[cfg(feature = "sticky-cookie")]

--- a/rpxy-lib/src/message_handler/header_ops/mod.rs
+++ b/rpxy-lib/src/message_handler/header_ops/mod.rs
@@ -10,10 +10,6 @@ pub(super) use common::{add_header_entry_overwrite_if_exist, host_from_uri_or_ho
 pub(super) use forwarding::add_forwarding_header;
 #[cfg(feature = "sticky-cookie")]
 pub(super) use forwarding::client_visible_secure;
-// Only the cache path consumes the re-exported `client_visible_scheme` name; under
-// sticky-cookie the scheme helper is reached internally via `client_visible_secure`.
-#[cfg(feature = "cache")]
-pub(super) use forwarding::{build_client_facing_effective_uri, client_visible_scheme};
 pub(super) use hop::{extract_upgrade, remove_connection_header, remove_hop_header};
 pub(crate) use redact::DebugHeaders;
 #[cfg(feature = "sticky-cookie")]


### PR DESCRIPTION
With the `cache` feature compiled in, every request paid for the partitioning (capturing the client-visible scheme and building the client-facing URI) even when no cache was configured, and every cache hit built an extra synthetic request - a cost on the request-forwarding hot path that this proxy layer should not carry. Cache entries are again keyed on the request URI forwarded upstream (after the rewrite to the upstream target), as in releases before 0.13.3, so the partitioning by client-facing effective request URI described in the 0.13.3 notes is no longer current behavior. Correctness for cached responses that vary on forwarded attributes now relies on the origin declaring the variation, per the standard HTTP shared-cache contract: a backend that serves different content depending on the original (client-facing) host, scheme, or URI - notably when several virtual hosts are flattened onto one upstream via `set_upstream_host` or the `default_app` fallback - must emit an appropriate `Vary` header on such responses or mark them non-cacheable.