### PR TITLE
fix: Respect trusted proxy X-Forwarded-Proto value when populating outgoing X-Forwarded-Proto header

### DIFF
--- a/rpxy-lib/src/message_handler/handler_manipulate_messages.rs
+++ b/rpxy-lib/src/message_handler/handler_manipulate_messages.rs
@@ -162,6 +162,7 @@ where
       authoritative_host.as_deref(),
       upstream_chosen,
       upstream_candidates,
+      tls_enabled,
       &self.globals.proxy_config.trusted_forwarded_proxies,
     )?;
 

--- a/rpxy-lib/src/message_handler/header_ops/forwarding.rs
+++ b/rpxy-lib/src/message_handler/header_ops/forwarding.rs
@@ -842,10 +842,12 @@ fn push_forwarded_port(out: &mut String, port: &ForwardedPort) {
 /// the sticky-cookie `Secure` attribute. The decision is fail-closed and bounded by the
 /// trusted-forwarded-proxy boundary:
 ///
-/// 1. If the rpxy listener is TLS-terminating, return `"https"`.
+/// 1. If the rpxy listener is TLS-terminating, return `"https"` (constant fast path).
 /// 2. Otherwise, only honor forwarding-derived scheme when the immediate peer is in
 ///    `trusted_forwarded_proxies` (same trust boundary as the forwarding-header policy); an
-///    untrusted peer is always `"http"` regardless of inbound forwarding headers.
+///    untrusted peer is always `"http"` regardless of inbound forwarding headers. With an
+///    empty `trusted_forwarded_proxies` list no peer can ever be trusted, so the result is
+///    the constant `"http"` and the header-parsing work is skipped on the hot path.
 /// 3. Header priority: `X-Forwarded-Proto` first comma-element wins; fall back to the
 ///    `proto=` parameter of the first `Forwarded` entry.
 /// 4. Only a `https` value (case-insensitive) maps to `"https"`; every other value, an absent
@@ -860,6 +862,9 @@ fn client_visible_scheme(
 ) -> &'static str {
   if tls_enabled {
     return "https";
+  }
+  if trusted_forwarded_proxies.is_empty() {
+    return "http";
   }
   let peer_ip = canonicalize_ip(client_addr.to_canonical().ip());
   if !is_trusted_proxy(&peer_ip, trusted_forwarded_proxies) {

--- a/rpxy-lib/src/message_handler/header_ops/forwarding.rs
+++ b/rpxy-lib/src/message_handler/header_ops/forwarding.rs
@@ -1212,6 +1212,24 @@ mod tests {
   }
 
   #[test]
+  fn client_visible_scheme_malformed_xfp_does_not_fall_through_to_forwarded_https() {
+    let mut headers = HeaderMap::new();
+    headers.insert(
+      X_FORWARDED_PROTO,
+      HeaderValue::from_bytes(b"\xffhttps").expect("HeaderValue accepts non-UTF-8 bytes"),
+    );
+    headers.insert(header::FORWARDED, HeaderValue::from_static("proto=https"));
+
+    let scheme = client_visible_scheme(
+      false,
+      &"10.1.2.3:1234".parse().unwrap(),
+      &headers,
+      &trusted(&["10.0.0.0/8"]),
+    );
+    assert_eq!(scheme, "http");
+  }
+
+  #[test]
   fn trusted_proxy_uses_forwarded_when_xff_missing() {
     let mut headers = HeaderMap::new();
     headers.insert(header::HOST, HeaderValue::from_static("app.example"));

--- a/rpxy-lib/src/message_handler/header_ops/forwarding.rs
+++ b/rpxy-lib/src/message_handler/header_ops/forwarding.rs
@@ -96,6 +96,14 @@ pub(super) struct ForwardedEntry {
   by: Option<String>,
 }
 
+impl ForwardedEntry {
+  /// Overwrite the `proto=` value of this entry. Used to pin rpxy's own hop to the local
+  /// listener protocol when generating a `Forwarded` header from re-parsed headers.
+  pub(super) fn set_proto(&mut self, proto: impl Into<String>) {
+    self.proto = Some(proto.into());
+  }
+}
+
 /// Add or update forwarding headers like `x-forwarded-for`.
 /// If only `forwarded` header exists, it will update `x-forwarded-for` with the proxy chain.
 /// If both `x-forwarded-for` and `forwarded` headers exist, it will update `x-forwarded-for` first and then add `forwarded` header.
@@ -111,6 +119,14 @@ pub(in crate::message_handler) fn add_forwarding_header(
   authoritative_host: Option<&str>,
   trusted_forwarded_proxies: &[IpNet],
 ) -> Result<()> {
+  // Resolve the client-visible scheme from the ORIGINAL inbound headers, before any
+  // forwarding-header mutation below. This must happen first: the incoming `Forwarded`
+  // header is regenerated from the normalized chain further down (and a proto-only entry
+  // such as `Forwarded: proto=https` does not survive normalization because a chain entry
+  // requires `for=`), so evaluating afterwards would read rpxy's own rewritten value and
+  // diverge from the sticky-cookie `Secure` decision, which sees the original headers.
+  let client_scheme = client_visible_scheme(tls, client_addr, headers, trusted_forwarded_proxies);
+
   let peer_ip = canonicalize_ip(client_addr.to_canonical().ip());
   let has_forwarded = headers.contains_key(header::FORWARDED);
   let normalized_chain = normalize_forwarding_chain(headers, &peer_ip, tls, authoritative_host, trusted_forwarded_proxies);
@@ -159,15 +175,20 @@ pub(in crate::message_handler) fn add_forwarding_header(
   // Constant values use HeaderValue::from_static (no runtime byte validation or allocation);
   // the port uses HeaderValue::from(u16) (lighter than to_string() + parse). insert() replaces
   // any existing values with a single value, matching add_header_entry_overwrite_if_exist.
-  let client_scheme = client_visible_scheme(tls, client_addr, headers, trusted_forwarded_proxies);
+  // `client_scheme` was resolved above from the original inbound headers, so X-Forwarded-Proto
+  // agrees with the sticky-cookie Secure decision regardless of the rewrites performed here.
   headers.insert(X_FORWARDED_PROTO, HeaderValue::from_static(client_scheme));
   headers.insert(X_FORWARDED_PORT, HeaderValue::from(listen_addr.port()));
 
   /////////// As Nginx-Proxy
   // x-real-ip: pre-built above from the first element of the XFF CSV.
   headers.insert(X_REAL_IP, x_real_ip_value);
-  // x-forwarded-ssl
-  headers.insert(X_FORWARDED_SSL, HeaderValue::from_static(if tls { "on" } else { "off" }));
+  // x-forwarded-ssl: derived from the same client-visible scheme as X-Forwarded-Proto so the
+  // two headers can never disagree about whether the client-facing connection was HTTPS.
+  headers.insert(
+    X_FORWARDED_SSL,
+    HeaderValue::from_static(if client_scheme == "https" { "on" } else { "off" }),
+  );
   // x-original-uri
   add_header_entry_overwrite_if_exist(headers, X_ORIGINAL_URI, original_uri.to_string())?;
   // x-forwarded-host
@@ -639,6 +660,14 @@ fn canonicalize_ip(ip: IpAddr) -> IpAddr {
   SocketAddr::new(ip, 0).to_canonical().ip()
 }
 
+/// Protocol string describing rpxy's own listener hop: `"https"` when rpxy terminates TLS,
+/// `"http"` otherwise. This is the protocol of the connection between rpxy's immediate peer
+/// and rpxy itself, as opposed to the client-visible scheme which may differ when a trusted
+/// upstream proxy terminates TLS in front of a plain rpxy listener.
+pub(super) fn listener_proto(tls_enabled: bool) -> &'static str {
+  if tls_enabled { "https" } else { "http" }
+}
+
 /// Build a ForwardedEntry for the immediate peer, which represents this proxy's authoritative view of the client connection. This is used as the basis for forwarding chain normalization and generation.
 fn build_peer_forwarded_entry(peer_ip: IpAddr, tls: bool, authoritative_host: Option<&str>) -> ForwardedEntry {
   ForwardedEntry {
@@ -647,7 +676,7 @@ fn build_peer_forwarded_entry(peer_ip: IpAddr, tls: bool, authoritative_host: Op
       port: None,
       raw: ForwardedNodeRaw::Ip,
     },
-    proto: if tls { Some("https".into()) } else { Some("http".into()) },
+    proto: Some(listener_proto(tls).into()),
     host: authoritative_host.map(str::to_owned),
     by: None,
   }
@@ -838,9 +867,18 @@ fn push_forwarded_port(out: &mut String, port: &ForwardedPort) {
 
 /// Decide the request's client-visible scheme (`"https"` or `"http"`).
 ///
-/// Used both for the outgoing `X-Forwarded-Proto` header and (via [`client_visible_secure`])
-/// the sticky-cookie `Secure` attribute. The decision is fail-closed and bounded by the
-/// trusted-forwarded-proxy boundary:
+/// Used for the outgoing `X-Forwarded-Proto` / `X-Forwarded-SSL` headers and (via
+/// [`client_visible_secure`]) the sticky-cookie `Secure` attribute.
+///
+/// # Call-order contract
+///
+/// MUST be called against the ORIGINAL inbound headers, before any forwarding-header
+/// mutation: `add_forwarding_header()` regenerates the incoming `Forwarded` header from the
+/// normalized chain (and a proto-only entry such as `Forwarded: proto=https` does not
+/// survive normalization), so a post-mutation evaluation would read rpxy's own rewritten
+/// value and diverge from the sticky-cookie decision, which sees the original headers.
+///
+/// The decision is fail-closed and bounded by the trusted-forwarded-proxy boundary:
 ///
 /// 1. If the rpxy listener is TLS-terminating, return `"https"` (constant fast path).
 /// 2. Otherwise, only honor forwarding-derived scheme when the immediate peer is in
@@ -1195,6 +1233,47 @@ mod tests {
 
     // A trusted peer's https scheme must be preserved, not rewritten to http.
     assert_eq!(headers.get(X_FORWARDED_PROTO).unwrap(), "https");
+    // X-Forwarded-SSL must agree with X-Forwarded-Proto on the same client-visible scheme.
+    assert_eq!(headers.get(X_FORWARDED_SSL).unwrap(), "on");
+  }
+
+  /// Regression test for the ordering of `client_visible_scheme()` inside
+  /// `add_forwarding_header()`.
+  ///
+  /// A trusted peer sends a proto-only `Forwarded` entry (`proto=https`, no `for=`) and no
+  /// `X-Forwarded-Proto`. Such an entry does not survive chain normalization (a chain entry
+  /// requires `for=`), so the incoming `Forwarded` header is regenerated as
+  /// `for=<peer>;proto=http`. `client_visible_scheme()` must therefore be evaluated BEFORE
+  /// that regeneration: afterwards it reads rpxy's own rewritten `proto=http` and emits
+  /// `X-Forwarded-Proto: http`, while the sticky-cookie path - which evaluates the same
+  /// logic against the original headers - decides `https`. Not feature-gated: this must
+  /// hold regardless of the sticky-cookie feature.
+  #[test]
+  fn add_forwarding_header_trusted_peer_proto_only_forwarded_https_yields_https() {
+    let mut headers = HeaderMap::new();
+    headers.insert(header::HOST, HeaderValue::from_static("app.example"));
+    headers.insert(header::FORWARDED, HeaderValue::from_static("proto=https"));
+
+    add_forwarding_header_from_original(
+      &mut headers,
+      &"10.1.2.3:1234".parse().unwrap(),
+      &"192.0.2.1:8080".parse().unwrap(),
+      false,
+      &Uri::from_static("/"),
+      &trusted(&["10.0.0.0/8"]),
+    )
+    .unwrap();
+
+    // The client-visible scheme resolved from the ORIGINAL inbound Forwarded header must
+    // win over the regenerated proto=http value.
+    assert_eq!(headers.get(X_FORWARDED_PROTO).unwrap(), "https");
+    assert_eq!(headers.get(X_FORWARDED_SSL).unwrap(), "on");
+    // The regenerated Forwarded header still describes rpxy's own hop with the local
+    // listener protocol (plain http), independent of the client-visible scheme.
+    assert_eq!(
+      headers.get(header::FORWARDED).unwrap(),
+      "for=10.1.2.3;proto=http;host=app.example"
+    );
   }
 
   #[test]
@@ -1225,12 +1304,7 @@ mod tests {
     );
     headers.insert(header::FORWARDED, HeaderValue::from_static("proto=https"));
 
-    let scheme = client_visible_scheme(
-      false,
-      &"10.1.2.3:1234".parse().unwrap(),
-      &headers,
-      &trusted(&["10.0.0.0/8"]),
-    );
+    let scheme = client_visible_scheme(false, &"10.1.2.3:1234".parse().unwrap(), &headers, &trusted(&["10.0.0.0/8"]));
     assert_eq!(scheme, "http");
   }
 
@@ -2011,6 +2085,39 @@ mod tests {
     let mut headers = HeaderMap::new();
     headers.insert(header::FORWARDED, HeaderValue::from_static("proto=https"));
     assert!(client_visible_secure(false, &trusted_addr(), &headers, &cidr_10()));
+  }
+
+  /// The sticky-cookie `Secure` decision and the outgoing `X-Forwarded-Proto` must be
+  /// derived from the SAME pre-mutation evaluation of the client-visible scheme. With a
+  /// proto-only `Forwarded: proto=https` entry (which does not survive chain
+  /// normalization), both paths must conclude `https`.
+  #[cfg(feature = "sticky-cookie")]
+  #[test]
+  fn cvs_agrees_with_outgoing_x_forwarded_proto_for_proto_only_forwarded() {
+    let build_headers = || {
+      let mut headers = HeaderMap::new();
+      headers.insert(header::HOST, HeaderValue::from_static("app.example"));
+      headers.insert(header::FORWARDED, HeaderValue::from_static("proto=https"));
+      headers
+    };
+
+    // Sticky-cookie path: evaluated against the original inbound headers.
+    let secure = client_visible_secure(false, &trusted_addr(), &build_headers(), &cidr_10());
+
+    // Forwarding-header path: through add_forwarding_header().
+    let mut headers = build_headers();
+    add_forwarding_header_from_original(
+      &mut headers,
+      &trusted_addr(),
+      &"192.0.2.1:8080".parse().unwrap(),
+      false,
+      &Uri::from_static("/"),
+      &cidr_10(),
+    )
+    .unwrap();
+
+    assert!(secure);
+    assert_eq!(headers.get(X_FORWARDED_PROTO).unwrap(), "https");
   }
 
   #[cfg(feature = "sticky-cookie")]

--- a/rpxy-lib/src/message_handler/header_ops/forwarding.rs
+++ b/rpxy-lib/src/message_handler/header_ops/forwarding.rs
@@ -159,10 +159,8 @@ pub(in crate::message_handler) fn add_forwarding_header(
   // Constant values use HeaderValue::from_static (no runtime byte validation or allocation);
   // the port uses HeaderValue::from(u16) (lighter than to_string() + parse). insert() replaces
   // any existing values with a single value, matching add_header_entry_overwrite_if_exist.
-  headers.insert(
-    X_FORWARDED_PROTO,
-    HeaderValue::from_static(if tls { "https" } else { "http" }),
-  );
+  let client_scheme = client_visible_scheme(tls, client_addr, headers, trusted_forwarded_proxies);
+  headers.insert(X_FORWARDED_PROTO, HeaderValue::from_static(client_scheme));
   headers.insert(X_FORWARDED_PORT, HeaderValue::from(listen_addr.port()));
 
   /////////// As Nginx-Proxy
@@ -840,8 +838,9 @@ fn push_forwarded_port(out: &mut String, port: &ForwardedPort) {
 
 /// Decide the request's client-visible scheme (`"https"` or `"http"`).
 ///
-/// Backs the sticky-cookie `Secure` attribute (via [`client_visible_secure`]). The decision is
-/// fail-closed and bounded by the trusted-forwarded-proxy boundary:
+/// Used both for the outgoing `X-Forwarded-Proto` header and (via [`client_visible_secure`])
+/// the sticky-cookie `Secure` attribute. The decision is fail-closed and bounded by the
+/// trusted-forwarded-proxy boundary:
 ///
 /// 1. If the rpxy listener is TLS-terminating, return `"https"`.
 /// 2. Otherwise, only honor forwarding-derived scheme when the immediate peer is in
@@ -853,7 +852,6 @@ fn push_forwarded_port(out: &mut String, port: &ForwardedPort) {
 ///    value, or any parse failure maps to `"http"`. A parse failure does NOT fall through to
 ///    the lower-priority source — a malformed `X-Forwarded-Proto` short-circuits without
 ///    consulting `Forwarded`.
-#[cfg(feature = "sticky-cookie")]
 fn client_visible_scheme(
   tls_enabled: bool,
   client_addr: &SocketAddr,
@@ -904,7 +902,6 @@ pub(in crate::message_handler) fn client_visible_secure(
 /// - `Err(())` when the header is present but unreadable (non-UTF-8 etc.). Caller MUST
 ///   NOT fall back; doing so would let a malformed XFP enable a low-priority `Forwarded:
 ///   proto=https` to elevate `Secure`.
-#[cfg(feature = "sticky-cookie")]
 fn xforwarded_proto_first(headers: &HeaderMap) -> Result<Option<String>, ()> {
   let raw = match join_header_values(headers, X_FORWARDED_PROTO) {
     Ok(Some(v)) => v,
@@ -932,7 +929,6 @@ fn xforwarded_proto_first(headers: &HeaderMap) -> Result<Option<String>, ()> {
 /// - `Ok(None)` when the header is absent, the first entry has no `proto=`, or the value
 ///   is empty.
 /// - `Err(())` on header value / quoted-string parse failure (fail-closed signal).
-#[cfg(feature = "sticky-cookie")]
 fn forwarded_first_proto(headers: &HeaderMap) -> Result<Option<String>, ()> {
   let raw = match join_header_values(headers, header::FORWARDED) {
     Ok(Some(v)) => v,
@@ -1173,6 +1169,46 @@ mod tests {
 
     assert_eq!(headers.get(X_FORWARDED_FOR).unwrap(), "203.0.113.20, 10.1.2.3");
     assert_eq!(headers.get(X_REAL_IP).unwrap(), "203.0.113.20");
+  }
+
+  #[test]
+  fn trusted_peer_honors_x_forwarded_proto_https() {
+    let mut headers = HeaderMap::new();
+    headers.insert(header::HOST, HeaderValue::from_static("app.example"));
+    headers.insert(X_FORWARDED_PROTO, HeaderValue::from_static("https"));
+    headers.insert(X_FORWARDED_FOR, HeaderValue::from_static("198.51.100.10"));
+
+    add_forwarding_header_from_original(
+      &mut headers,
+      &"10.1.2.3:1234".parse().unwrap(),
+      &"192.0.2.1:8080".parse().unwrap(),
+      false,
+      &Uri::from_static("/"),
+      &trusted(&["10.0.0.0/8"]),
+    )
+    .unwrap();
+
+    // A trusted peer's https scheme must be preserved, not rewritten to http.
+    assert_eq!(headers.get(X_FORWARDED_PROTO).unwrap(), "https");
+  }
+
+  #[test]
+  fn trusted_peer_without_proto_header_falls_back_to_http() {
+    let mut headers = HeaderMap::new();
+    headers.insert(header::HOST, HeaderValue::from_static("app.example"));
+    headers.insert(X_FORWARDED_FOR, HeaderValue::from_static("198.51.100.10"));
+
+    add_forwarding_header_from_original(
+      &mut headers,
+      &"10.1.2.3:1234".parse().unwrap(),
+      &"192.0.2.1:8080".parse().unwrap(),
+      false,
+      &Uri::from_static("/"),
+      &trusted(&["10.0.0.0/8"]),
+    )
+    .unwrap();
+
+    assert_eq!(headers.get(X_FORWARDED_PROTO).unwrap(), "http");
   }
 
   #[test]

--- a/rpxy-lib/src/message_handler/header_ops/upstream.rs
+++ b/rpxy-lib/src/message_handler/header_ops/upstream.rs
@@ -10,7 +10,7 @@ use crate::{
 
 use super::{
   common::add_header_entry_overwrite_if_exist,
-  forwarding::{extract_forwarding_chain_from_headers, generate_forwarded_header, reduce_trusted_proxy_chain},
+  forwarding::{extract_forwarding_chain_from_headers, generate_forwarded_header, listener_proto, reduce_trusted_proxy_chain},
 };
 
 /// overwrite HOST value with upstream hostname (like 192.168.xx.x seen from rpxy)
@@ -46,11 +46,14 @@ pub(in crate::message_handler) fn apply_default_app_host_rewrite(
 /// This function is called after almost all other headers has been set and updated.
 /// `authoritative_host` is the host of the original request (URI host preferred, port
 /// included, Host-header fallback), computed once by the caller before any Host rewrite.
+/// `tls` states whether rpxy's own listener terminates TLS; it decides the `proto=` value
+/// emitted for rpxy's own hop when this function generates a `Forwarded` header.
 pub(in crate::message_handler) fn apply_upstream_options_to_header(
   headers: &mut HeaderMap,
   authoritative_host: Option<&str>,
   upstream_chosen: &Upstream,
   upstream_candidates: &UpstreamCandidates,
+  tls: bool,
   trusted_forwarded_proxies: &[IpNet],
 ) -> Result<()> {
   // `options` is a set, so dispatch by direct membership instead of iterating it. The three
@@ -81,7 +84,16 @@ pub(in crate::message_handler) fn apply_upstream_options_to_header(
       warn!("Failed to generate Forwarded header: no X-Forwarded-For information found in headers");
       return Ok(());
     };
-    let normalized_chain = reduce_trusted_proxy_chain(forwarding_chain, trusted_forwarded_proxies);
+    let mut normalized_chain = reduce_trusted_proxy_chain(forwarding_chain, trusted_forwarded_proxies);
+    // The last hop of the normalized chain is rpxy's own peer entry. Its `proto=` must
+    // describe the connection between that peer and rpxy, i.e. rpxy's local listener
+    // protocol - NOT the client-visible scheme. X-Forwarded-Proto now carries the
+    // client-visible scheme (which may be `https` when a trusted upstream proxy terminates
+    // TLS in front of a plain listener), and re-parsing the headers would otherwise copy
+    // that value onto rpxy's own hop.
+    if let Some(own_hop) = normalized_chain.last_mut() {
+      own_hop.set_proto(listener_proto(tls));
+    }
     match generate_forwarded_header(&normalized_chain) {
       Ok(forwarded_value) => {
         add_header_entry_overwrite_if_exist(headers, header::FORWARDED, forwarded_value)?;
@@ -104,6 +116,11 @@ mod tests {
     globals::UpstreamUri,
   };
   use ahash::HashSet;
+  use ipnet::IpNet;
+
+  fn trusted(cidrs: &[&str]) -> Vec<IpNet> {
+    cidrs.iter().map(|c| c.parse::<IpNet>().unwrap()).collect()
+  }
 
   fn candidates_with_options(uri: &str, options: HashSet<UpstreamOption>) -> UpstreamCandidates {
     UpstreamCandidates {
@@ -126,7 +143,15 @@ mod tests {
       "http://backend.internal",
       HashSet::from_iter([UpstreamOption::UpgradeInsecureRequests]),
     );
-    apply_upstream_options_to_header(&mut headers, Some("app.example"), &candidates.inner[0], &candidates, &[]).unwrap();
+    apply_upstream_options_to_header(
+      &mut headers,
+      Some("app.example"),
+      &candidates.inner[0],
+      &candidates,
+      false,
+      &[],
+    )
+    .unwrap();
     assert_eq!(headers.get(header::UPGRADE_INSECURE_REQUESTS).unwrap(), "1");
   }
 
@@ -134,7 +159,15 @@ mod tests {
   fn upgrade_insecure_requests_absent_when_option_unset() {
     let mut headers = HeaderMap::new();
     let candidates = candidates_with_options("http://backend.internal", HashSet::default());
-    apply_upstream_options_to_header(&mut headers, Some("app.example"), &candidates.inner[0], &candidates, &[]).unwrap();
+    apply_upstream_options_to_header(
+      &mut headers,
+      Some("app.example"),
+      &candidates.inner[0],
+      &candidates,
+      false,
+      &[],
+    )
+    .unwrap();
     assert!(headers.get(header::UPGRADE_INSECURE_REQUESTS).is_none());
   }
 
@@ -146,7 +179,15 @@ mod tests {
       "http://backend.internal",
       HashSet::from_iter([UpstreamOption::UpgradeInsecureRequests]),
     );
-    apply_upstream_options_to_header(&mut headers, Some("app.example"), &candidates.inner[0], &candidates, &[]).unwrap();
+    apply_upstream_options_to_header(
+      &mut headers,
+      Some("app.example"),
+      &candidates.inner[0],
+      &candidates,
+      false,
+      &[],
+    )
+    .unwrap();
     // or_insert leaves a pre-existing value untouched
     assert_eq!(headers.get(header::UPGRADE_INSECURE_REQUESTS).unwrap(), "0");
   }
@@ -182,6 +223,7 @@ mod tests {
       Some("app.example:8443"),
       &upstream_candidates.inner[0],
       &upstream_candidates,
+      true,
       &[],
     )
     .unwrap();
@@ -189,6 +231,54 @@ mod tests {
     assert_eq!(
       headers.get(header::FORWARDED).unwrap(),
       "for=198.51.100.10;proto=https;host=\"app.example:8443\""
+    );
+  }
+
+  /// When the `forwarded_header` option generates a `Forwarded` header on a PLAIN listener
+  /// behind a trusted TLS-terminating proxy, `X-Forwarded-Proto` carries the client-visible
+  /// scheme (`https`) - but the `proto=` value of rpxy's own hop (the last chain entry) must
+  /// describe rpxy's local listener protocol (`http`), not the client-visible scheme.
+  #[test]
+  fn forwarded_header_generation_uses_listener_proto_for_own_hop() {
+    let mut headers = HeaderMap::new();
+    headers.insert(header::HOST, HeaderValue::from_static("app.example"));
+    headers.insert(
+      http::HeaderName::from_static("x-forwarded-for"),
+      HeaderValue::from_static("198.51.100.10, 10.1.2.3"),
+    );
+    headers.insert(
+      http::HeaderName::from_static("x-forwarded-proto"),
+      HeaderValue::from_static("https"),
+    );
+
+    let upstream = Upstream::from(&UpstreamUri {
+      inner: "http://backend.internal".parse().unwrap(),
+    });
+    let upstream_candidates = UpstreamCandidates {
+      inner: vec![upstream],
+      path: "/".into(),
+      replace_path: None,
+      load_balance: LoadBalance::default(),
+      options: HashSet::from_iter([UpstreamOption::ForwardedHeader]),
+      #[cfg(feature = "health-check")]
+      health_check_config: None,
+    };
+
+    apply_upstream_options_to_header(
+      &mut headers,
+      Some("app.example"),
+      &upstream_candidates.inner[0],
+      &upstream_candidates,
+      false,
+      &trusted(&["10.0.0.0/8"]),
+    )
+    .unwrap();
+
+    // The last hop (10.1.2.3, rpxy's own peer) carries proto=http from the local listener,
+    // while the earlier client hop has no proto= (not observable by rpxy).
+    assert_eq!(
+      headers.get(header::FORWARDED).unwrap(),
+      "for=198.51.100.10, for=10.1.2.3;proto=http;host=app.example"
     );
   }
 
@@ -243,6 +333,7 @@ mod tests {
       Some("app.example"),
       &upstream_candidates.inner[0],
       &upstream_candidates,
+      false,
       &[],
     )
     .unwrap();
@@ -273,6 +364,7 @@ mod tests {
       Some("app.example"),
       &upstream_candidates.inner[0],
       &upstream_candidates,
+      false,
       &[],
     )
     .unwrap();
@@ -306,6 +398,7 @@ mod tests {
       Some("app.example"),
       &upstream_candidates.inner[0],
       &upstream_candidates,
+      false,
       &[],
     )
     .unwrap_err();


### PR DESCRIPTION
## Problem
Previously `add_forwarding_header` unconditionally set `X-Forwarded-Proto` purely based on whether the local listener used TLS.
It ignored valid `X-Forwarded-Proto` / `Forwarded` proto information received from trusted upstream proxies on plain listeners.
This caused incorrect scheme information to be forwarded to backend services.

## Solution
Reuse the existing `client_visible_scheme()` logic to resolve the client-visible scheme when constructing forwarding headers.
This aligns `X-Forwarded-Proto` generation with the same trusted-proxy, fail-closed rules already used for sticky cookie Secure attribute decisions.

Changes:
1. Call `client_visible_scheme()` and use its result for outgoing X_FORWARDED_PROTO
2. Remove `#[cfg(feature = "sticky-cookie")]` from shared proto parsing helpers, as they are now consumed in two code paths
3. Add unit tests:
   - trusted peer sends X-Forwarded-Proto: https → preserved
   - trusted peer provides no proto headers → fallback to http

## Semantics preserved
- Fail closed security model remains intact
- Untrusted peers cannot inject arbitrary scheme values
- Malformed proto headers do not allow fallback to alternative header source