### PR TITLE
docs: document upstream HTTP version behavior and force_http11/http2 options

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,20 @@ This example configuration demonstrates a very common path-based routing situati
 
 Since this is currently a work-in-progress project, we are frequently adding new options. We first add new option entries in `config-example.toml` as examples. Please refer to it for up-to-date options. We will prepare comprehensive documentation for all options.
 
+### Upstream HTTP Version
+
+gRPC requests (`Content-Type: application/grpc`) are always sent to the upstream using HTTP/2. For other requests, a plaintext HTTP upstream (`tls = false`) always receives HTTP/1.1. A TLS upstream (`tls = true`) preserves the client's HTTP version by default, except that HTTP/3 is sent upstream as HTTP/2 because upstream HTTP/3 is not supported.
+
+Use `force_http11_upstream` or `force_http2_upstream` to override the ordinary upstream-version selection. These options are mutually exclusive; gRPC requests remain HTTP/2.
+
+`upstream_options` belongs to an individual `reverse_proxy` entry, not to the app/domain table. Placing it at the app/domain level is silently ignored.
+
+```toml
+[[apps.example.reverse_proxy]]
+upstream = [{ location = "backend.example:443", tls = true }]
+upstream_options = ["force_http11_upstream"]
+```
+
 ### Forwarding Headers and Trusted Proxies
 
 `rpxy` always rewrites the downstream-facing forwarding headers that backend applications commonly trust, including `X-Forwarded-For`, `X-Real-IP`, `X-Forwarded-Proto`, `X-Forwarded-Host`, `X-Forwarded-Port`, `X-Forwarded-SSL`, and `X-Original-URI`.

--- a/config-example.toml
+++ b/config-example.toml
@@ -126,6 +126,7 @@ load_balance = "round_robin" # or "random" or "sticky" (sticky session) or "prim
                              # "primary_backup": always routes to the first healthy upstream; requires health_check to be enabled.
 upstream_options = [
   "keep_original_host",   # [default] do not overwrite HOST value with upstream hostname (like 192.168.xx.x seen from rpxy), which is prior to "set_upstream_host" if both are specified.
+  # By default, TLS upstreams mirror the client HTTP version; plaintext upstreams use HTTP/1.1.
   "force_http2_upstream", # mutually exclusive with "force_http11_upstream"
 ]
 
@@ -159,6 +160,7 @@ upstream = [
 load_balance = "random" # or "round_robin" or "sticky" (sticky session) or "none" (fix to the first one, default)
 upstream_options = [
   "upgrade_insecure_requests",
+  # By default, TLS upstreams mirror the client HTTP version; plaintext upstreams use HTTP/1.1.
   "force_http11_upstream",
   "set_upstream_host",        # overwrite HOST value with upstream hostname (like www.yahoo.com). rpxy always overwrites X-Forwarded-Host with the original client-visible host and never forwards a client-supplied X-Forwarded-Host as-is.
   "forwarded_header"          # add Forwarded header (disabled by default. However, update one if already present.) Incoming Forwarded/X-Forwarded-* values are normalized according to trusted_forwarded_proxies before generation.


### PR DESCRIPTION
## Summary

Documents how rpxy chooses the upstream HTTP version, and clarifies that `force_http11_upstream` / `force_http2_upstream` belong inside a `reverse_proxy` entry's `upstream_options`, not the app/domain table. Adds an "Upstream HTTP Version" subsection to the README and a clarifying comment next to the force-option examples in `config-example.toml`.

## Background

In #184, a user set `force_http11_upstream` because their TLS upstream only speaks HTTP/1.1, but rpxy still forwarded HTTP/2 and returned 500. The maintainer diagnosed it as a config placement mistake (`upstream_options` was at the app level, where it is silently ignored) and noted the underlying behavior was undocumented. Both the maintainer ("we need more friendly configuration documentation... README.md are really unfriendly") and the reporter ("just documenting this would be super helpful for new users") asked for docs.

The documented behavior is verified against `rpxy-lib/src/message_handler/request_ops.rs::update_request_line`: `application/grpc` is always sent as HTTP/2; a plaintext-HTTP upstream (`tls = false`) is downgraded to HTTP/1.1; a TLS upstream preserves the client's HTTP version except HTTP/3, which is sent as HTTP/2; and `force_http11_upstream`/`force_http2_upstream` override the selection. The HTTP/2 auto-detection the reporter floated (which the maintainer called "quite tough") is intentionally out of scope here.

Refs #184

AI was used for assistance.
